### PR TITLE
fixed instruction and data collision. removed old fix

### DIFF
--- a/inc/block.h
+++ b/inc/block.h
@@ -64,6 +64,7 @@ class DRAM_ARRAY {
 class PACKET {
   public:
     uint8_t instruction, 
+            is_data,
             tlb_access,
             scheduled,
             translated,
@@ -113,6 +114,7 @@ class PACKET {
 
     PACKET() {
         instruction = 0;
+        is_data = 1;
         tlb_access = 0;
         scheduled = 0;
         translated = 0;

--- a/src/dram_controller.cc
+++ b/src/dram_controller.cc
@@ -419,7 +419,7 @@ int MEMORY_CONTROLLER::add_rq(PACKET *packet)
     if (all_warmup_complete < NUM_CPUS) {
         if (packet->instruction) 
             upper_level_icache[packet->cpu]->return_data(packet);
-        else // data
+        if (packet->is_data)
             upper_level_dcache[packet->cpu]->return_data(packet);
 
         return -1;
@@ -436,7 +436,7 @@ int MEMORY_CONTROLLER::add_rq(PACKET *packet)
             packet->data = WQ[channel].entry[wq_index].data;
             if (packet->instruction) 
                 upper_level_icache[packet->cpu]->return_data(packet);
-            else // data
+            if (packet->is_data) 
                 upper_level_dcache[packet->cpu]->return_data(packet);
         //}
 

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -581,6 +581,7 @@ void O3_CPU::fetch_instruction()
 	  // add it to the ITLB's read queue
 	  PACKET trace_packet;
 	  trace_packet.instruction = 1;
+	  trace_packet.is_data = 0;
 	  trace_packet.tlb_access = 1;
 	  trace_packet.fill_level = FILL_L1;
 	  trace_packet.cpu = cpu;
@@ -621,6 +622,7 @@ void O3_CPU::fetch_instruction()
 	  // add it to the L1-I's read queue
 	  PACKET fetch_packet;
 	  fetch_packet.instruction = 1;
+	  fetch_packet.is_data = 0;
 	  fetch_packet.fill_level = FILL_L1;
 	  fetch_packet.cpu = cpu;
 	  fetch_packet.address = IFETCH_BUFFER.entry[index].instruction_pa >> 6;
@@ -808,6 +810,7 @@ int O3_CPU::prefetch_code_line(uint64_t ip, uint64_t pf_addr)
 
       PACKET pf_packet;
       pf_packet.instruction = 1; // this is a code prefetch
+      pf_packet.is_data = 0;
       pf_packet.fill_level = FILL_L1;
       pf_packet.pf_origin_level = FILL_L1;
       pf_packet.cpu = cpu;


### PR DESCRIPTION
Fix for instruction and data collision. 
Packets / MSHR now track is_instruction vs. is_data separately. A line can now be both data and code (e.g., under JIT scenario).
This enables an mshr entry to be able merge instruction and data requests, and forward them to both icache and dcache once resolved.