### PR TITLE
Call the initializer of L1I prefetcher

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -695,6 +695,7 @@ int main(int argc, char** argv)
         ooo_cpu[i].L1I.MAX_READ = 2;
         ooo_cpu[i].L1I.fill_level = FILL_L1;
         ooo_cpu[i].L1I.lower_level = &ooo_cpu[i].L2C; 
+        ooo_cpu[i].l1i_prefetcher_initialize();
 
         ooo_cpu[i].L1D.cpu = i;
         ooo_cpu[i].L1D.cache_type = IS_L1D;


### PR DESCRIPTION
`O3_CPU::l1i_prefetcher_initialize()` is defined in each L1I prefetcher but called from nowhere, so add a function call.