### PR TITLE
Update README with build script arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ git clone https://github.com/ChampSim/ChampSim.git
 ChampSim takes five parameters: Branch predictor, L1D prefetcher, L2C prefetcher, LLC replacement policy, and the number of cores. 
 For example, `./build_champsim.sh bimodal no no lru 1` builds a single-core processor with bimodal branch predictor, no L1/L2 data prefetchers, and the baseline LRU replacement policy for the LLC.
 ```
-$ ./build_champsim.sh bimodal no no no lru 1
+$ ./build_champsim.sh bimodal no no no no lru 1
 
-$ ./build_champsim.sh ${BRANCH} ${L1D_PREFETCHER} ${L2C_PREFETCHER} ${LLC_PREFETCHER} ${LLC_REPLACEMENT} ${NUM_CORE}
+$ ./build_champsim.sh ${BRANCH} ${L1I_PREFETCHER} ${L1D_PREFETCHER} ${L2C_PREFETCHER} ${LLC_PREFETCHER} ${LLC_REPLACEMENT} ${NUM_CORE}
 ```
 
 # Download DPC-3 trace


### PR DESCRIPTION
The build script expects 7 arguments but the old README had only 6.
Added `L1I_PREFETCHER` to the list of arguments in doc.