### PR TITLE
Fix decode width

### DIFF
--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -788,7 +788,7 @@ void O3_CPU::decode_and_dispatch()
 	}
 
       count_decodes++;
-      if(count_decodes > DECODE_WIDTH)
+      if(count_decodes >= DECODE_WIDTH)
 	{
 	  break;
 	}


### PR DESCRIPTION
```
  uint32_t count_decodes = 0;
  for(uint32_t i=0; i<DECODE_BUFFER.SIZE; i++)
    {

      ... (decode an instruction) ...

      count_decodes++;
      if(count_decodes > DECODE_WIDTH) // DECODE_WIDTH is set to 6
	{
	  break;
	}
    }
```


The above original code is executed as follows;

  count_decodes = 0, 1, 2, 3, 4, 5, 6, then break.

so up to 7 instructions (more than DECODE_WIDTH) are decoded in one cycle.

It is correct to use `>=` instead of `>` as line 753.