### PR TITLE
[#30] Added run-time modifiable comparison for register indices

### DIFF
--- a/inc/ooo_cpu.h
+++ b/inc/ooo_cpu.h
@@ -2,6 +2,7 @@
 #define OOO_CPU_H
 
 #include "cache.h"
+#include <functional>
 
 #ifdef CRC2_COMPILE
 #define STAT_PRINTING_PERIOD 1000000
@@ -181,7 +182,6 @@ class O3_CPU {
          do_memory_scheduling(uint32_t rob_index),
          operate_lsq(),
          complete_execution(uint32_t rob_index),
-         reg_RAW_dependency(uint32_t prior, uint32_t current, uint32_t source_index),
          reg_RAW_release(uint32_t rob_index),
          mem_RAW_dependency(uint32_t prior, uint32_t current, uint32_t data_index, uint32_t lq_index),
          handle_o3_fetch(PACKET *current_packet, uint32_t cache_type),
@@ -190,6 +190,8 @@ class O3_CPU {
          release_load_queue(uint32_t lq_index),
          complete_instr_fetch(PACKET_QUEUE *queue, uint8_t is_it_tlb),
          complete_data_fetch(PACKET_QUEUE *queue, uint8_t is_it_tlb);
+
+    void reg_RAW_dependency(uint32_t prior, uint32_t current, uint32_t source_index, std::function<bool(uint8_t, uint8_t)> comp = std::equal_to<uint8_t>());
 
     void initialize_core();
     void add_load_queue(uint32_t rob_index, uint32_t data_index),

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -1,6 +1,7 @@
 #include "ooo_cpu.h"
 #include "set.h"
 
+#include <array>
 #include <functional>
 
 // out-of-order core
@@ -921,6 +922,33 @@ void O3_CPU::do_scheduling(uint32_t rob_index)
     }
 }
 
+struct x86_reg_comp
+{
+    const std::array<uint8_t, 256> reg_mapper = {{
+          0,   0,   0,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,  15,
+         16,  17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  10,  10,  10,   9,   9,
+          9,   8,   8,   8,   7,   7,   7,   5,   4,   3,   6,  25,  26,   3,   3,   4,
+          4,   5,   5,   6,   6,   7,   8,   9,  10,  25,  26,  11,  11,  11,  12,  12,
+         12,  13,  13,  13,  14,  14,  14,  15,  15,  15,  16,  16,  16,  17,  17,  17,
+         18,  18,  18,  83,  84,  85,  86,  87,  88,  89,  90, 123, 124, 125, 126, 127,
+        128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143,
+        144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 123, 124, 125, 126, 127,
+        128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143,
+        144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159,
+        160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175,
+        176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191,
+        192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207,
+        208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223,
+        224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239,
+        240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255
+    }};
+
+    bool operator () (const uint8_t lhs, const uint8_t rhs) const
+    {
+        return reg_mapper[lhs] == reg_mapper[rhs];
+    }
+};
+
 void O3_CPU::reg_dependency(uint32_t rob_index)
 {
     // print out source/destination registers
@@ -948,20 +976,20 @@ void O3_CPU::reg_dependency(uint32_t rob_index)
             for (int i=prior; i>=(int)ROB.head; i--) if (ROB.entry[i].executed != COMPLETED) {
 		for (uint32_t j=0; j<NUM_INSTR_SOURCES; j++) {
 			if (ROB.entry[rob_index].source_registers[j] && (ROB.entry[rob_index].reg_RAW_checked[j] == 0))
-				reg_RAW_dependency(i, rob_index, j);
+                reg_RAW_dependency(i, rob_index, j, x86_reg_comp());
 		}
 	    }
         } else {
             for (int i=prior; i>=0; i--) if (ROB.entry[i].executed != COMPLETED) {
 		for (uint32_t j=0; j<NUM_INSTR_SOURCES; j++) {
 			if (ROB.entry[rob_index].source_registers[j] && (ROB.entry[rob_index].reg_RAW_checked[j] == 0))
-				reg_RAW_dependency(i, rob_index, j);
+                reg_RAW_dependency(i, rob_index, j, x86_reg_comp());
 		}
 	    }
             for (int i=ROB.SIZE-1; i>=(int)ROB.head; i--) if (ROB.entry[i].executed != COMPLETED) {
 		for (uint32_t j=0; j<NUM_INSTR_SOURCES; j++) {
 			if (ROB.entry[rob_index].source_registers[j] && (ROB.entry[rob_index].reg_RAW_checked[j] == 0))
-				reg_RAW_dependency(i, rob_index, j);
+                reg_RAW_dependency(i, rob_index, j, x86_reg_comp());
 		}
 	    }
         }

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -1,6 +1,8 @@
 #include "ooo_cpu.h"
 #include "set.h"
 
+#include <functional>
+
 // out-of-order core
 O3_CPU ooo_cpu[NUM_CPUS]; 
 uint64_t current_core_cycle[NUM_CPUS], stall_cycle[NUM_CPUS];
@@ -966,13 +968,13 @@ void O3_CPU::reg_dependency(uint32_t rob_index)
     }
 }
 
-void O3_CPU::reg_RAW_dependency(uint32_t prior, uint32_t current, uint32_t source_index)
+void O3_CPU::reg_RAW_dependency(uint32_t prior, uint32_t current, uint32_t source_index, std::function<bool(uint8_t, uint8_t)> comp)
 {
     for (uint32_t i=0; i<MAX_INSTR_DESTINATIONS; i++) {
         if (ROB.entry[prior].destination_registers[i] == 0)
             continue;
 
-        if (ROB.entry[prior].destination_registers[i] == ROB.entry[current].source_registers[source_index]) {
+        if (comp(ROB.entry[prior].destination_registers[i], ROB.entry[current].source_registers[source_index])) {
 
             // we need to mark this dependency in the ROB since the producer might not be added in the store queue yet
             ROB.entry[prior].registers_instrs_depend_on_me.insert (current);   // this load cannot be executed until the prior store gets executed


### PR DESCRIPTION
This allows us to configure multiple ways to compare register indices. Currently, it does a naive equality check, but more robust comparators are now possible.

Addresses Issue #30