### PR TITLE
Bugfix: Underutilized scheduling width

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -788,8 +788,6 @@ int main(int argc, char** argv)
 	      ooo_cpu[i].update_rob();
 
 	      // schedule
-	      uint32_t schedule_index = ooo_cpu[i].ROB.next_schedule;
-	      if ((ooo_cpu[i].ROB.entry[schedule_index].scheduled == 0) && (ooo_cpu[i].ROB.entry[schedule_index].event_cycle <= current_core_cycle[i]))
 		ooo_cpu[i].schedule_instruction();
 	      // execute
 	      ooo_cpu[i].execute_instruction();

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -850,8 +850,7 @@ void O3_CPU::schedule_instruction()
     {
         for (uint32_t i=ROB.head; i<ROB.tail; i++)
         {
-            ooo_model_instr &rob_entry = ROB.entry.at(i);
-            if ((rob_entry.fetched != COMPLETED) || (rob_entry.event_cycle > current_core_cycle[cpu]) || (num_searched >= SCHEDULER_SIZE))
+            if ((ROB.entry[i].fetched != COMPLETED) || (ROB.entry[i].event_cycle > current_core_cycle[cpu]) || (num_searched >= SCHEDULER_SIZE))
                 return;
 
             if (ROB.entry[i].scheduled == 0)
@@ -864,8 +863,7 @@ void O3_CPU::schedule_instruction()
     {
         for (uint32_t i=ROB.head; i<ROB.SIZE; i++)
         {
-            ooo_model_instr &rob_entry = ROB.entry.at(i);
-            if ((rob_entry.fetched != COMPLETED) || (rob_entry.event_cycle > current_core_cycle[cpu]) || (num_searched >= SCHEDULER_SIZE))
+            if ((ROB.entry[i].fetched != COMPLETED) || (ROB.entry[i].event_cycle > current_core_cycle[cpu]) || (num_searched >= SCHEDULER_SIZE))
                 return;
 
             if (ROB.entry[i].scheduled == 0)
@@ -875,8 +873,7 @@ void O3_CPU::schedule_instruction()
         }
         for (uint32_t i=0; i<ROB.tail; i++)
         {
-            ooo_model_instr &rob_entry = ROB.entry.at(i);
-            if ((rob_entry.fetched != COMPLETED) || (rob_entry.event_cycle > current_core_cycle[cpu]) || (num_searched >= SCHEDULER_SIZE))
+            if ((ROB.entry[i].fetched != COMPLETED) || (ROB.entry[i].event_cycle > current_core_cycle[cpu]) || (num_searched >= SCHEDULER_SIZE))
                 return;
 
             if (ROB.entry[i].scheduled == 0)


### PR DESCRIPTION
The ROB.next_fetch member is never modified, so it always keeps its default value of zero. This causes the scheduler to always run from ROB.head to ROB.SIZE, which is a bug. This pull request changes it so that it runs from ROB.head to ROB.tail, still halting early if it reaches a scheduled instruction or the machine's schedule width. This results generally in an increased performance in the simulations.