### PR TITLE
Scheduler update

### DIFF
--- a/inc/block.h
+++ b/inc/block.h
@@ -106,7 +106,9 @@ class PACKET {
     uint32_t cpu, data_index, lq_index, sq_index;
 
     uint64_t address, 
-             full_addr, 
+             full_addr,
+             v_address,
+             full_v_addr,
              instruction_pa,
              data_pa,
              data,

--- a/inc/ooo_cpu.h
+++ b/inc/ooo_cpu.h
@@ -18,7 +18,7 @@ using namespace std;
 #define EXEC_WIDTH 6
 #define LQ_WIDTH 2
 #define SQ_WIDTH 2
-#define RETIRE_WIDTH 4
+#define RETIRE_WIDTH 5
 #define SCHEDULER_SIZE 128
 #define BRANCH_MISPREDICT_PENALTY 1
 //#define SCHEDULING_LATENCY 0
@@ -209,6 +209,8 @@ class O3_CPU {
 
     uint32_t check_and_add_lsq(uint32_t rob_index);
 
+    uint8_t mem_reg_dependence_resolved(uint32_t rob_index);
+
     // branch predictor
     uint8_t predict_branch(uint64_t ip);
     void    initialize_branch_predictor(),
@@ -221,7 +223,7 @@ class O3_CPU {
   void l1i_prefetcher_cycle_operate();
   void l1i_prefetcher_cache_fill(uint64_t v_addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_v_addr);
   void l1i_prefetcher_final_stats();
-  int prefetch_code_line(uint64_t pf_v_addr); 
+  int prefetch_code_line(uint64_t pf_v_addr);
 };
 
 extern O3_CPU ooo_cpu[NUM_CPUS];

--- a/src/main.cc
+++ b/src/main.cc
@@ -467,7 +467,9 @@ uint64_t va_to_pa(uint32_t cpu, uint64_t instr_id, uint64_t va, uint64_t unique_
     cout << " => ppage: " << (pa >> LOG2_PAGE_SIZE) << " vadress: " << unique_va << " paddress: " << pa << dec << endl; });
 
     // as a hack for code prefetching, code translations are magical and do not pay these penalties
-    if(!is_code)
+    //if(!is_code)
+    // actually, just disable this stall feature entirely
+    if(0)
       {
 	// if it's data, pay these penalties
 	if (swap)
@@ -788,7 +790,7 @@ int main(int argc, char** argv)
 	      ooo_cpu[i].update_rob();
 
 	      // schedule
-		ooo_cpu[i].schedule_instruction();
+	      ooo_cpu[i].schedule_instruction();
 	      // execute
 	      ooo_cpu[i].execute_instruction();
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -788,8 +788,6 @@ int main(int argc, char** argv)
 	      ooo_cpu[i].update_rob();
 
 	      // schedule
-	      uint32_t schedule_index = ooo_cpu[i].ROB.next_schedule;
-	      if ((ooo_cpu[i].ROB.entry[schedule_index].scheduled == 0) && (ooo_cpu[i].ROB.entry[schedule_index].event_cycle <= current_core_cycle[i]))
 		ooo_cpu[i].schedule_instruction();
 	      // execute
 	      ooo_cpu[i].execute_instruction();

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -850,8 +850,7 @@ void O3_CPU::schedule_instruction()
     {
         for (uint32_t i=ROB.head; i<ROB.tail; i++)
         {
-            ooo_model_instr &rob_entry = ROB.entry.at(i);
-            if ((rob_entry.fetched != COMPLETED) || (rob_entry.event_cycle > current_core_cycle[cpu]) || (num_searched >= SCHEDULER_SIZE))
+            if ((ROB.entry[i].fetched != COMPLETED) || (ROB.entry[i].event_cycle > current_core_cycle[cpu]) || (num_searched >= SCHEDULER_SIZE))
                 return;
 
             if (ROB.entry[i].scheduled == 0)
@@ -864,8 +863,7 @@ void O3_CPU::schedule_instruction()
     {
         for (uint32_t i=ROB.head; i<ROB.SIZE; i++)
         {
-            ooo_model_instr &rob_entry = ROB.entry.at(i);
-            if ((rob_entry.fetched != COMPLETED) || (rob_entry.event_cycle > current_core_cycle[cpu]) || (num_searched >= SCHEDULER_SIZE))
+            if ((ROB.entry[i].fetched != COMPLETED) || (ROB.entry[i].event_cycle > current_core_cycle[cpu]) || (num_searched >= SCHEDULER_SIZE))
                 return;
 
             if (ROB.entry[i].scheduled == 0)
@@ -875,8 +873,7 @@ void O3_CPU::schedule_instruction()
         }
         for (uint32_t i=0; i<ROB.tail; i++)
         {
-            ooo_model_instr &rob_entry = ROB.entry.at(i);
-            if ((rob_entry.fetched != COMPLETED) || (rob_entry.event_cycle > current_core_cycle[cpu]) || (num_searched >= SCHEDULER_SIZE))
+            if ((ROB.entry[i].fetched != COMPLETED) || (ROB.entry[i].event_cycle > current_core_cycle[cpu]) || (num_searched >= SCHEDULER_SIZE))
                 return;
 
             if (ROB.entry[i].scheduled == 0)

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -630,6 +630,8 @@ void O3_CPU::fetch_instruction()
 	  fetch_packet.address = IFETCH_BUFFER.entry[index].instruction_pa >> 6;
 	  fetch_packet.instruction_pa = IFETCH_BUFFER.entry[index].instruction_pa;
 	  fetch_packet.full_addr = IFETCH_BUFFER.entry[index].instruction_pa;
+	  fetch_packet.v_address = IFETCH_BUFFER.entry[index].ip >> LOG2_PAGE_SIZE;
+	  fetch_packet.full_v_addr = IFETCH_BUFFER.entry[index].ip;
 	  fetch_packet.instr_id = 0;
 	  fetch_packet.rob_index = 0;
 	  fetch_packet.producer = 0;
@@ -856,7 +858,8 @@ void O3_CPU::schedule_instruction()
             if (ROB.entry[i].scheduled == 0)
                 do_scheduling(i);
 
-            num_searched++;
+	    if(ROB.entry[i].executed == 0)
+	      num_searched++;
         }
     }
     else
@@ -869,7 +872,8 @@ void O3_CPU::schedule_instruction()
             if (ROB.entry[i].scheduled == 0)
                 do_scheduling(i);
 
-            num_searched++;
+	    if(ROB.entry[i].executed == 0)
+	      num_searched++;
         }
         for (uint32_t i=0; i<ROB.tail; i++)
         {
@@ -879,7 +883,8 @@ void O3_CPU::schedule_instruction()
             if (ROB.entry[i].scheduled == 0)
                 do_scheduling(i);
 
-            num_searched++;
+	    if(ROB.entry[i].executed == 0)
+	      num_searched++;
         }
     }
 }
@@ -1077,49 +1082,81 @@ void O3_CPU::do_execution(uint32_t rob_index)
     //}
 }
 
+uint8_t O3_CPU::mem_reg_dependence_resolved(uint32_t rob_index)
+{
+  if(ROB.entry[rob_index].reg_ready)
+    {
+      return 1;
+    }
+  else
+    {
+      uint8_t count_source_regs = 0;
+      uint8_t stack_pointer_source = 0;
+      for(int i=0; i<NUM_INSTR_SOURCES; i++)
+	{
+	  if(ROB.entry[rob_index].source_registers[i] != 0)
+	    {
+	      count_source_regs++;
+	    }
+	  if(ROB.entry[rob_index].source_registers[i] == REG_STACK_POINTER)
+	    {
+	      stack_pointer_source = 1;
+	    }
+	}
+
+      if(stack_pointer_source == 1)
+	{
+	  return 0;
+	}
+
+      if((count_source_regs == 1) && (ROB.entry[rob_index].source_registers[0] == ROB.entry[rob_index].destination_registers[0]))
+	{
+	  return 1;
+	}
+    }
+  
+  return 0;
+}
+
 void O3_CPU::schedule_memory_instruction()
 {
     if ((ROB.head == ROB.tail) && ROB.occupancy == 0)
         return;
 
     // execution is out-of-order but we have an in-order scheduling algorithm to detect all RAW dependencies
-    uint32_t limit = ROB.next_schedule;
     num_searched = 0;
-    if (ROB.head < limit) {
-        for (uint32_t i=ROB.head; i<limit; i++) {
-
-            if (ROB.entry[i].is_memory == 0)
-                continue;
-
+    if (ROB.head < ROB.tail) {
+        for (uint32_t i=ROB.head; i<ROB.tail; i++) {
             if ((ROB.entry[i].fetched != COMPLETED) || (ROB.entry[i].event_cycle > current_core_cycle[cpu]) || (num_searched >= SCHEDULER_SIZE))
                 break;
 
-            if (ROB.entry[i].is_memory && ROB.entry[i].reg_ready && (ROB.entry[i].scheduled == INFLIGHT))
+            if (ROB.entry[i].is_memory && mem_reg_dependence_resolved(i) && (ROB.entry[i].scheduled == INFLIGHT))
                 do_memory_scheduling(i);
+
+	    if(ROB.entry[i].executed == 0)
+	      num_searched++;
         }
     }
     else {
         for (uint32_t i=ROB.head; i<ROB.SIZE; i++) {
-
-            if (ROB.entry[i].is_memory == 0)
-                continue;
-
             if ((ROB.entry[i].fetched != COMPLETED) || (ROB.entry[i].event_cycle > current_core_cycle[cpu]) || (num_searched >= SCHEDULER_SIZE))
                 break;
 
-            if (ROB.entry[i].is_memory && ROB.entry[i].reg_ready && (ROB.entry[i].scheduled == INFLIGHT))
+            if (ROB.entry[i].is_memory && mem_reg_dependence_resolved(i) && (ROB.entry[i].scheduled == INFLIGHT))
                 do_memory_scheduling(i);
-        }
-        for (uint32_t i=0; i<limit; i++) {
 
-            if (ROB.entry[i].is_memory == 0)
-                continue;
-
+	    if(ROB.entry[i].executed == 0)
+	      num_searched++;
+	}
+        for (uint32_t i=0; i<ROB.tail; i++) {
             if ((ROB.entry[i].fetched != COMPLETED) || (ROB.entry[i].event_cycle > current_core_cycle[cpu]) || (num_searched >= SCHEDULER_SIZE))
                 break;
 
-            if (ROB.entry[i].is_memory && ROB.entry[i].reg_ready && (ROB.entry[i].scheduled == INFLIGHT))
+            if (ROB.entry[i].is_memory && mem_reg_dependence_resolved(i) && (ROB.entry[i].scheduled == INFLIGHT))
                 do_memory_scheduling(i);
+
+	    if(ROB.entry[i].executed == 0)
+	      num_searched++;
         }
     }
 }
@@ -1142,8 +1179,6 @@ void O3_CPU::do_memory_scheduling(uint32_t rob_index)
         cout << "[ROB] " << __func__ << " instr_id: " << ROB.entry[rob_index].instr_id << " rob_index: " << rob_index;
         cout << " scheduled all num_mem_ops: " << ROB.entry[rob_index].num_mem_ops << endl; });
     }
-
-    num_searched++;
 }
 
 uint32_t O3_CPU::check_and_add_lsq(uint32_t rob_index) 
@@ -1697,6 +1732,8 @@ int O3_CPU::execute_load(uint32_t rob_index, uint32_t lq_index, uint32_t data_in
     data_packet.lq_index = lq_index;
     data_packet.address = LQ.entry[lq_index].physical_address >> LOG2_BLOCK_SIZE;
     data_packet.full_addr = LQ.entry[lq_index].physical_address;
+    data_packet.v_address = LQ.entry[lq_index].virtual_address >> LOG2_BLOCK_SIZE;
+    data_packet.full_v_addr = LQ.entry[lq_index].virtual_address;
     data_packet.instr_id = LQ.entry[lq_index].instr_id;
     data_packet.rob_index = LQ.entry[lq_index].rob_index;
     data_packet.ip = LQ.entry[lq_index].ip;
@@ -2254,6 +2291,8 @@ void O3_CPU::retire_rob()
                         data_packet.sq_index = sq_index;
                         data_packet.address = SQ.entry[sq_index].physical_address >> LOG2_BLOCK_SIZE;
                         data_packet.full_addr = SQ.entry[sq_index].physical_address;
+                        data_packet.v_address = SQ.entry[sq_index].virtual_address >> LOG2_BLOCK_SIZE;
+                        data_packet.full_v_addr = SQ.entry[sq_index].virtual_address;
                         data_packet.instr_id = SQ.entry[sq_index].instr_id;
                         data_packet.rob_index = SQ.entry[sq_index].rob_index;
                         data_packet.ip = SQ.entry[sq_index].ip;


### PR DESCRIPTION
Now the entire scheduler width is more correctly and consistently used to find instructions ready to execute and/or issue loads.  Also, the loads associated with an instruction can no be issued before the instruction's register dependencies are freed up for some register access patterns.