### PR TITLE
Pipeline decoder

### DIFF
--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -777,6 +777,7 @@ void O3_CPU::decode_and_dispatch()
 	{
 	  // apply decode latency
 	  DECODE_BUFFER.entry[decode_index].event_cycle = current_core_cycle[cpu] + DECODE_LATENCY;
+	  count_decodes++;
 	}
       
       if(decode_index == DECODE_BUFFER.tail)
@@ -789,7 +790,6 @@ void O3_CPU::decode_and_dispatch()
 	  decode_index = 0;
 	}
 
-      count_decodes++;
       if(count_decodes >= DECODE_WIDTH)
 	{
 	  break;


### PR DESCRIPTION
I think decoder should be pipelined.
This pull request addresses this issue.

If it's intentionally non-pipelined, I think it should be noted somewhere.