### PR TITLE
Upstream Georgios Vavouliotis's Page Walker

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,22 @@ $ ./run_4core.sh bimodal-no-no-no-lru-4core 1 10 0 400.perlbench-41B.champsimtra
 ```
 Note that we need to specify multiple trace files for `run_4core.sh`. `N_MIX` is used to represent a unique ID for mixed multi-programmed workloads. 
 
+## Run-time flags
+
+Two environment variables are read that can be used to configure page walker
+settings. The status of these values will be reported in the default output.
+
+* `CS_PAGE_TABLE_LATENCY`
+	* Sets `PAGE_TABLE_LATENCY` (a constant estimate of the time to walk the
+	  page table) to the value of this variable.
+	* default is 100 (as of 2020-06-16), if unset.
+	* If set to be the default value, it will appear as changed in the output,
+	  despite having no effect.
+* `CS_DO_PAGE_WALK`
+	* Set to any non-empty string to enable.
+	* Enables the simulated page walker, makes `CS_PAGE_TABLE_LATENCY`, and the
+	  default value for `PAGE_TABLE_LATENCY` (100) irrelevant as they are not
+used.
 
 # Add your own branch predictor, data prefetchers, and replacement policy
 **Copy an empty template**

--- a/inc/cache.h
+++ b/inc/cache.h
@@ -1,6 +1,32 @@
 #ifndef CACHE_H
 #define CACHE_H
 
+/*
+Georgios's Page Walker
+Author: Georgios Vavouliotis
+Advisors: Lluc Alvarez, Marc Casas Guix
+{georgios.vavouliotis, lluc.alvarez, marc.casas}@bsc.es
+
+Ported by James Coman - james in the domain tamu.edu
+*/
+#include <stdint.h>
+#define PML4_SET 2
+#define PML4_WAY 4
+#define PDP_SET 8
+#define PDP_WAY 1
+#define PD_SET 1
+#define PD_WAY 4
+
+//uint64_t mmu_timer; //One of the placements from Georgios
+int simulated_page_walker(uint32_t cpu, uint64_t vpage, int swap, uint64_t instr_id, uint64_t ip, int type);
+
+/* you can implement each page walk cache level as a 2d array */
+extern uint64_t pml4[PML4_SET][PML4_WAY], pdp[PDP_SET][PDP_WAY], pd[PD_SET][PD_WAY];
+
+/* implementation of LRU policy with counters */
+extern uint64_t pml4_lru[PML4_SET][PML4_WAY], pdp_lru[PDP_SET][PDP_WAY], pd_lru[PD_SET][PD_WAY];
+
+
 #include "memory_class.h"
 
 // PAGE
@@ -84,6 +110,7 @@ class CACHE : public MEMORY {
     const string NAME;
     const uint32_t NUM_SET, NUM_WAY, NUM_LINE, WQ_SIZE, RQ_SIZE, PQ_SIZE, MSHR_SIZE;
     uint32_t LATENCY;
+	uint64_t mmu_timer;
     BLOCK **block;
     int fill_level;
     uint32_t MAX_READ, MAX_FILL;
@@ -118,6 +145,7 @@ class CACHE : public MEMORY {
         : NAME(v1), NUM_SET(v2), NUM_WAY(v3), NUM_LINE(v4), WQ_SIZE(v5), RQ_SIZE(v6), PQ_SIZE(v7), MSHR_SIZE(v8) {
 
         LATENCY = 0;
+		mmu_timer=0;
 
         // cache block
         block = new BLOCK* [NUM_SET];
@@ -222,6 +250,22 @@ class CACHE : public MEMORY {
              find_victim(uint32_t cpu, uint64_t instr_id, uint32_t set, const BLOCK *current_set, uint64_t ip, uint64_t full_addr, uint32_t type),
              llc_find_victim(uint32_t cpu, uint64_t instr_id, uint32_t set, const BLOCK *current_set, uint64_t ip, uint64_t full_addr, uint32_t type),
              lru_victim(uint32_t cpu, uint64_t instr_id, uint32_t set, const BLOCK *current_set, uint64_t ip, uint64_t full_addr, uint32_t type);
+
+/*
+Georgios's Page Walker
+Author: Georgios Vavouliotis
+Advisors: Lluc Alvarez, Marc Casas Guix
+{georgios.vavouliotis, lluc.alvarez, marc.casas}@bsc.es
+
+Ported by James Coman - james in the domain tamu.edu
+*/
+/* functions for searching in the page walk caches for possible hits */
+int  search_pml4(uint64_t address), search_pdp(uint64_t address), search_pd(uint64_t address);
+
+/* functions for storing/updating entries in the page walk caches */
+void update_pml4(uint64_t timer, uint64_t address), update_pdp(uint64_t timer, uint64_t address), update_pd(uint64_t timer, uint64_t address);
+
+
 };
 
 #endif

--- a/inc/champsim.h
+++ b/inc/champsim.h
@@ -94,7 +94,7 @@ extern uint64_t previous_ppage, num_adjacent_page, num_cl[NUM_CPUS], allocated_p
 void print_stats();
 uint64_t rotl64 (uint64_t n, unsigned int c),
          rotr64 (uint64_t n, unsigned int c),
-  va_to_pa(uint32_t cpu, uint64_t instr_id, uint64_t va, uint64_t unique_vpage, uint8_t is_code);
+  va_to_pa(uint32_t cpu, uint64_t instr_id, uint64_t va, uint64_t unique_vpage, uint8_t is_code, uint64_t ip, int type);
 
 // log base 2 function from efectiu
 int lg2(int n);

--- a/inc/ooo_cpu.h
+++ b/inc/ooo_cpu.h
@@ -221,7 +221,7 @@ class O3_CPU {
   void l1i_prefetcher_cycle_operate();
   void l1i_prefetcher_cache_fill(uint64_t v_addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_v_addr);
   void l1i_prefetcher_final_stats();
-  int prefetch_code_line(uint64_t pf_v_addr); 
+  int prefetch_code_line(uint64_t ip, uint64_t pf_v_addr);
 };
 
 extern O3_CPU ooo_cpu[NUM_CPUS];

--- a/prefetcher/next_line.l1i_pref
+++ b/prefetcher/next_line.l1i_pref
@@ -17,7 +17,7 @@ void O3_CPU::l1i_prefetcher_cache_operate(uint64_t v_addr, uint8_t cache_hit, ui
   if((cache_hit == 0) && (L1I.MSHR.occupancy < (L1I.MSHR.SIZE>>1)))
     {
       uint64_t pf_addr = v_addr + (1<<LOG2_BLOCK_SIZE);
-      prefetch_code_line(pf_addr);
+      prefetch_code_line(v_addr, pf_addr);
     }
 }
 

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -464,7 +464,8 @@ uint32_t O3_CPU::add_to_ifetch_buffer(ooo_model_instr *arch_instr)
   IFETCH_BUFFER.entry[index].event_cycle = current_core_cycle[cpu];
 
   // magically translate instructions
-  uint64_t instr_pa = va_to_pa(cpu, IFETCH_BUFFER.entry[index].instr_id, IFETCH_BUFFER.entry[index].ip , (IFETCH_BUFFER.entry[index].ip)>>LOG2_PAGE_SIZE, 1);
+  uint64_t instr_pa = va_to_pa(cpu, IFETCH_BUFFER.entry[index].instr_id, IFETCH_BUFFER.entry[index].ip , (IFETCH_BUFFER.entry[index].ip)>>LOG2_PAGE_SIZE, 1, IFETCH_BUFFER.entry[index].ip, PREFETCH);
+  //Should this be something other than prefetch?
   instr_pa >>= LOG2_PAGE_SIZE;
   instr_pa <<= LOG2_PAGE_SIZE;
   instr_pa |= (IFETCH_BUFFER.entry[index].ip & ((1 << LOG2_PAGE_SIZE) - 1));  
@@ -797,7 +798,7 @@ void O3_CPU::decode_and_dispatch()
     }
 }
 
-int O3_CPU::prefetch_code_line(uint64_t pf_v_addr)
+int O3_CPU::prefetch_code_line(uint64_t ip, uint64_t pf_v_addr)
 {
   if(pf_v_addr == 0)
     {
@@ -810,7 +811,7 @@ int O3_CPU::prefetch_code_line(uint64_t pf_v_addr)
   if (L1I.PQ.occupancy < L1I.PQ.SIZE)
     {
       // magically translate prefetches
-      uint64_t pf_pa = (va_to_pa(cpu, 0, pf_v_addr, pf_v_addr>>LOG2_PAGE_SIZE, 1) & (~((1 << LOG2_PAGE_SIZE) - 1))) | (pf_v_addr & ((1 << LOG2_PAGE_SIZE) - 1));
+      uint64_t pf_pa = (va_to_pa(cpu, 0, pf_v_addr, pf_v_addr>>LOG2_PAGE_SIZE, 1, ip, PREFETCH) & (~((1 << LOG2_PAGE_SIZE) - 1))) | (pf_v_addr & ((1 << LOG2_PAGE_SIZE) - 1));
 
       PACKET pf_packet;
       pf_packet.instruction = 1; // this is a code prefetch


### PR DESCRIPTION
## Change Summary

Realistic Page Walker provided by Georgios Vavouliotis in `simulated_page_walker()` called by `va_to_pa()`

`README.md` is modified for usage instructions, which are runtime

`va_to_pa()` is modified to accept `ip` and `type` as arguments which are used by the
page walker. This undoes some of Seth's work in [`ee93e2`.](https://github.com/ChampSim/ChampSim/commit/ee93e223aefb311ac820e72013c1f4c46157ab5d) Unsure if that is a problem. If it is, there will need to be another way to get `ip` to `simulated_page_walker()`, through `va_to_pa()`

## Some possible areas of concern:

+ Line 683 of `cache.cc` - if the type passed is appropriate (`RQ.entry[index].type`)
+ Lines 467 and 814 of `ooo_cpu.c`, if the type `PREFETCH` is correct here.
+ Line 826 of `ooo_cpu.c`, which reads: `pf_packet.ip = pf_v_addr;` after modification in `ee93e2` to not be `pf_packet.ip = ip`. This could now be changed back. Should it?
