### PR TITLE
MSHR merging:- Keep prior fill information

### DIFF
--- a/src/cache.cc
+++ b/src/cache.cc
@@ -763,7 +763,15 @@ void CACHE::handle_read()
                         if (MSHR.entry[mshr_index].type == PREFETCH) {
                             uint8_t  prior_returned = MSHR.entry[mshr_index].returned;
                             uint64_t prior_event_cycle = MSHR.entry[mshr_index].event_cycle;
-                            MSHR.entry[mshr_index] = RQ.entry[index];
+                            uint8_t  prior_fill_l1i = MSHR.entry[mshr_index].fill_l1i;
+			    uint8_t  prior_fill_l1d = MSHR.entry[mshr_index].fill_l1d;
+			    
+			    MSHR.entry[mshr_index] = RQ.entry[index];
+                            
+			    if(prior_fill_l1i && MSHR.entry[mshr_index].fill_l1i == 0)
+				    MSHR.entry[mshr_index].fill_l1i = 1;
+			    if(prior_fill_l1d && MSHR.entry[mshr_index].fill_l1d == 0)
+				    MSHR.entry[mshr_index].fill_l1d = 1;
                             
                             // in case request is already returned, we should keep event_cycle and retunred variables
                             MSHR.entry[mshr_index].returned = prior_returned;

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -777,6 +777,7 @@ void O3_CPU::decode_and_dispatch()
 	{
 	  // apply decode latency
 	  DECODE_BUFFER.entry[decode_index].event_cycle = current_core_cycle[cpu] + DECODE_LATENCY;
+	  count_decodes++;
 	}
       
       if(decode_index == DECODE_BUFFER.tail)
@@ -789,7 +790,6 @@ void O3_CPU::decode_and_dispatch()
 	  decode_index = 0;
 	}
 
-      count_decodes++;
       if(count_decodes >= DECODE_WIDTH)
 	{
 	  break;


### PR DESCRIPTION
The bug:- If an instruction prefetch request from L1I prefetcher is present in L2C and demand request comes from L1D for the same cache block, then fill_l1i information will be lost. If a subsequent instruction demand request comes to same cache block, it will get merged in L1I MSHR and it will wait forever. 
This will also not create a deadlock situation because deadlock is checked once the request reaches ROB.