### PR TITLE
Virtual Address Space data prefetching

### DIFF
--- a/inc/block.h
+++ b/inc/block.h
@@ -20,6 +20,8 @@ class BLOCK {
 
     uint64_t address,
              full_addr,
+             v_address,
+             full_v_addr,
              tag,
              data,
              ip,

--- a/prefetcher/ip_stride.l2c_pref
+++ b/prefetcher/ip_stride.l2c_pref
@@ -49,7 +49,7 @@ void CACHE::l2c_prefetcher_initialize()
         trackers[i].lru = i;
 }
 
-uint32_t CACHE::l2c_prefetcher_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in)
+uint32_t CACHE::l2c_prefetcher_operate(uint64_t v_addr, uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in)
 {
     // check for a tracker hit
     uint64_t cl_addr = addr >> LOG2_BLOCK_SIZE;
@@ -104,7 +104,7 @@ uint32_t CACHE::l2c_prefetcher_operate(uint64_t addr, uint64_t ip, uint8_t cache
     // don't do anything if we somehow saw the same address twice in a row
     if (stride == 0)
         return metadata_in;
-
+    
     // only do any prefetching if there's a pattern of seeing the same
     // stride more than once
     if (stride == trackers[index].last_stride) {
@@ -138,7 +138,7 @@ uint32_t CACHE::l2c_prefetcher_operate(uint64_t addr, uint64_t ip, uint8_t cache
     return metadata_in;
 }
 
-uint32_t CACHE::l2c_prefetcher_cache_fill(uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
+uint32_t CACHE::l2c_prefetcher_cache_fill(uint64_t v_addr, uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
 {
   return metadata_in;
 }

--- a/prefetcher/kpcp.l2c_pref
+++ b/prefetcher/kpcp.l2c_pref
@@ -595,7 +595,7 @@ void L2_PT_update(uint32_t cpu, int signature, int delta)
 */
 
 // TODO: from here
-uint32_t CACHE::l2c_prefetcher_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in)
+uint32_t CACHE::l2c_prefetcher_operate(uint64_t v_addr, uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in)
 {
     // Check ST
     L2_ST_update(cpu, addr);
@@ -728,7 +728,7 @@ uint32_t CACHE::l2c_prefetcher_operate(uint64_t addr, uint64_t ip, uint8_t cache
     return metadata_in;
 }
 
-uint32_t CACHE::l2c_prefetcher_cache_fill(uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
+uint32_t CACHE::l2c_prefetcher_cache_fill(uint64_t v_addr, uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
 {
 	// L2 FILL
     uint64_t evicted_cl = evicted_addr >> LOG2_BLOCK_SIZE;

--- a/prefetcher/l1d_prefetcher.cc
+++ b/prefetcher/l1d_prefetcher.cc
@@ -5,12 +5,12 @@ void CACHE::l1d_prefetcher_initialize()
 
 }
 
-void CACHE::l1d_prefetcher_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type)
+void CACHE::l1d_prefetcher_operate(uint64_t v_addr, uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type)
 {
 
 }
 
-void CACHE::l1d_prefetcher_cache_fill(uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
+void CACHE::l1d_prefetcher_cache_fill(uint64_t v_addr, uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
 {
 
 }

--- a/prefetcher/l2c_prefetcher.cc
+++ b/prefetcher/l2c_prefetcher.cc
@@ -5,12 +5,12 @@ void CACHE::l2c_prefetcher_initialize()
 
 }
 
-uint32_t CACHE::l2c_prefetcher_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in)
+uint32_t CACHE::l2c_prefetcher_operate(uint64_t v_addr, uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in)
 {
   return metadata_in;
 }
 
-uint32_t CACHE::l2c_prefetcher_cache_fill(uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
+uint32_t CACHE::l2c_prefetcher_cache_fill(uint64_t v_addr, uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
 {
   return metadata_in;
 }

--- a/prefetcher/llc_prefetcher.cc
+++ b/prefetcher/llc_prefetcher.cc
@@ -5,12 +5,12 @@ void CACHE::llc_prefetcher_initialize()
 
 }
 
-uint32_t CACHE::llc_prefetcher_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in)
+uint32_t CACHE::llc_prefetcher_operate(uint64_t v_addr, uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in)
 {
   return metadata_in;
 }
 
-uint32_t CACHE::llc_prefetcher_cache_fill(uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
+uint32_t CACHE::llc_prefetcher_cache_fill(uint64_t v_addr, uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
 {
   return metadata_in;
 }

--- a/prefetcher/next_line.l1d_pref
+++ b/prefetcher/next_line.l1d_pref
@@ -5,7 +5,7 @@ void CACHE::l1d_prefetcher_initialize()
     cout << "CPU " << cpu << " L1D next line prefetcher" << endl;
 }
 
-void CACHE::l1d_prefetcher_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type)
+void CACHE::l1d_prefetcher_operate(uint64_t v_addr, uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type)
 {
     uint64_t pf_addr = ((addr>>LOG2_BLOCK_SIZE)+1) << LOG2_BLOCK_SIZE;
 
@@ -16,7 +16,7 @@ void CACHE::l1d_prefetcher_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit
     prefetch_line(ip, addr, pf_addr, FILL_L1, 0);
 }
 
-void CACHE::l1d_prefetcher_cache_fill(uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
+void CACHE::l1d_prefetcher_cache_fill(uint64_t v_addr, uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
 {
 
 }

--- a/prefetcher/next_line.l2c_pref
+++ b/prefetcher/next_line.l2c_pref
@@ -5,7 +5,7 @@ void CACHE::l2c_prefetcher_initialize()
     cout << "CPU " << cpu << " L2C next line prefetcher" << endl;
 }
 
-uint32_t CACHE::l2c_prefetcher_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in)
+uint32_t CACHE::l2c_prefetcher_operate(uint64_t v_addr, uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in)
 {
     uint64_t pf_addr = ((addr>>LOG2_BLOCK_SIZE)+1) << LOG2_BLOCK_SIZE;
 
@@ -18,7 +18,7 @@ uint32_t CACHE::l2c_prefetcher_operate(uint64_t addr, uint64_t ip, uint8_t cache
     return metadata_in;
 }
 
-uint32_t CACHE::l2c_prefetcher_cache_fill(uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
+uint32_t CACHE::l2c_prefetcher_cache_fill(uint64_t v_addr, uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
 {
   return metadata_in;
 }

--- a/prefetcher/next_line.llc_pref
+++ b/prefetcher/next_line.llc_pref
@@ -5,7 +5,7 @@ void CACHE::llc_prefetcher_initialize()
     cout << "LLC Next Line Prefetcher" << endl;
 }
 
-uint32_t CACHE::llc_prefetcher_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in)
+uint32_t CACHE::llc_prefetcher_operate(uint64_t v_addr, uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in)
 {
   uint64_t pf_addr = ((addr>>LOG2_BLOCK_SIZE)+1) << LOG2_BLOCK_SIZE;
   prefetch_line(ip, addr, pf_addr, FILL_LLC, 0);
@@ -13,7 +13,7 @@ uint32_t CACHE::llc_prefetcher_operate(uint64_t addr, uint64_t ip, uint8_t cache
   return metadata_in;
 }
 
-uint32_t CACHE::llc_prefetcher_cache_fill(uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
+uint32_t CACHE::llc_prefetcher_cache_fill(uint64_t v_addr, uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
 {
   return metadata_in;
 }

--- a/prefetcher/no.l1d_pref
+++ b/prefetcher/no.l1d_pref
@@ -5,12 +5,12 @@ void CACHE::l1d_prefetcher_initialize()
 
 }
 
-void CACHE::l1d_prefetcher_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type)
+void CACHE::l1d_prefetcher_operate(uint64_t v_addr, uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type)
 {
 
 }
 
-void CACHE::l1d_prefetcher_cache_fill(uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
+void CACHE::l1d_prefetcher_cache_fill(uint64_t v_addr, uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
 {
 
 }

--- a/prefetcher/no.l2c_pref
+++ b/prefetcher/no.l2c_pref
@@ -5,12 +5,12 @@ void CACHE::l2c_prefetcher_initialize()
 
 }
 
-uint32_t CACHE::l2c_prefetcher_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in)
+uint32_t CACHE::l2c_prefetcher_operate(uint64_t v_addr, uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in)
 {
   return metadata_in;
 }
 
-uint32_t CACHE::l2c_prefetcher_cache_fill(uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
+uint32_t CACHE::l2c_prefetcher_cache_fill(uint64_t v_addr, uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
 {
   return metadata_in;
 }

--- a/prefetcher/no.llc_pref
+++ b/prefetcher/no.llc_pref
@@ -5,12 +5,12 @@ void CACHE::llc_prefetcher_initialize()
 
 }
 
-uint32_t CACHE::llc_prefetcher_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in)
+uint32_t CACHE::llc_prefetcher_operate(uint64_t v_addr, uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in)
 {
   return metadata_in;
 }
 
-uint32_t CACHE::llc_prefetcher_cache_fill(uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
+uint32_t CACHE::llc_prefetcher_cache_fill(uint64_t v_addr, uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
 {
   return metadata_in;
 }

--- a/prefetcher/spp_dev.l2c_pref
+++ b/prefetcher/spp_dev.l2c_pref
@@ -11,7 +11,7 @@ void CACHE::l2c_prefetcher_initialize()
 
 }
 
-uint32_t CACHE::l2c_prefetcher_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in)
+uint32_t CACHE::l2c_prefetcher_operate(uint64_t v_addr, uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in)
 {
     uint64_t page = addr >> LOG2_PAGE_SIZE;
     uint32_t page_offset = (addr >> LOG2_BLOCK_SIZE) & (PAGE_SIZE / BLOCK_SIZE - 1),
@@ -118,7 +118,7 @@ uint32_t CACHE::l2c_prefetcher_operate(uint64_t addr, uint64_t ip, uint8_t cache
     return metadata_in;
 }
 
-uint32_t CACHE::l2c_prefetcher_cache_fill(uint64_t addr, uint32_t set, uint32_t match, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
+uint32_t CACHE::l2c_prefetcher_cache_fill(uint64_t v_addr, uint64_t addr, uint32_t set, uint32_t match, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
 {
 #ifdef FILTER_ON
     SPP_DP (cout << endl;);

--- a/prefetcher/va_ampm_lite.l2c_pref
+++ b/prefetcher/va_ampm_lite.l2c_pref
@@ -1,0 +1,322 @@
+#include "cache.h"
+
+#define L2C_VA_AMPM_LITE_REGION_COUNT 128
+#define L2C_VA_AMPM_LITE_MAX_DISTANCE 256
+#define L2C_VA_AMPM_LITE_PREFETCH_DEGREE 2
+
+struct l2c_va_ampm_lite_region_t
+{
+  uint64_t vpn;
+  uint64_t access_map;
+  uint64_t prefetch_map;
+  uint64_t lru;
+};
+
+l2c_va_ampm_lite_region_t l2c_va_ampm_lite_regions[L2C_VA_AMPM_LITE_REGION_COUNT];
+uint64_t l2c_va_ampm_lite_region_lru;
+
+int l2c_prefetch_va_or_pa(CACHE *cache, uint64_t ip, uint64_t v_base_addr, uint64_t v_pf_addr, uint64_t p_base_addr, int pf_fill_level, int pf_metadata)
+{
+  if((v_base_addr>>LOG2_BLOCK_SIZE) == (v_pf_addr>>LOG2_BLOCK_SIZE))
+    {
+      // attempting to prefetch the same cache line!
+      return -1;
+    }
+
+  if((v_base_addr>>LOG2_PAGE_SIZE) != (v_pf_addr>>LOG2_PAGE_SIZE))
+    {
+      // prefetching to different pages, so use virtual address prefetching
+      if(cache->va_prefetch_line(ip, v_pf_addr, pf_fill_level, pf_metadata))
+        {
+          return 1;
+        }
+      else
+        {
+          return 0;
+        }
+    }
+
+   if((v_base_addr>>LOG2_PAGE_SIZE) == (v_pf_addr>>LOG2_PAGE_SIZE))
+     {
+       // prefetching in the same page, so use physical address prefetching
+       long long int pf_offset = v_pf_addr -v_base_addr;
+       if(cache->prefetch_line(ip, p_base_addr, p_base_addr+pf_offset, pf_fill_level, pf_metadata))
+         {
+           return 2;
+         }
+       else
+         {
+           return 0;
+         }
+     }
+
+  return 0;
+}
+
+void va_ampm_allocate_region(int region_index, uint64_t allocate_vpn)
+{
+  l2c_va_ampm_lite_regions[region_index].vpn = allocate_vpn;
+  l2c_va_ampm_lite_regions[region_index].access_map = 0;
+  l2c_va_ampm_lite_regions[region_index].prefetch_map = 0;
+  l2c_va_ampm_lite_regions[region_index].lru = l2c_va_ampm_lite_region_lru;
+  l2c_va_ampm_lite_region_lru++;  
+}
+
+int va_ampm_find_region(uint64_t search_vpn)
+{
+  static int way_predict_index = 0;
+  static uint64_t way_predict_vpn = 0;
+
+  if(way_predict_vpn == search_vpn)
+    {
+      return way_predict_index;
+    }
+    
+  int region_index = -1;
+  for(int i=0; i<L2C_VA_AMPM_LITE_REGION_COUNT; i++)
+    {
+      if(l2c_va_ampm_lite_regions[i].vpn == search_vpn)
+	{
+	  region_index = i;
+	  break;
+	}
+    }
+  
+  way_predict_index = region_index;
+  way_predict_vpn = search_vpn;
+  return region_index;
+}
+
+int va_ampm_get_lru_region()
+{
+  int lru_index = 0;
+  uint64_t lru_value = l2c_va_ampm_lite_regions[lru_index].lru;
+  for(int i=0; i<L2C_VA_AMPM_LITE_REGION_COUNT; i++)
+    {
+      if(l2c_va_ampm_lite_regions[i].lru < lru_value)
+	{
+	  lru_index = i;
+	  lru_value = l2c_va_ampm_lite_regions[lru_index].lru;
+	}
+    }
+
+  return lru_index;
+}
+
+bool va_ampm_check_access(int region_index, int region_offset)
+{
+  return ((l2c_va_ampm_lite_regions[region_index].access_map)>>region_offset)&1;
+}
+
+void va_ampm_set_access(int region_index, int region_offset)
+{
+  uint64_t one_set_bit = (1L<<region_offset);
+  l2c_va_ampm_lite_regions[region_index].access_map |= one_set_bit;
+}
+
+void va_ampm_reset_access(int region_index, int region_offset)
+{
+  l2c_va_ampm_lite_regions[region_index].access_map &= (~(1<<region_offset));
+}
+
+bool va_ampm_check_prefetch(int region_index, int region_offset)
+{
+  return ((l2c_va_ampm_lite_regions[region_index].prefetch_map)>>region_offset)&1;
+}
+
+void va_ampm_set_prefetch(int region_index, int region_offset)
+{
+  uint64_t one_set_bit = (1L<<region_offset);
+  l2c_va_ampm_lite_regions[region_index].prefetch_map |= one_set_bit;
+}
+
+void va_ampm_reset_prefetch(int region_index, int region_offset)
+{
+  l2c_va_ampm_lite_regions[region_index].prefetch_map &= (~(1<<region_offset));
+}
+
+bool va_ampm_check_cl_access(uint64_t v_addr)
+{
+  uint64_t vpn = v_addr>>LOG2_PAGE_SIZE;
+  uint64_t page_offset = (v_addr>>LOG2_BLOCK_SIZE)&63;
+  int region_index = va_ampm_find_region(vpn);
+
+  if(region_index == -1)
+    {
+      return false;
+    }
+
+  return va_ampm_check_access(region_index, page_offset);
+}
+
+void va_ampm_set_cl_access(uint64_t v_addr)
+{
+  uint64_t vpn = v_addr>>LOG2_PAGE_SIZE;
+  uint64_t page_offset = (v_addr>>LOG2_BLOCK_SIZE)&63;
+  int region_index = va_ampm_find_region(vpn);
+
+  if(region_index == -1)
+    {
+      // we're not currently tracking this region, so allocate a new region so we can mark it
+      int lru_index = va_ampm_get_lru_region();
+      va_ampm_allocate_region(lru_index, vpn);
+      region_index = lru_index;
+    }
+
+  va_ampm_set_access(region_index, page_offset);
+}
+
+void va_ampm_reset_cl_access(uint64_t v_addr)
+{
+  uint64_t vpn = v_addr>>LOG2_PAGE_SIZE;
+  uint64_t page_offset = (v_addr>>LOG2_BLOCK_SIZE)&63;
+  int region_index = va_ampm_find_region(vpn);
+
+  if(region_index == -1)
+    {
+      // we're not currently tracking this region, but it doesn't matter so we just do nothing
+      return;
+    }
+
+  va_ampm_reset_access(region_index, page_offset);
+}
+
+bool va_ampm_check_cl_prefetch(uint64_t v_addr)
+{
+  uint64_t vpn = v_addr>>LOG2_PAGE_SIZE;
+  uint64_t page_offset = (v_addr>>LOG2_BLOCK_SIZE)&63;
+  int region_index = va_ampm_find_region(vpn);
+
+  if(region_index == -1)
+    {
+      return false;
+    }
+
+  return va_ampm_check_prefetch(region_index, page_offset);
+}
+
+void va_ampm_set_cl_prefetch(uint64_t v_addr)
+{
+  uint64_t vpn = v_addr>>LOG2_PAGE_SIZE;
+  uint64_t page_offset = (v_addr>>LOG2_BLOCK_SIZE)&63;
+  int region_index = va_ampm_find_region(vpn);
+
+  if(region_index == -1)
+    {
+      // we're not currently tracking this region, so allocate a new region so we can mark it
+      int lru_index = va_ampm_get_lru_region();
+      va_ampm_allocate_region(lru_index, vpn);
+      region_index = lru_index;
+    }
+
+  va_ampm_set_prefetch(region_index, page_offset);
+}
+
+void va_ampm_reset_cl_prefetch(uint64_t v_addr)
+{
+  uint64_t vpn = v_addr>>LOG2_PAGE_SIZE;
+  uint64_t page_offset = (v_addr>>LOG2_BLOCK_SIZE)&63;
+  int region_index = va_ampm_find_region(vpn);
+
+  if(region_index == -1)
+    {
+      // we're not currently tracking this region, but it doesn't matter so we just do nothing
+      return;
+    }
+
+  va_ampm_reset_prefetch(region_index, page_offset);
+}
+
+void CACHE::l2c_prefetcher_initialize() 
+{
+  cout << "CPU " << cpu << " L2C Virtual Address Space AMPM-Lite Prefetcher" << endl;
+
+  l2c_va_ampm_lite_region_lru = 0;
+  for(int i=0; i<L2C_VA_AMPM_LITE_REGION_COUNT; i++)
+    {
+      va_ampm_allocate_region(i, 0);
+    }
+}
+
+uint32_t CACHE::l2c_prefetcher_operate(uint64_t v_addr, uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in)
+{
+  uint64_t current_vpn = v_addr>>LOG2_PAGE_SIZE;
+  int region_index = va_ampm_find_region(current_vpn);
+
+  if(region_index == -1)
+    {
+      // not tracking this region yet, so replace the LRU region
+      int lru_index = va_ampm_get_lru_region();
+      va_ampm_allocate_region(lru_index, current_vpn);
+      return metadata_in;
+    }
+
+  // mark this demand access
+  va_ampm_set_cl_access(v_addr);
+
+  // attempt to prefetch in the positive direction
+  int prefetches_issued = 0;
+  for(int i=1; i<=L2C_VA_AMPM_LITE_MAX_DISTANCE; i++)
+    {
+      if((va_ampm_check_cl_access(v_addr - (i*BLOCK_SIZE))) && (va_ampm_check_cl_access(v_addr - (2*i*BLOCK_SIZE)))
+	 && (va_ampm_check_cl_access(v_addr+(i*BLOCK_SIZE)) == false) && (va_ampm_check_cl_prefetch(v_addr+(i*BLOCK_SIZE)) == false))
+	{
+	  // found something that we should prefetch
+	  int pf_fill_level = FILL_L2;
+	  if (MSHR.occupancy > (MSHR.SIZE>>1))
+	    {
+	      pf_fill_level = FILL_LLC;
+	    }
+	  bool prefetch_success = (l2c_prefetch_va_or_pa(this, ip, v_addr, v_addr+(i*BLOCK_SIZE), addr, pf_fill_level, 0) > 0);
+	  if(prefetch_success)
+	    {
+	      va_ampm_set_cl_prefetch(v_addr+(i*BLOCK_SIZE));
+	      prefetches_issued++;
+	    }
+	}
+      
+      if(prefetches_issued >= L2C_VA_AMPM_LITE_PREFETCH_DEGREE)
+	{
+	  break;
+	}
+    }
+  
+  // attempt to prefetch in the negative direction
+  prefetches_issued = 0;
+  for(int i=1; i<=L2C_VA_AMPM_LITE_MAX_DISTANCE; i++)
+    {
+      if((va_ampm_check_cl_access(v_addr + (i*BLOCK_SIZE))) && (va_ampm_check_cl_access(v_addr + (2*i*BLOCK_SIZE)))
+	 && (va_ampm_check_cl_access(v_addr-(i*BLOCK_SIZE)) == false) && (va_ampm_check_cl_prefetch(v_addr-(i*BLOCK_SIZE)) == false))
+	{
+	  // found something that we should prefetch
+	  int pf_fill_level = FILL_L2;
+	  if (MSHR.occupancy > (MSHR.SIZE>>1))
+	    {
+	      pf_fill_level = FILL_LLC;
+	    }
+	  bool prefetch_success = (l2c_prefetch_va_or_pa(this, ip, v_addr, v_addr-(i*BLOCK_SIZE), addr, pf_fill_level, 0) > 0);
+	  if(prefetch_success)
+	    {
+	      va_ampm_set_cl_prefetch(v_addr-(i*BLOCK_SIZE));
+	      prefetches_issued++;
+	    }
+	}
+      
+      if(prefetches_issued >= L2C_VA_AMPM_LITE_PREFETCH_DEGREE)
+	{
+	  break;
+	}
+    }
+  
+  return metadata_in;
+}
+
+uint32_t CACHE::l2c_prefetcher_cache_fill(uint64_t v_addr, uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
+{
+  return metadata_in;
+}
+
+void CACHE::l2c_prefetcher_final_stats()
+{
+
+}

--- a/prefetcher/va_ip_stride.l2c_pref
+++ b/prefetcher/va_ip_stride.l2c_pref
@@ -1,0 +1,175 @@
+#include "cache.h"
+
+#define L2C_IP_STRIDE_TRACKER_COUNT 128
+#define L2C_IP_STRIDE_PREFETCH_DEGREE 4
+
+struct l2c_ip_stride_tracker_t
+{
+  uint64_t ip;
+  uint64_t last_vcl;
+  int64_t last_stride;
+  uint64_t lru;
+};
+
+l2c_ip_stride_tracker_t l2c_ip_trackers[L2C_IP_STRIDE_TRACKER_COUNT];
+int l2c_ip_tracker_lru_counter;
+
+int l2c_prefetch_va_or_pa(CACHE *cache, uint64_t ip, uint64_t v_base_addr, uint64_t v_pf_addr, uint64_t p_base_addr, int pf_fill_level, int pf_metadata)
+{
+  if((v_base_addr>>LOG2_BLOCK_SIZE) == (v_pf_addr>>LOG2_BLOCK_SIZE))
+    {
+      // attempting to prefetch the same cache line!
+      return -1;
+    }
+
+  if((v_base_addr>>LOG2_PAGE_SIZE) != (v_pf_addr>>LOG2_PAGE_SIZE))
+    {
+      // prefetching to different pages, so use virtual address prefetching
+      if(cache->va_prefetch_line(ip, v_pf_addr, pf_fill_level, pf_metadata))
+	{
+	  return 1;
+	}
+      else
+	{
+	  return 0;
+	}
+    }
+
+   if((v_base_addr>>LOG2_PAGE_SIZE) == (v_pf_addr>>LOG2_PAGE_SIZE))
+     {
+       // prefetching in the same page, so use physical address prefetching
+       int64_t pf_offset = 0;
+       if(v_pf_addr > v_base_addr)
+	 {
+	   pf_offset = v_pf_addr - v_base_addr;
+	 }
+       else
+	 {
+	   pf_offset = v_base_addr - v_pf_addr;
+	   pf_offset *= -1;
+	 }
+       if(cache->prefetch_line(ip, p_base_addr, p_base_addr+pf_offset, pf_fill_level, pf_metadata))
+	 {
+	   return 2;
+	 }
+       else
+	 {
+	   return 0;
+	 }
+     }
+  
+  return 0;
+}
+
+void CACHE::l2c_prefetcher_initialize() 
+{
+  cout << "CPU " << cpu << " Virtual Address Space Instruction Pointer Stride L2C Prefetcher" << endl;
+  
+  for(int i=0; i<L2C_IP_STRIDE_TRACKER_COUNT; i++)
+    {
+      l2c_ip_trackers[i].ip = 0;
+      l2c_ip_trackers[i].last_vcl = 0;
+      l2c_ip_trackers[i].last_stride = 0;
+      l2c_ip_trackers[i].lru = 0;
+    }
+  l2c_ip_tracker_lru_counter = 0;
+}
+
+uint32_t CACHE::l2c_prefetcher_operate(uint64_t v_addr, uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in)
+{
+  if(type == PREFETCH)
+    {
+      return metadata_in;
+    }
+
+  if(v_addr == 0)
+    {
+      return metadata_in;
+    }
+
+  uint64_t v_cl = v_addr>>LOG2_BLOCK_SIZE;
+  
+  // see if we're tracking this
+  int ip_index = -1;
+  for(int i=0; i<L2C_IP_STRIDE_TRACKER_COUNT; i++)
+    {
+      if(l2c_ip_trackers[i].ip == ip)
+	{
+	  ip_index = i;
+	  break;
+	}
+    }
+
+  if(ip_index == -1)
+    {
+      // find the LRU tracker entry
+      int lru_index = 0;
+      uint64_t lru_value = l2c_ip_trackers[lru_index].lru;
+      for(int i=0; i<L2C_IP_STRIDE_TRACKER_COUNT; i++)
+	{
+	  if(l2c_ip_trackers[i].lru < lru_value)
+	    {
+	      lru_index = i;
+	      lru_value = l2c_ip_trackers[lru_index].lru;
+	    }
+	}
+
+      // and replace it
+      l2c_ip_trackers[lru_index].ip = ip;
+      l2c_ip_trackers[lru_index].last_vcl = v_cl;
+      l2c_ip_trackers[lru_index].last_stride = 0;
+      l2c_ip_trackers[lru_index].lru = l2c_ip_tracker_lru_counter;
+      l2c_ip_tracker_lru_counter++;
+
+      return metadata_in;
+    }
+
+  int64_t current_stride = 0;
+  if(v_addr >= l2c_ip_trackers[ip_index].last_vcl)
+    {
+      current_stride = v_cl - l2c_ip_trackers[ip_index].last_vcl;
+    }
+  else
+    {
+      current_stride = l2c_ip_trackers[ip_index].last_vcl - v_cl;
+      current_stride *= -1;
+    }
+
+  if(current_stride == 0)
+    {
+      return metadata_in;
+    }
+
+  if(current_stride == l2c_ip_trackers[ip_index].last_stride)
+    {
+      for(int i=0; i<L2C_IP_STRIDE_PREFETCH_DEGREE; i++)
+	{
+	  if (MSHR.occupancy < (MSHR.SIZE>>1))
+	    {
+	      l2c_prefetch_va_or_pa(this, ip, v_addr, (v_cl+((1+i)*current_stride))<<LOG2_BLOCK_SIZE, addr, FILL_L2, 0);
+	    }
+	  else
+	    {
+	      l2c_prefetch_va_or_pa(this, ip, v_addr, (v_cl+((1+i)*current_stride))<<LOG2_BLOCK_SIZE, addr, FILL_LLC, 0);	      
+	    }
+	}
+    }
+
+  l2c_ip_trackers[ip_index].last_vcl = v_cl;
+  l2c_ip_trackers[ip_index].last_stride = current_stride;
+
+  l2c_ip_trackers[ip_index].lru = l2c_ip_tracker_lru_counter;
+  l2c_ip_tracker_lru_counter++;
+
+  return metadata_in;
+}
+
+uint32_t CACHE::l2c_prefetcher_cache_fill(uint64_t v_addr, uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
+{
+  return metadata_in;
+}
+
+void CACHE::l2c_prefetcher_final_stats()
+{
+
+}

--- a/prefetcher/va_next_line.l1d_pref
+++ b/prefetcher/va_next_line.l1d_pref
@@ -1,0 +1,32 @@
+#include "cache.h"
+
+void CACHE::l1d_prefetcher_initialize() 
+{
+    cout << "CPU " << cpu << " L1D virtual address space next line prefetcher" << endl;
+}
+
+void CACHE::l1d_prefetcher_operate(uint64_t v_addr, uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type)
+{
+  uint64_t page_offset = ((addr>>LOG2_BLOCK_SIZE)&63);
+
+  if(page_offset < 63)
+    {
+      uint64_t pf_addr = ((addr>>LOG2_BLOCK_SIZE)+1) << LOG2_BLOCK_SIZE;
+      prefetch_line(ip, addr, pf_addr, FILL_L1, 0);      
+    }
+  else
+    {
+      uint64_t pf_addr = ((v_addr>>LOG2_BLOCK_SIZE)+1) << LOG2_BLOCK_SIZE;
+      va_prefetch_line(ip, pf_addr, FILL_L1, 0);
+    }
+}
+
+void CACHE::l1d_prefetcher_cache_fill(uint64_t v_addr, uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
+{
+
+}
+
+void CACHE::l1d_prefetcher_final_stats()
+{
+    cout << "CPU " << cpu << " L1D virtual address space next line prefetcher final stats" << endl;
+}

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -659,7 +659,7 @@ void O3_CPU::fetch_instruction()
 	      // mark all instructions from this cache line as having been fetched
 	      for(uint32_t j=0; j<IFETCH_BUFFER.SIZE; j++)
 		{
-		  if(((IFETCH_BUFFER.entry[j].ip)>>6) == ((IFETCH_BUFFER.entry[index].ip)>>6))
+		  if(((IFETCH_BUFFER.entry[j].ip)>>6) == ((IFETCH_BUFFER.entry[index].ip)>>6) && (IFETCH_BUFFER.entry[j].fetched == 0))
 		    {
 		      IFETCH_BUFFER.entry[j].translated = COMPLETED;
 		      IFETCH_BUFFER.entry[j].fetched = INFLIGHT;
@@ -779,6 +779,7 @@ void O3_CPU::decode_and_dispatch()
 	{
 	  // apply decode latency
 	  DECODE_BUFFER.entry[decode_index].event_cycle = current_core_cycle[cpu] + DECODE_LATENCY;
+	  count_decodes++;
 	}
       
       if(decode_index == DECODE_BUFFER.tail)
@@ -791,8 +792,7 @@ void O3_CPU::decode_and_dispatch()
 	  decode_index = 0;
 	}
 
-      count_decodes++;
-      if(count_decodes > DECODE_WIDTH)
+      if(count_decodes >= DECODE_WIDTH)
 	{
 	  break;
 	}


### PR DESCRIPTION
Added basic virtual address space data prefetching, along with example prefetchers.  This builds on the existing interface for data prefetchers, giving them the virtual address as well as the physical address.  A cache line can now be prefetched using its virtual address and the new function va_prefetch_line().  This allows you to prefetch outside of page boundaries, and gives visibility into which physical pages are contiguous in the virtual address space.

For this first version, VA->PA translation happens magically after a fixed number of cycles.