### PR TITLE
Added L0 instruction buffer

### DIFF
--- a/inc/instruction.h
+++ b/inc/instruction.h
@@ -115,8 +115,6 @@ class ooo_model_instr {
             branch_taken,
             branch_mispredicted,
             branch_prediction_made,
-            translated,
-            data_translated,
             source_added[NUM_INSTR_SOURCES],
             destination_added[NUM_INSTR_DESTINATIONS_SPARC],
             is_producer,
@@ -130,11 +128,12 @@ class ooo_model_instr {
     uint8_t branch_type;
     uint64_t branch_target;
 
-    uint32_t fetched, scheduled;
+    uint8_t translated = 0,
+            fetched = 0,
+            decoded = 0,
+            scheduled = 0,
+            executed = 0;
     int num_reg_ops, num_mem_ops, num_reg_dependent;
-
-    // executed bit is set after all dependencies are eliminated and this instr is chosen on a cycle, according to EXEC_WIDTH
-    int executed;
 
     uint8_t destination_registers[NUM_INSTR_DESTINATIONS_SPARC]; // output registers
 
@@ -185,14 +184,9 @@ class ooo_model_instr {
         branch_taken = 0;
         branch_mispredicted = 0;
 	branch_prediction_made = 0;
-        translated = 0;
-        data_translated = 0;
         is_producer = 0;
         is_consumer = 0;
         reg_RAW_producer = 0;
-        fetched = 0;
-        scheduled = 0;
-        executed = 0;
         reg_ready = 0;
         mem_ready = 0;
         asid[0] = UINT8_MAX;

--- a/inc/ooo_cpu.h
+++ b/inc/ooo_cpu.h
@@ -1,6 +1,8 @@
 #ifndef OOO_CPU_H
 #define OOO_CPU_H
 
+#include <array>
+
 #include "cache.h"
 
 #ifdef CRC2_COMPILE
@@ -24,6 +26,10 @@ using namespace std;
 //#define SCHEDULING_LATENCY 0
 //#define EXEC_LATENCY 0
 //#define DECODE_LATENCY 2
+
+// Dimensions of instruction buffer
+#define L0I_SET 1
+#define L0I_WAY 1
 
 #define STA_SIZE (ROB_SIZE*NUM_INSTR_DESTINATIONS_SPARC)
 
@@ -51,6 +57,17 @@ class O3_CPU {
              next_print_instruction, num_retired;
     uint32_t inflight_reg_executions, inflight_mem_executions, num_searched;
     uint32_t next_ITLB_fetch;
+
+    struct l0i_entry_t
+    {
+        bool valid = false;
+        unsigned lru = L0I_WAY;
+        uint64_t addr = 0;
+    };
+
+    // instruction buffer
+    using l0i_t= std::array<std::array<l0i_entry_t, L0I_WAY>, L0I_SET>;
+    l0i_t L0I;
 
     // reorder buffer, load/store queue, register file
     CORE_BUFFER IFETCH_BUFFER{"IFETCH_BUFFER", FETCH_WIDTH*2};

--- a/inc/ooo_cpu.h
+++ b/inc/ooo_cpu.h
@@ -214,11 +214,9 @@ class O3_CPU {
     void update_rob();
     void retire_rob();
 
-    void  add_to_rob(ooo_model_instr *arch_instr);
     uint32_t check_rob(uint64_t instr_id);
 
     uint32_t add_to_ifetch_buffer(ooo_model_instr *arch_instr);
-    void add_to_decode_buffer(ooo_model_instr *arch_instr);
 
     uint32_t check_and_add_lsq(uint32_t rob_index);
 

--- a/inc/ooo_cpu.h
+++ b/inc/ooo_cpu.h
@@ -28,8 +28,8 @@ using namespace std;
 //#define DECODE_LATENCY 2
 
 // Dimensions of instruction buffer
-#define L0I_SET 8
-#define L0I_WAY 8
+#define DIB_SET 8
+#define DIB_WAY 8
 
 #define STA_SIZE (ROB_SIZE*NUM_INSTR_DESTINATIONS_SPARC)
 
@@ -58,16 +58,16 @@ class O3_CPU {
     uint32_t inflight_reg_executions, inflight_mem_executions, num_searched;
     uint32_t next_ITLB_fetch;
 
-    struct l0i_entry_t
+    struct dib_entry_t
     {
         bool valid = false;
-        unsigned lru = L0I_WAY;
+        unsigned lru = DIB_WAY;
         uint64_t addr = 0;
     };
 
     // instruction buffer
-    using l0i_t= std::array<std::array<l0i_entry_t, L0I_WAY>, L0I_SET>;
-    l0i_t L0I;
+    using dib_t= std::array<std::array<dib_entry_t, DIB_WAY>, DIB_SET>;
+    dib_t DIB;
 
     // reorder buffer, load/store queue, register file
     CORE_BUFFER IFETCH_BUFFER{"IFETCH_BUFFER", FETCH_WIDTH*2};

--- a/inc/ooo_cpu.h
+++ b/inc/ooo_cpu.h
@@ -28,8 +28,8 @@ using namespace std;
 //#define DECODE_LATENCY 2
 
 // Dimensions of instruction buffer
-#define L0I_SET 1
-#define L0I_WAY 1
+#define L0I_SET 8
+#define L0I_WAY 8
 
 #define STA_SIZE (ROB_SIZE*NUM_INSTR_DESTINATIONS_SPARC)
 
@@ -214,11 +214,11 @@ class O3_CPU {
     void update_rob();
     void retire_rob();
 
-    uint32_t  add_to_rob(ooo_model_instr *arch_instr),
-              check_rob(uint64_t instr_id);
+    void  add_to_rob(ooo_model_instr *arch_instr);
+    uint32_t check_rob(uint64_t instr_id);
 
     uint32_t add_to_ifetch_buffer(ooo_model_instr *arch_instr);
-    uint32_t add_to_decode_buffer(ooo_model_instr *arch_instr);
+    void add_to_decode_buffer(ooo_model_instr *arch_instr);
 
     uint32_t check_and_add_lsq(uint32_t rob_index);
 


### PR DESCRIPTION
Programs, especially those with small instruction footprints, tend to access the same instruction cache line many times before moving on to another line. While the L1I does hold the cache line, it has a hit latency of 4 cycles. Once a demand returns from the L1I, all instructions in the ROB from that cache line are marked as fetched. However, this excludes instructions that enter the ROB just after their line returns. For these instructions, we must create a new demand.

This patch introduces an instruction buffer that keeps the most recent instruction block and marks an instruction in this block as immediately fetched if it is read from the trace. As submitted, this patch has only one entry, but is configurable in the number of sets and ways, managed in an LRU fashion.

My tests suggest that this reduces the number of L1I cache hits by 35% while not changing the number of L1I cache misses. This can permit better instruction prefetchers to be developed because there is less noise from repeated requests to the MRU cache line.