### PR TITLE
Virtual Memory overhaul, part 1

### DIFF
--- a/inc/champsim.h
+++ b/inc/champsim.h
@@ -93,10 +93,10 @@ extern queue <uint64_t> page_queue;
 extern map <uint64_t, uint64_t> page_table, inverse_table, recent_page, unique_cl[NUM_CPUS];
 extern uint64_t previous_ppage, num_adjacent_page, num_cl[NUM_CPUS], allocated_pages, num_page[NUM_CPUS], minor_fault[NUM_CPUS], major_fault[NUM_CPUS];
 
-extern VirtualMemory* vmem;
-
 void print_stats();
 
-// log base 2 function from efectiu
-int lg2(int n);
+constexpr uint64_t lg2(uint64_t n)
+{
+    return n < 2 ? 0 : 1+lg2(n/2);
+}
 #endif

--- a/inc/champsim.h
+++ b/inc/champsim.h
@@ -19,6 +19,8 @@
 #include <string>
 #include <iomanip>
 
+#include "vmem.h"
+
 // USEFUL MACROS
 //#define DEBUG_PRINT
 #define SANITY_CHECK
@@ -91,28 +93,10 @@ extern queue <uint64_t> page_queue;
 extern map <uint64_t, uint64_t> page_table, inverse_table, recent_page, unique_cl[NUM_CPUS];
 extern uint64_t previous_ppage, num_adjacent_page, num_cl[NUM_CPUS], allocated_pages, num_page[NUM_CPUS], minor_fault[NUM_CPUS], major_fault[NUM_CPUS];
 
+extern VirtualMemory* vmem;
+
 void print_stats();
-uint64_t rotl64 (uint64_t n, unsigned int c),
-         rotr64 (uint64_t n, unsigned int c),
-  va_to_pa(uint32_t cpu, uint64_t instr_id, uint64_t va, uint64_t unique_vpage, uint8_t is_code);
 
 // log base 2 function from efectiu
 int lg2(int n);
-
-// smart random number generator
-class RANDOM {
-  public:
-    std::random_device rd;
-    std::mt19937_64 engine{rd()};
-    std::uniform_int_distribution<uint64_t> dist{0, 0xFFFFFFFFF}; // used to generate random physical page numbers
-
-    RANDOM (uint64_t seed) {
-        engine.seed(seed);
-    }
-
-    uint64_t draw_rand() {
-        return dist(engine);
-    };
-};
-extern uint64_t champsim_seed;
 #endif

--- a/inc/vmem.h
+++ b/inc/vmem.h
@@ -27,8 +27,8 @@ class VirtualMemory
   uint64_t rand_state;
   uint64_t vmem_rand();
  public:
+  // capacity and pg_size are measured in bytes, and capacity must be a multiple of pg_size
   VirtualMemory(uint32_t number_of_cpus, uint64_t capacity, uint64_t pg_size, uint32_t page_table_levels, uint64_t random_seed);
-  ~VirtualMemory();
   uint32_t get_paget_table_level_count();
   uint64_t va_to_pa(uint32_t cpu_num, uint64_t vaddr);
   uint64_t get_pte_pa(uint32_t cpu_num, uint64_t vaddr, uint32_t level);

--- a/inc/vmem.h
+++ b/inc/vmem.h
@@ -1,3 +1,5 @@
+#ifndef VMEM_H
+#define VMEM_H
 
 #include <iostream>
 #include <deque>
@@ -31,3 +33,6 @@ class VirtualMemory
   uint64_t va_to_pa(uint32_t cpu_num, uint64_t vaddr);
   uint64_t get_pte_pa(uint32_t cpu_num, uint64_t vaddr, uint32_t level);
 };
+
+#endif
+

--- a/inc/vmem.h
+++ b/inc/vmem.h
@@ -1,0 +1,33 @@
+
+#include <iostream>
+#include <deque>
+#include <map>
+
+#define VMEM_RAND_FACTOR 91827349653
+// reserve 1MB of space
+#define VMEM_RESERVE_CAPACITY 1048576
+
+class VirtualMemory
+{
+ private:
+  uint32_t num_cpus;
+  uint32_t page_size;
+  uint32_t log2_page_size;
+  uint64_t num_ppages;
+  std::deque<uint64_t> ppage_free_list;
+  uint64_t get_next_free_ppage();
+
+  std::map<uint64_t, uint64_t>* vpage_to_ppage_map;
+  
+  uint32_t pt_levels;
+  std::map<uint64_t, uint64_t>** page_table;
+  
+  uint64_t rand_state;
+  uint64_t vmem_rand();
+ public:
+  VirtualMemory(uint32_t number_of_cpus, uint64_t capacity, uint64_t pg_size, uint32_t page_table_levels, uint64_t random_seed);
+  ~VirtualMemory();
+  uint32_t get_paget_table_level_count();
+  uint64_t va_to_pa(uint32_t cpu_num, uint64_t vaddr);
+  uint64_t get_pte_pa(uint32_t cpu_num, uint64_t vaddr, uint32_t level);
+};

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -1,7 +1,12 @@
 #include "cache.h"
+
+#include "champsim.h"
 #include "set.h"
+#include "vmem.h"
 
 uint64_t l2pf_access = 0;
+
+extern VirtualMemory *vmem;
 
 void CACHE::handle_fill()
 {

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -6,7 +6,7 @@
 
 uint64_t l2pf_access = 0;
 
-extern VirtualMemory *vmem;
+extern VirtualMemory vmem;
 
 void CACHE::handle_fill()
 {
@@ -683,7 +683,7 @@ void CACHE::handle_read()
 			  // TODO: need to differentiate page table walk and actual swap
 			  
 			  // emulate page table walk
-			  uint64_t pa = vmem->va_to_pa(read_cpu, RQ.entry[index].full_addr);
+			  uint64_t pa = vmem.va_to_pa(read_cpu, RQ.entry[index].full_addr);
 			  
 			  RQ.entry[index].data = pa >> LOG2_PAGE_SIZE; 
 			  RQ.entry[index].event_cycle = current_core_cycle[read_cpu];
@@ -1582,7 +1582,7 @@ void CACHE::va_translate_prefetches()
     {
       if((VAPQ.entry[vapq_index].address == VAPQ.entry[vapq_index].v_address) && (VAPQ.entry[vapq_index].event_cycle <= current_core_cycle[cpu]))
         {
-	  VAPQ.entry[vapq_index].full_addr = vmem->va_to_pa(cpu, VAPQ.entry[vapq_index].full_v_addr);
+	  VAPQ.entry[vapq_index].full_addr = vmem.va_to_pa(cpu, VAPQ.entry[vapq_index].full_v_addr);
 	  VAPQ.entry[vapq_index].address = (VAPQ.entry[vapq_index].full_addr)>>LOG2_BLOCK_SIZE;
           break;
         }

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -678,8 +678,7 @@ void CACHE::handle_read()
 			  // TODO: need to differentiate page table walk and actual swap
 			  
 			  // emulate page table walk
-			  //uint64_t pa = va_to_pa(read_cpu, RQ.entry[index].instr_id, RQ.entry[index].full_addr, RQ.entry[index].address, 0);
-			  uint64_t pa = va_to_pa(read_cpu, RQ.entry[index].instr_id, RQ.entry[index].full_addr, (RQ.entry[index].full_addr)>>LOG2_PAGE_SIZE, 0);
+			  uint64_t pa = vmem->va_to_pa(read_cpu, RQ.entry[index].full_addr);
 			  
 			  RQ.entry[index].data = pa >> LOG2_PAGE_SIZE; 
 			  RQ.entry[index].event_cycle = current_core_cycle[read_cpu];
@@ -1578,7 +1577,7 @@ void CACHE::va_translate_prefetches()
     {
       if((VAPQ.entry[vapq_index].address == VAPQ.entry[vapq_index].v_address) && (VAPQ.entry[vapq_index].event_cycle <= current_core_cycle[cpu]))
         {
-	  VAPQ.entry[vapq_index].full_addr = va_to_pa(cpu, 0, VAPQ.entry[vapq_index].full_v_addr, (VAPQ.entry[vapq_index].full_v_addr)>>LOG2_PAGE_SIZE, 0);
+	  VAPQ.entry[vapq_index].full_addr = vmem->va_to_pa(cpu, VAPQ.entry[vapq_index].full_v_addr);
 	  VAPQ.entry[vapq_index].address = (VAPQ.entry[vapq_index].full_addr)>>LOG2_BLOCK_SIZE;
           break;
         }

--- a/src/main.cc
+++ b/src/main.cc
@@ -269,17 +269,6 @@ void signal_handler(int signal)
 	exit(1);
 }
 
-// log base 2 function from efectiu
-int lg2(int n)
-{
-    int i, m = n, c = -1;
-    for (i=0; m; i++) {
-        m /= 2;
-        c++;
-    }
-    return c;
-}
-
 void cpu_l1i_prefetcher_cache_operate(uint32_t cpu_num, uint64_t v_addr, uint8_t cache_hit, uint8_t prefetch_hit)
 {
   ooo_cpu[cpu_num].l1i_prefetcher_cache_operate(v_addr, cache_hit, prefetch_hit);

--- a/src/main.cc
+++ b/src/main.cc
@@ -19,6 +19,8 @@ uint64_t warmup_instructions     = 1000000,
 
 time_t start_time;
 
+VirtualMemory* vmem;
+
 // PAGE TABLE
 uint32_t PAGE_TABLE_LATENCY = 0, SWAP_LATENCY = 0;
 queue <uint64_t > page_queue;
@@ -276,211 +278,6 @@ int lg2(int n)
         c++;
     }
     return c;
-}
-
-uint64_t rotl64 (uint64_t n, unsigned int c)
-{
-    const unsigned int mask = (CHAR_BIT*sizeof(n)-1);
-
-    assert ( (c<=mask) &&"rotate by type width or more");
-    c &= mask;  // avoid undef behaviour with NDEBUG.  0 overhead for most types / compilers
-    return (n<<c) | (n>>( (-c)&mask ));
-}
-
-uint64_t rotr64 (uint64_t n, unsigned int c)
-{
-    const unsigned int mask = (CHAR_BIT*sizeof(n)-1);
-
-    assert ( (c<=mask) &&"rotate by type width or more");
-    c &= mask;  // avoid undef behaviour with NDEBUG.  0 overhead for most types / compilers
-    return (n>>c) | (n<<( (-c)&mask ));
-}
-
-RANDOM champsim_rand(champsim_seed);
-uint64_t va_to_pa(uint32_t cpu, uint64_t instr_id, uint64_t va, uint64_t unique_vpage, uint8_t is_code)
-{
-#ifdef SANITY_CHECK
-    if (va == 0) 
-        assert(0);
-#endif
-
-    uint8_t  swap = 0;
-    uint64_t high_bit_mask = rotr64(cpu, lg2(NUM_CPUS)),
-             unique_va = va | high_bit_mask;
-    //uint64_t vpage = unique_va >> LOG2_PAGE_SIZE,
-    uint64_t vpage = unique_vpage | high_bit_mask,
-             voffset = unique_va & ((1<<LOG2_PAGE_SIZE) - 1);
-
-    // smart random number generator
-    uint64_t random_ppage;
-
-    map <uint64_t, uint64_t>::iterator pr = page_table.begin();
-    map <uint64_t, uint64_t>::iterator ppage_check = inverse_table.begin();
-
-    // check unique cache line footprint
-    map <uint64_t, uint64_t>::iterator cl_check = unique_cl[cpu].find(unique_va >> LOG2_BLOCK_SIZE);
-    if (cl_check == unique_cl[cpu].end()) { // we've never seen this cache line before
-        unique_cl[cpu].insert(make_pair(unique_va >> LOG2_BLOCK_SIZE, 0));
-        num_cl[cpu]++;
-    }
-    else
-        cl_check->second++;
-
-    pr = page_table.find(vpage);
-    if (pr == page_table.end()) { // no VA => PA translation found 
-
-        if (allocated_pages >= DRAM_PAGES) { // not enough memory
-
-            // TODO: elaborate page replacement algorithm
-            // here, ChampSim randomly selects a page that is not recently used and we only track 32K recently accessed pages
-            uint8_t  found_NRU = 0;
-            uint64_t NRU_vpage = 0; // implement it
-            map <uint64_t, uint64_t>::iterator pr2 = recent_page.begin();
-            for (pr = page_table.begin(); pr != page_table.end(); pr++) {
-
-                NRU_vpage = pr->first;
-                if (recent_page.find(NRU_vpage) == recent_page.end()) {
-                    found_NRU = 1;
-                    break;
-                }
-            }
-#ifdef SANITY_CHECK
-            if (found_NRU == 0)
-                assert(0);
-
-            if (pr == page_table.end())
-                assert(0);
-#endif
-            DP ( if (warmup_complete[cpu]) {
-            cout << "[SWAP] update page table NRU_vpage: " << hex << pr->first << " new_vpage: " << vpage << " ppage: " << pr->second << dec << endl; });
-
-            // update page table with new VA => PA mapping
-            // since we cannot change the key value already inserted in a map structure, we need to erase the old node and add a new node
-            uint64_t mapped_ppage = pr->second;
-            page_table.erase(pr);
-            page_table.insert(make_pair(vpage, mapped_ppage));
-
-            // update inverse table with new PA => VA mapping
-            ppage_check = inverse_table.find(mapped_ppage);
-#ifdef SANITY_CHECK
-            if (ppage_check == inverse_table.end())
-                assert(0);
-#endif
-            ppage_check->second = vpage;
-
-            DP ( if (warmup_complete[cpu]) {
-            cout << "[SWAP] update inverse table NRU_vpage: " << hex << NRU_vpage << " new_vpage: ";
-            cout << ppage_check->second << " ppage: " << ppage_check->first << dec << endl; });
-
-            // update page_queue
-            page_queue.pop();
-            page_queue.push(vpage);
-
-            // invalidate corresponding vpage and ppage from the cache hierarchy
-            ooo_cpu[cpu].ITLB.invalidate_entry(NRU_vpage);
-            ooo_cpu[cpu].DTLB.invalidate_entry(NRU_vpage);
-            ooo_cpu[cpu].STLB.invalidate_entry(NRU_vpage);
-            for (uint32_t i=0; i<BLOCK_SIZE; i++) {
-                uint64_t cl_addr = (mapped_ppage << 6) | i;
-                ooo_cpu[cpu].L1I.invalidate_entry(cl_addr);
-                ooo_cpu[cpu].L1D.invalidate_entry(cl_addr);
-                ooo_cpu[cpu].L2C.invalidate_entry(cl_addr);
-                uncore.LLC.invalidate_entry(cl_addr);
-            }
-
-            // swap complete
-            swap = 1;
-        } else {
-            uint8_t fragmented = 0;
-            if (num_adjacent_page > 0)
-                random_ppage = ++previous_ppage;
-            else {
-                random_ppage = champsim_rand.draw_rand();
-                fragmented = 1;
-            }
-
-            // encoding cpu number 
-            // this allows ChampSim to run homogeneous multi-programmed workloads without VA => PA aliasing
-            // (e.g., cpu0: astar  cpu1: astar  cpu2: astar  cpu3: astar...)
-            //random_ppage &= (~((NUM_CPUS-1)<< (32-LOG2_PAGE_SIZE)));
-            //random_ppage |= (cpu<<(32-LOG2_PAGE_SIZE)); 
-
-            while (1) { // try to find an empty physical page number
-                ppage_check = inverse_table.find(random_ppage); // check if this page can be allocated 
-                if (ppage_check != inverse_table.end()) { // random_ppage is not available
-                    DP ( if (warmup_complete[cpu]) {
-                    cout << "vpage: " << hex << ppage_check->first << " is already mapped to ppage: " << random_ppage << dec << endl; }); 
-                    
-                    if (num_adjacent_page > 0)
-                        fragmented = 1;
-
-                    // try one more time
-                    random_ppage = champsim_rand.draw_rand();
-                    
-                    // encoding cpu number 
-                    //random_ppage &= (~((NUM_CPUS-1)<<(32-LOG2_PAGE_SIZE)));
-                    //random_ppage |= (cpu<<(32-LOG2_PAGE_SIZE)); 
-                }
-                else
-                    break;
-            }
-
-            // insert translation to page tables
-            //printf("Insert  num_adjacent_page: %u  vpage: %lx  ppage: %lx\n", num_adjacent_page, vpage, random_ppage);
-            page_table.insert(make_pair(vpage, random_ppage));
-            inverse_table.insert(make_pair(random_ppage, vpage));
-            page_queue.push(vpage);
-            previous_ppage = random_ppage;
-            num_adjacent_page--;
-            num_page[cpu]++;
-            allocated_pages++;
-
-            // try to allocate pages contiguously
-            if (fragmented) {
-                num_adjacent_page = 1 << (rand() % 10);
-                DP ( if (warmup_complete[cpu]) {
-                cout << "Recalculate num_adjacent_page: " << num_adjacent_page << endl; });
-            }
-        }
-
-        if (swap)
-            major_fault[cpu]++;
-        else
-            minor_fault[cpu]++;
-    }
-    else {
-        //printf("Found  vpage: %lx  random_ppage: %lx\n", vpage, pr->second);
-    }
-
-    pr = page_table.find(vpage);
-#ifdef SANITY_CHECK
-    if (pr == page_table.end())
-        assert(0);
-#endif
-    uint64_t ppage = pr->second;
-
-    uint64_t pa = ppage << LOG2_PAGE_SIZE;
-    pa |= voffset;
-
-    DP ( if (warmup_complete[cpu]) {
-    cout << "[PAGE_TABLE] instr_id: " << instr_id << " vpage: " << hex << vpage;
-    cout << " => ppage: " << (pa >> LOG2_PAGE_SIZE) << " vadress: " << unique_va << " paddress: " << pa << dec << endl; });
-
-    // as a hack for code prefetching, code translations are magical and do not pay these penalties
-    //if(!is_code)
-    // actually, just disable this stall feature entirely
-    if(0)
-      {
-	// if it's data, pay these penalties
-	if (swap)
-	  stall_cycle[cpu] = current_core_cycle[cpu] + SWAP_LATENCY;
-	else
-	  stall_cycle[cpu] = current_core_cycle[cpu] + PAGE_TABLE_LATENCY;
-      }
-
-    //cout << "cpu: " << cpu << " allocated unique_vpage: " << hex << unique_vpage << " to ppage: " << ppage << dec << endl;
-
-    return pa;
 }
 
 void cpu_l1i_prefetcher_cache_operate(uint32_t cpu_num, uint64_t v_addr, uint8_t cache_hit, uint8_t prefetch_hit)
@@ -782,6 +579,9 @@ int main(int argc, char** argv)
 
     uncore.LLC.llc_initialize_replacement();
     uncore.LLC.llc_prefetcher_initialize();
+
+    // initialize virtual memory system
+    vmem = new VirtualMemory(NUM_CPUS, 8589934592, 4096, 4, 1);
 
     // simulation entry point
     start_time = time(NULL);

--- a/src/main.cc
+++ b/src/main.cc
@@ -19,7 +19,7 @@ uint64_t warmup_instructions     = 1000000,
 
 time_t start_time;
 
-VirtualMemory* vmem;
+VirtualMemory vmem(NUM_CPUS, 8589934592, 4096, 5, 1);
 
 // PAGE TABLE
 uint32_t PAGE_TABLE_LATENCY = 0, SWAP_LATENCY = 0;
@@ -568,9 +568,6 @@ int main(int argc, char** argv)
 
     uncore.LLC.llc_initialize_replacement();
     uncore.LLC.llc_prefetcher_initialize();
-
-    // initialize virtual memory system
-    vmem = new VirtualMemory(NUM_CPUS, 8589934592, 4096, 4, 1);
 
     // simulation entry point
     start_time = time(NULL);

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -7,7 +7,7 @@ O3_CPU ooo_cpu[NUM_CPUS];
 uint64_t current_core_cycle[NUM_CPUS], stall_cycle[NUM_CPUS];
 uint32_t SCHEDULING_LATENCY = 0, EXEC_LATENCY = 0, DECODE_LATENCY = 0;
 
-extern VirtualMemory *vmem;
+extern VirtualMemory vmem;
 
 void O3_CPU::initialize_core()
 {
@@ -467,7 +467,7 @@ uint32_t O3_CPU::add_to_ifetch_buffer(ooo_model_instr *arch_instr)
   IFETCH_BUFFER.entry[index].event_cycle = current_core_cycle[cpu];
 
   // magically translate instructions
-  uint64_t instr_pa = vmem->va_to_pa(cpu, IFETCH_BUFFER.entry[index].ip);
+  uint64_t instr_pa = vmem.va_to_pa(cpu, IFETCH_BUFFER.entry[index].ip);
   instr_pa >>= LOG2_PAGE_SIZE;
   instr_pa <<= LOG2_PAGE_SIZE;
   instr_pa |= (IFETCH_BUFFER.entry[index].ip & ((1 << LOG2_PAGE_SIZE) - 1));  
@@ -815,7 +815,7 @@ int O3_CPU::prefetch_code_line(uint64_t pf_v_addr)
   if (L1I.PQ.occupancy < L1I.PQ.SIZE)
     {
       // magically translate prefetches
-      uint64_t pf_pa = (vmem->va_to_pa(cpu, pf_v_addr) & (~((1 << LOG2_PAGE_SIZE) - 1))) | (pf_v_addr & ((1 << LOG2_PAGE_SIZE) - 1));
+      uint64_t pf_pa = (vmem.va_to_pa(cpu, pf_v_addr) & (~((1 << LOG2_PAGE_SIZE) - 1))) | (pf_v_addr & ((1 << LOG2_PAGE_SIZE) - 1));
 
       PACKET pf_packet;
       pf_packet.instruction = 1; // this is a code prefetch

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -1,10 +1,13 @@
 #include "ooo_cpu.h"
 #include "set.h"
+#include "vmem.h"
 
 // out-of-order core
 O3_CPU ooo_cpu[NUM_CPUS]; 
 uint64_t current_core_cycle[NUM_CPUS], stall_cycle[NUM_CPUS];
 uint32_t SCHEDULING_LATENCY = 0, EXEC_LATENCY = 0, DECODE_LATENCY = 0;
+
+extern VirtualMemory *vmem;
 
 void O3_CPU::initialize_core()
 {

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -464,7 +464,7 @@ uint32_t O3_CPU::add_to_ifetch_buffer(ooo_model_instr *arch_instr)
   IFETCH_BUFFER.entry[index].event_cycle = current_core_cycle[cpu];
 
   // magically translate instructions
-  uint64_t instr_pa = va_to_pa(cpu, IFETCH_BUFFER.entry[index].instr_id, IFETCH_BUFFER.entry[index].ip , (IFETCH_BUFFER.entry[index].ip)>>LOG2_PAGE_SIZE, 1);
+  uint64_t instr_pa = vmem->va_to_pa(cpu, IFETCH_BUFFER.entry[index].ip);
   instr_pa >>= LOG2_PAGE_SIZE;
   instr_pa <<= LOG2_PAGE_SIZE;
   instr_pa |= (IFETCH_BUFFER.entry[index].ip & ((1 << LOG2_PAGE_SIZE) - 1));  
@@ -812,7 +812,7 @@ int O3_CPU::prefetch_code_line(uint64_t pf_v_addr)
   if (L1I.PQ.occupancy < L1I.PQ.SIZE)
     {
       // magically translate prefetches
-      uint64_t pf_pa = (va_to_pa(cpu, 0, pf_v_addr, pf_v_addr>>LOG2_PAGE_SIZE, 1) & (~((1 << LOG2_PAGE_SIZE) - 1))) | (pf_v_addr & ((1 << LOG2_PAGE_SIZE) - 1));
+      uint64_t pf_pa = (vmem->va_to_pa(cpu, pf_v_addr) & (~((1 << LOG2_PAGE_SIZE) - 1))) | (pf_v_addr & ((1 << LOG2_PAGE_SIZE) - 1));
 
       PACKET pf_packet;
       pf_packet.instruction = 1; // this is a code prefetch

--- a/src/vmem.cc
+++ b/src/vmem.cc
@@ -70,10 +70,6 @@ VirtualMemory::VirtualMemory(uint32_t number_of_cpus, uint64_t capacity, uint64_
     }
 }
 
-VirtualMemory::~VirtualMemory()
-{
-}
-
 uint64_t VirtualMemory::get_next_free_ppage()
 {
   if(ppage_free_list.empty())

--- a/src/vmem.cc
+++ b/src/vmem.cc
@@ -1,86 +1,72 @@
-
 #include "vmem.h"
+#include "champsim.h"
 
 VirtualMemory::VirtualMemory(uint32_t number_of_cpus, uint64_t capacity, uint64_t pg_size, uint32_t page_table_levels, uint64_t random_seed)
 {
-  num_cpus = number_of_cpus;
-  pt_levels = page_table_levels;
+    num_cpus = number_of_cpus;
+    pt_levels = page_table_levels;
 
-  // calculate number of physical pages
-  page_size = pg_size;
-  if(capacity%page_size != 0)
+    // calculate number of physical pages
+    page_size = pg_size;
+    if(capacity%page_size != 0)
     {
-      std::cout << "VirtualMemory initialization error: memory capacity must be a multiple of page size!" << std::endl;
-      exit(0);
+        std::cout << "VirtualMemory initialization error: memory capacity must be a multiple of page size!" << std::endl;
+        exit(0);
     }
-  num_ppages = capacity/page_size;
-  std::cout << std::endl << "VirtualMemory physical capacity: " << capacity << " num_ppages: " << num_ppages << std::endl;
+    num_ppages = capacity/page_size;
+    std::cout << std::endl << "VirtualMemory physical capacity: " << capacity << " num_ppages: " << num_ppages << std::endl;
 
-  // calculate log2_page_size
-  log2_page_size = 0;
-  uint32_t page_size_temp = page_size;
-  for(uint32_t i=0; i<32; i++)
+    if (pg_size != (1<<lg2(pg_size)) || pg_size < 1024)
     {
-      if((page_size_temp&1) == 1)
-	{
-	  log2_page_size = i;
-	  break;
-	}
-      page_size_temp >>= 1;
+        std::cout<< "VirtualMemory initialization error: page size must be a power of 2, and at least 1024!" << std::endl;
+        exit(0);
     }
-  if((page_size_temp != 1) || (pg_size < 1024))
+    std::cout << "VirtualMemory page size: " << page_size << " log2_page_size: " << lg2(page_size) << std::endl;
+
+    // initialize random number generator
+    rand_state = random_seed+VMEM_RAND_FACTOR;
+    if(rand_state == 0)
     {
-      std::cout<< "VirtualMemory initialization error: page size must be a power of 2, and at least 1024!" << std::endl;
-      exit(0);
-    }
-  std::cout << "VirtualMemory page size: " << page_size << " log2_page_size: " << log2_page_size << std::endl;
-  
-  // initialize random number generator
-  rand_state = random_seed+VMEM_RAND_FACTOR;
-  if(rand_state == 0)
-    {
-      rand_state = VMEM_RAND_FACTOR<<1;
+        rand_state = VMEM_RAND_FACTOR<<1;
     }
 
-  std::cout << "VirtualMemory initalizing ppage free list ... ";
-  ppage_free_list.resize(num_ppages);
-  // populate the free list
-  for(uint64_t i=0; i<num_ppages; i++)
+    std::cout << "VirtualMemory initalizing ppage free list ... ";
+    ppage_free_list.resize(num_ppages);
+    // populate the free list
+    for(uint64_t i=0; i<num_ppages; i++)
     {
-      ppage_free_list[i] = i;
+        ppage_free_list[i] = i;
     }
-  std::cout << "done" << std::endl << "VirtualMemory shuffling ppage free list ... ";
-  // remove the reserve space from the free list
-  uint64_t num_reserve_ppages = VMEM_RESERVE_CAPACITY/pg_size;
-  if(num_reserve_ppages == 0)
-    {
-      num_reserve_ppages = 1;
-    }
-  for(int i=0; i<num_reserve_ppages; i++)
-    {
-      ppage_free_list.pop_front();
-    }
-  // then shuffle it
-  uint64_t num_swap_ppages = num_ppages-num_reserve_ppages;
-  for(uint64_t i=0; i<num_swap_ppages; i++)
-    {
-      // i is the swap source, swap target is random
-      uint64_t swap_target = (vmem_rand()%(num_swap_ppages));
+    std::cout << "done" << std::endl << "VirtualMemory shuffling ppage free list ... ";
+    // remove the reserve space from the free list
+    uint64_t num_reserve_ppages = VMEM_RESERVE_CAPACITY < pg_size ? 1 : VMEM_RESERVE_CAPACITY/pg_size;
 
-      uint64_t swap_temp = ppage_free_list[i];
-      ppage_free_list[i] = ppage_free_list[swap_target];
-      ppage_free_list[swap_target] = swap_temp;
-    }
-  std::cout << "done" << std::endl << std::endl;
-
-  // initialize V to P page map tables
-  vpage_to_ppage_map = new std::map<uint64_t, uint64_t>[num_cpus];
-
-  // initialize per-process page tables
-  page_table = new std::map<uint64_t, uint64_t>*[num_cpus];
-  for(uint32_t i=0; i<num_cpus; i++)
+    for(int i=0; i<num_reserve_ppages; i++)
     {
-      page_table[i] = new std::map<uint64_t, uint64_t>[pt_levels];
+        ppage_free_list.pop_front();
+    }
+
+    // then shuffle it
+    uint64_t num_swap_ppages = num_ppages-num_reserve_ppages;
+    for(uint64_t i=0; i<num_swap_ppages; i++)
+    {
+        // i is the swap source, swap target is random
+        uint64_t swap_target = (vmem_rand()%(num_swap_ppages));
+
+        uint64_t swap_temp = ppage_free_list[i];
+        ppage_free_list[i] = ppage_free_list[swap_target];
+        ppage_free_list[swap_target] = swap_temp;
+    }
+    std::cout << "done" << std::endl << std::endl;
+
+    // initialize V to P page map tables
+    vpage_to_ppage_map = new std::map<uint64_t, uint64_t>[num_cpus];
+
+    // initialize per-process page tables
+    page_table = new std::map<uint64_t, uint64_t>*[num_cpus];
+    for(uint32_t i=0; i<num_cpus; i++)
+    {
+        page_table[i] = new std::map<uint64_t, uint64_t>[pt_levels];
     }
 }
 
@@ -109,8 +95,8 @@ uint32_t VirtualMemory::get_paget_table_level_count()
 
 uint64_t VirtualMemory::va_to_pa(uint32_t cpu_num, uint64_t vaddr)
 {
-  uint64_t vpage = vaddr>>log2_page_size;
-  uint64_t voffset = vaddr&((1<<log2_page_size)-1);
+  uint64_t vpage = vaddr>>lg2(page_size);
+  uint64_t voffset = vaddr&((1<<lg2(page_size))-1);
 
   if(vpage_to_ppage_map[cpu_num].find(vpage) == vpage_to_ppage_map[cpu_num].end())
     {
@@ -118,12 +104,12 @@ uint64_t VirtualMemory::va_to_pa(uint32_t cpu_num, uint64_t vaddr)
       vpage_to_ppage_map[cpu_num][vpage] = get_next_free_ppage();
     }
   
-  return (((vpage_to_ppage_map[cpu_num][vpage])<<log2_page_size)+voffset);
+  return (((vpage_to_ppage_map[cpu_num][vpage])<<lg2(page_size))+voffset);
 }
 
 uint64_t VirtualMemory::get_pte_pa(uint32_t cpu_num, uint64_t vaddr, uint32_t level)
 {
-  uint64_t vpage = vaddr>>log2_page_size;
+  uint64_t vpage = vaddr>>lg2(page_size);
   uint64_t pte_offset = vpage&511;
   
   uint32_t shift_bits = 9 + (9*(pt_levels-1-level));
@@ -135,7 +121,7 @@ uint64_t VirtualMemory::get_pte_pa(uint32_t cpu_num, uint64_t vaddr, uint32_t le
       page_table[cpu_num][level][pt_lookup_tag] = get_next_free_ppage();
     }
   
-  return (((page_table[cpu_num][level][pt_lookup_tag])<<log2_page_size)+(pte_offset*8));
+  return (((page_table[cpu_num][level][pt_lookup_tag])<<lg2(page_size))+(pte_offset*8));
 }
 
 uint64_t VirtualMemory::vmem_rand()

--- a/src/vmem.cc
+++ b/src/vmem.cc
@@ -1,0 +1,151 @@
+
+#include "vmem.h"
+
+VirtualMemory::VirtualMemory(uint32_t number_of_cpus, uint64_t capacity, uint64_t pg_size, uint32_t page_table_levels, uint64_t random_seed)
+{
+  num_cpus = number_of_cpus;
+  pt_levels = page_table_levels;
+
+  // calculate number of physical pages
+  page_size = pg_size;
+  if(capacity%page_size != 0)
+    {
+      std::cout << "VirtualMemory initialization error: memory capacity must be a multiple of page size!" << std::endl;
+      exit(0);
+    }
+  num_ppages = capacity/page_size;
+  std::cout << std::endl << "VirtualMemory physical capacity: " << capacity << " num_ppages: " << num_ppages << std::endl;
+
+  // calculate log2_page_size
+  log2_page_size = 0;
+  uint32_t page_size_temp = page_size;
+  for(uint32_t i=0; i<32; i++)
+    {
+      if((page_size_temp&1) == 1)
+	{
+	  log2_page_size = i;
+	  break;
+	}
+      page_size_temp >>= 1;
+    }
+  if((page_size_temp != 1) || (pg_size < 1024))
+    {
+      std::cout<< "VirtualMemory initialization error: page size must be a power of 2, and at least 1024!" << std::endl;
+      exit(0);
+    }
+  std::cout << "VirtualMemory page size: " << page_size << " log2_page_size: " << log2_page_size << std::endl;
+  
+  // initialize random number generator
+  rand_state = random_seed+VMEM_RAND_FACTOR;
+  if(rand_state == 0)
+    {
+      rand_state = VMEM_RAND_FACTOR<<1;
+    }
+
+  std::cout << "VirtualMemory initalizing ppage free list ... ";
+  ppage_free_list.resize(num_ppages);
+  // populate the free list
+  for(uint64_t i=0; i<num_ppages; i++)
+    {
+      ppage_free_list[i] = i;
+    }
+  std::cout << "done" << std::endl << "VirtualMemory shuffling ppage free list ... ";
+  // remove the reserve space from the free list
+  uint64_t num_reserve_ppages = VMEM_RESERVE_CAPACITY/pg_size;
+  if(num_reserve_ppages == 0)
+    {
+      num_reserve_ppages = 1;
+    }
+  for(int i=0; i<num_reserve_ppages; i++)
+    {
+      ppage_free_list.pop_front();
+    }
+  // then shuffle it
+  uint64_t num_swap_ppages = num_ppages-num_reserve_ppages;
+  for(uint64_t i=0; i<num_swap_ppages; i++)
+    {
+      // i is the swap source, swap target is random
+      uint64_t swap_target = (vmem_rand()%(num_swap_ppages));
+
+      uint64_t swap_temp = ppage_free_list[i];
+      ppage_free_list[i] = ppage_free_list[swap_target];
+      ppage_free_list[swap_target] = swap_temp;
+    }
+  std::cout << "done" << std::endl << std::endl;
+
+  // initialize V to P page map tables
+  vpage_to_ppage_map = new std::map<uint64_t, uint64_t>[num_cpus];
+
+  // initialize per-process page tables
+  page_table = new std::map<uint64_t, uint64_t>*[num_cpus];
+  for(uint32_t i=0; i<num_cpus; i++)
+    {
+      page_table[i] = new std::map<uint64_t, uint64_t>[pt_levels];
+    }
+}
+
+VirtualMemory::~VirtualMemory()
+{
+}
+
+uint64_t VirtualMemory::get_next_free_ppage()
+{
+  if(ppage_free_list.empty())
+    {
+      // ran out of physical pages to allocate, so throw error and exit
+      std::cout << "VirtualMemory error: ran out of physical pages to allocate!  Try a larger memory size." << std::endl;
+      exit(0);
+    }
+  
+  uint64_t free_ppage = ppage_free_list[0];
+  ppage_free_list.pop_front();
+  return free_ppage;
+}
+
+uint32_t VirtualMemory::get_paget_table_level_count()
+{
+  return pt_levels;
+}
+
+uint64_t VirtualMemory::va_to_pa(uint32_t cpu_num, uint64_t vaddr)
+{
+  uint64_t vpage = vaddr>>log2_page_size;
+  uint64_t voffset = vaddr&((1<<log2_page_size)-1);
+
+  if(vpage_to_ppage_map[cpu_num].find(vpage) == vpage_to_ppage_map[cpu_num].end())
+    {
+      // this vpage doesn't yet have a ppage mapping
+      vpage_to_ppage_map[cpu_num][vpage] = get_next_free_ppage();
+    }
+  
+  return (((vpage_to_ppage_map[cpu_num][vpage])<<log2_page_size)+voffset);
+}
+
+uint64_t VirtualMemory::get_pte_pa(uint32_t cpu_num, uint64_t vaddr, uint32_t level)
+{
+  uint64_t vpage = vaddr>>log2_page_size;
+  uint64_t pte_offset = vpage&511;
+  
+  uint32_t shift_bits = 9 + (9*(pt_levels-1-level));
+  uint64_t pt_lookup_tag = vpage>>shift_bits;
+
+  if(page_table[cpu_num][level].find(pt_lookup_tag) == page_table[cpu_num][level].end())
+    {
+      // this PTE doesn't yet have a mapping
+      page_table[cpu_num][level][pt_lookup_tag] = get_next_free_ppage();
+    }
+  
+  return (((page_table[cpu_num][level][pt_lookup_tag])<<log2_page_size)+(pte_offset*8));
+}
+
+uint64_t VirtualMemory::vmem_rand()
+{
+  rand_state += VMEM_RAND_FACTOR;
+
+  rand_state ^= (rand_state<<13);
+  rand_state ^= (rand_state>>7);
+  rand_state ^= (rand_state<<11);
+  rand_state ^= (rand_state>>1);
+  
+  return rand_state;
+}


### PR DESCRIPTION
This is the first step in implementing the ideas presented in Issue #49 

It replaces the va_to_pa() function with a new class, called VirtualMemory.  The VirtualMemory class has a function, va_to_pa(), which offers the same functionality as the old function, but is much simpler and faster, and will be easier to integrate with future virtual memory system changes like TLBs and page walkers.  The capacity, page size, and number of levels in the page table are all configurable.  It also uses its own random number function to shuffle the physical address space, so as to not interfere with any other RNG systems.

The new class also allows you to get the address of the page table entry for a given virtual address in each level of the page table.  This is the part of the code that I'm less sure of, and would appreciate some eyeballs on.  This code isn't used by anything in ChampSim yet, but would need to work correctly before we can add page walkers.