### PR TITLE
Cache write bandwidth

### DIFF
--- a/inc/cache.h
+++ b/inc/cache.h
@@ -89,8 +89,8 @@ class CACHE : public MEMORY {
     uint32_t LATENCY;
     BLOCK **block;
     int fill_level;
-    uint32_t MAX_READ, MAX_FILL;
-    uint32_t reads_available_this_cycle;
+    uint32_t MAX_READ, MAX_WRITE;
+    uint32_t reads_available_this_cycle, writes_available_this_cycle;
     uint8_t cache_type;
 
     // prefetch stats
@@ -152,8 +152,8 @@ class CACHE : public MEMORY {
         lower_level = NULL;
         extra_interface = NULL;
         fill_level = -1;
-        MAX_READ = 1;
-        MAX_FILL = 1;
+        MAX_READ = MAX_READ_PER_CYCLE;
+        MAX_WRITE = MAX_WRITE_PER_CYCLE;
 
         pf_requested = 0;
         pf_issued = 0;

--- a/inc/champsim.h
+++ b/inc/champsim.h
@@ -25,7 +25,6 @@
 #define LLC_BYPASS
 #define DRC_BYPASS
 #define NO_CRC2_COMPILE
-#define SINGLE_CORE_TRACE_END_EXIT 1
 
 #ifdef DEBUG_PRINT
 #define DP(x) x

--- a/inc/champsim.h
+++ b/inc/champsim.h
@@ -25,6 +25,7 @@
 #define LLC_BYPASS
 #define DRC_BYPASS
 #define NO_CRC2_COMPILE
+#define SINGLE_CORE_TRACE_END_EXIT 1
 
 #ifdef DEBUG_PRINT
 #define DP(x) x
@@ -43,7 +44,7 @@
 #define BLOCK_SIZE 64
 #define LOG2_BLOCK_SIZE 6
 #define MAX_READ_PER_CYCLE 8
-#define MAX_FILL_PER_CYCLE 1
+#define MAX_WRITE_PER_CYCLE 8
 
 #define INFLIGHT 1
 #define COMPLETED 2

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -5,6 +5,8 @@ uint64_t l2pf_access = 0;
 
 void CACHE::handle_fill()
 {
+  for(uint32_t i=0; i<MAX_WRITE; i++) {
+
     // handle fill
     uint32_t fill_cpu = (MSHR.next_fill_index == MSHR_SIZE) ? NUM_CPUS : MSHR.entry[MSHR.next_fill_index].cpu;
     if (fill_cpu == NUM_CPUS)
@@ -74,162 +76,178 @@ void CACHE::handle_fill()
             MSHR.remove_queue(&MSHR.entry[mshr_index]);
             MSHR.num_returned--;
 
+	    writes_available_this_cycle--;
+
             update_fill_cycle();
-
-            return; // return here, no need to process further in this function
         }
+	else
 #endif
+	  {
+	    uint8_t  do_fill = 1;
 
-        uint8_t  do_fill = 1;
+	    // is this dirty?
+	    if (block[set][way].dirty) {
 
-        // is this dirty?
-        if (block[set][way].dirty) {
-
-            // check if the lower level WQ has enough room to keep this writeback request
-            if (lower_level) {
+	      // check if the lower level WQ has enough room to keep this writeback request
+	      if (lower_level) {
                 if (lower_level->get_occupancy(2, block[set][way].address) == lower_level->get_size(2, block[set][way].address)) {
 
-                    // lower level WQ is full, cannot replace this victim
-                    do_fill = 0;
-                    lower_level->increment_WQ_FULL(block[set][way].address);
-                    STALL[MSHR.entry[mshr_index].type]++;
+		  // lower level WQ is full, cannot replace this victim
+		  do_fill = 0;
+		  lower_level->increment_WQ_FULL(block[set][way].address);
+		  STALL[MSHR.entry[mshr_index].type]++;
 
-                    DP ( if (warmup_complete[fill_cpu]) {
-                    cout << "[" << NAME << "] " << __func__ << "do_fill: " << +do_fill;
-                    cout << " lower level wq is full!" << " fill_addr: " << hex << MSHR.entry[mshr_index].address;
-                    cout << " victim_addr: " << block[set][way].tag << dec << endl; });
+		  DP ( if (warmup_complete[fill_cpu]) {
+		      cout << "[" << NAME << "] " << __func__ << "do_fill: " << +do_fill;
+		      cout << " lower level wq is full!" << " fill_addr: " << hex << MSHR.entry[mshr_index].address;
+		      cout << " victim_addr: " << block[set][way].tag << dec << endl; });
                 }
                 else {
-                    PACKET writeback_packet;
+		  PACKET writeback_packet;
 
-                    writeback_packet.fill_level = fill_level << 1;
-                    writeback_packet.cpu = fill_cpu;
-                    writeback_packet.address = block[set][way].address;
-                    writeback_packet.full_addr = block[set][way].full_addr;
-                    writeback_packet.data = block[set][way].data;
-                    writeback_packet.instr_id = MSHR.entry[mshr_index].instr_id;
-                    writeback_packet.ip = 0; // writeback does not have ip
-                    writeback_packet.type = WRITEBACK;
-                    writeback_packet.event_cycle = current_core_cycle[fill_cpu];
+		  writeback_packet.fill_level = fill_level << 1;
+		  writeback_packet.cpu = fill_cpu;
+		  writeback_packet.address = block[set][way].address;
+		  writeback_packet.full_addr = block[set][way].full_addr;
+		  writeback_packet.data = block[set][way].data;
+		  writeback_packet.instr_id = MSHR.entry[mshr_index].instr_id;
+		  writeback_packet.ip = 0; // writeback does not have ip
+		  writeback_packet.type = WRITEBACK;
+		  writeback_packet.event_cycle = current_core_cycle[fill_cpu];
 
-                    lower_level->add_wq(&writeback_packet);
+		  lower_level->add_wq(&writeback_packet);
                 }
-            }
+	      }
 #ifdef SANITY_CHECK
-            else {
+	      else {
                 // sanity check
                 if (cache_type != IS_STLB)
-                    assert(0);
-            }
+		  assert(0);
+	      }
 #endif
-        }
+	    }
 
-        if (do_fill){
-            // update prefetcher
-	  if (cache_type == IS_L1I)
-	    l1i_prefetcher_cache_fill(fill_cpu, ((MSHR.entry[mshr_index].ip)>>LOG2_BLOCK_SIZE)<<LOG2_BLOCK_SIZE, set, way, (MSHR.entry[mshr_index].type == PREFETCH) ? 1 : 0,
-				      ((block[set][way].ip)>>LOG2_BLOCK_SIZE)<<LOG2_BLOCK_SIZE);
-	    if (cache_type == IS_L1D)
-	      l1d_prefetcher_cache_fill(MSHR.entry[mshr_index].full_v_addr, MSHR.entry[mshr_index].full_addr, set, way,
-					(MSHR.entry[mshr_index].type == PREFETCH) ? 1 : 0, block[set][way].address<<LOG2_BLOCK_SIZE, MSHR.entry[mshr_index].pf_metadata);
-	    if  (cache_type == IS_L2C)
-	      MSHR.entry[mshr_index].pf_metadata = l2c_prefetcher_cache_fill((MSHR.entry[mshr_index].v_address)<<LOG2_BLOCK_SIZE, (MSHR.entry[mshr_index].address)<<LOG2_BLOCK_SIZE, set, way,
-									     (MSHR.entry[mshr_index].type == PREFETCH) ? 1 : 0,
-									     (block[set][way].address)<<LOG2_BLOCK_SIZE, MSHR.entry[mshr_index].pf_metadata);
-            if (cache_type == IS_LLC)
-	      {
-		cpu = fill_cpu;
-		MSHR.entry[mshr_index].pf_metadata = llc_prefetcher_cache_fill((MSHR.entry[mshr_index].v_address)<<LOG2_BLOCK_SIZE, (MSHR.entry[mshr_index].address)<<LOG2_BLOCK_SIZE, set, way,
+	    if (do_fill){
+	      // update prefetcher
+	      if (cache_type == IS_L1I)
+		l1i_prefetcher_cache_fill(fill_cpu, ((MSHR.entry[mshr_index].ip)>>LOG2_BLOCK_SIZE)<<LOG2_BLOCK_SIZE, set, way, (MSHR.entry[mshr_index].type == PREFETCH) ? 1 : 0,
+					  ((block[set][way].ip)>>LOG2_BLOCK_SIZE)<<LOG2_BLOCK_SIZE);
+	      if (cache_type == IS_L1D)
+		l1d_prefetcher_cache_fill(MSHR.entry[mshr_index].full_v_addr, MSHR.entry[mshr_index].full_addr, set, way,
+					  (MSHR.entry[mshr_index].type == PREFETCH) ? 1 : 0, block[set][way].address<<LOG2_BLOCK_SIZE, MSHR.entry[mshr_index].pf_metadata);
+	      if  (cache_type == IS_L2C)
+		MSHR.entry[mshr_index].pf_metadata = l2c_prefetcher_cache_fill((MSHR.entry[mshr_index].v_address)<<LOG2_BLOCK_SIZE, (MSHR.entry[mshr_index].address)<<LOG2_BLOCK_SIZE, set, way,
 									       (MSHR.entry[mshr_index].type == PREFETCH) ? 1 : 0,
 									       (block[set][way].address)<<LOG2_BLOCK_SIZE, MSHR.entry[mshr_index].pf_metadata);
-		cpu = 0;
-	      }
+	      if (cache_type == IS_LLC)
+		{
+		  cpu = fill_cpu;
+		  MSHR.entry[mshr_index].pf_metadata = llc_prefetcher_cache_fill((MSHR.entry[mshr_index].v_address)<<LOG2_BLOCK_SIZE, (MSHR.entry[mshr_index].address)<<LOG2_BLOCK_SIZE, set, way,
+										 (MSHR.entry[mshr_index].type == PREFETCH) ? 1 : 0,
+										 (block[set][way].address)<<LOG2_BLOCK_SIZE, MSHR.entry[mshr_index].pf_metadata);
+		  cpu = 0;
+		}
               
-            // update replacement policy
-            if (cache_type == IS_LLC) {
+	      // update replacement policy
+	      if (cache_type == IS_LLC) {
                 llc_update_replacement_state(fill_cpu, set, way, MSHR.entry[mshr_index].full_addr, MSHR.entry[mshr_index].ip, block[set][way].full_addr, MSHR.entry[mshr_index].type, 0);
-            }
-            else
+	      }
+	      else
                 update_replacement_state(fill_cpu, set, way, MSHR.entry[mshr_index].full_addr, MSHR.entry[mshr_index].ip, block[set][way].full_addr, MSHR.entry[mshr_index].type, 0);
 
-            // COLLECT STATS
-            sim_miss[fill_cpu][MSHR.entry[mshr_index].type]++;
-            sim_access[fill_cpu][MSHR.entry[mshr_index].type]++;
+	      // COLLECT STATS
+	      sim_miss[fill_cpu][MSHR.entry[mshr_index].type]++;
+	      sim_access[fill_cpu][MSHR.entry[mshr_index].type]++;
 
-            fill_cache(set, way, &MSHR.entry[mshr_index]);
+	      fill_cache(set, way, &MSHR.entry[mshr_index]);
 
-            // RFO marks cache line dirty
-            if (cache_type == IS_L1D) {
+	      // RFO marks cache line dirty
+	      if (cache_type == IS_L1D) {
                 if (MSHR.entry[mshr_index].type == RFO)
-                    block[set][way].dirty = 1;
-            }
+		  block[set][way].dirty = 1;
+	      }
 
-            // check fill level
-            if (MSHR.entry[mshr_index].fill_level < fill_level) {
+	      // check fill level
+	      if (MSHR.entry[mshr_index].fill_level < fill_level) {
 
-	      if(fill_level == FILL_L2)
-                {
-                  if(MSHR.entry[mshr_index].fill_l1i)
-                    {
-                      upper_level_icache[fill_cpu]->return_data(&MSHR.entry[mshr_index]);
-                    }
-                  if(MSHR.entry[mshr_index].fill_l1d)
-                    {
-                      upper_level_dcache[fill_cpu]->return_data(&MSHR.entry[mshr_index]);
-                    }
-                }
-	      else
-		{
-		  if (MSHR.entry[mshr_index].instruction)
-                    upper_level_icache[fill_cpu]->return_data(&MSHR.entry[mshr_index]);
-		  if (MSHR.entry[mshr_index].is_data)
-                    upper_level_dcache[fill_cpu]->return_data(&MSHR.entry[mshr_index]);
-		}
-            }
+		if(fill_level == FILL_L2)
+		  {
+		    if(MSHR.entry[mshr_index].fill_l1i)
+		      {
+			upper_level_icache[fill_cpu]->return_data(&MSHR.entry[mshr_index]);
+		      }
+		    if(MSHR.entry[mshr_index].fill_l1d)
+		      {
+			upper_level_dcache[fill_cpu]->return_data(&MSHR.entry[mshr_index]);
+		      }
+		  }
+		else
+		  {
+		    if (MSHR.entry[mshr_index].instruction)
+		      upper_level_icache[fill_cpu]->return_data(&MSHR.entry[mshr_index]);
+		    if (MSHR.entry[mshr_index].is_data)
+		      upper_level_dcache[fill_cpu]->return_data(&MSHR.entry[mshr_index]);
+		  }
+	      }
 
-            // update processed packets
-            if (cache_type == IS_ITLB) { 
+	      // update processed packets
+	      if (cache_type == IS_ITLB) {
                 MSHR.entry[mshr_index].instruction_pa = block[set][way].data;
                 if (PROCESSED.occupancy < PROCESSED.SIZE)
-                    PROCESSED.add_queue(&MSHR.entry[mshr_index]);
-            }
-            else if (cache_type == IS_DTLB) {
+		  PROCESSED.add_queue(&MSHR.entry[mshr_index]);
+	      }
+	      else if (cache_type == IS_DTLB) {
                 MSHR.entry[mshr_index].data_pa = block[set][way].data;
                 if (PROCESSED.occupancy < PROCESSED.SIZE)
-                    PROCESSED.add_queue(&MSHR.entry[mshr_index]);
-            }
-            else if (cache_type == IS_L1I) {
-                if (PROCESSED.occupancy < PROCESSED.SIZE)
-                    PROCESSED.add_queue(&MSHR.entry[mshr_index]);
-            }
-            //else if (cache_type == IS_L1D) {
-            else if ((cache_type == IS_L1D) && (MSHR.entry[mshr_index].type != PREFETCH)) {
-                if (PROCESSED.occupancy < PROCESSED.SIZE)
-                    PROCESSED.add_queue(&MSHR.entry[mshr_index]);
-            }
-
-	    if(warmup_complete[fill_cpu] && (MSHR.entry[mshr_index].cycle_enqueued != 0))
-	      {
-		uint64_t current_miss_latency = (current_core_cycle[fill_cpu] - MSHR.entry[mshr_index].cycle_enqueued);
-		/*
-		if(cache_type == IS_L1D)
-		  {
-		    cout << current_core_cycle[fill_cpu] << " - " << MSHR.entry[mshr_index].cycle_enqueued << " = " << current_miss_latency << " MSHR index: " << mshr_index << endl;
-		  }
-		*/
-		total_miss_latency += current_miss_latency;
+		  PROCESSED.add_queue(&MSHR.entry[mshr_index]);
 	      }
-	  
-            MSHR.remove_queue(&MSHR.entry[mshr_index]);
-            MSHR.num_returned--;
+	      else if (cache_type == IS_L1I) {
+                if (PROCESSED.occupancy < PROCESSED.SIZE)
+		  PROCESSED.add_queue(&MSHR.entry[mshr_index]);
+	      }
+	      //else if (cache_type == IS_L1D) {
+	      else if ((cache_type == IS_L1D) && (MSHR.entry[mshr_index].type != PREFETCH)) {
+                if (PROCESSED.occupancy < PROCESSED.SIZE)
+		  PROCESSED.add_queue(&MSHR.entry[mshr_index]);
+	      }
 
-            update_fill_cycle();
-        }
+	      if(warmup_complete[fill_cpu] && (MSHR.entry[mshr_index].cycle_enqueued != 0))
+		{
+		  uint64_t current_miss_latency = (current_core_cycle[fill_cpu] - MSHR.entry[mshr_index].cycle_enqueued);
+		  /*
+		    if(cache_type == IS_L1D)
+		    {
+		    cout << current_core_cycle[fill_cpu] << " - " << MSHR.entry[mshr_index].cycle_enqueued << " = " << current_miss_latency << " MSHR index: " << mshr_index << endl;
+		    }
+		  */
+		  total_miss_latency += current_miss_latency;
+		}
+	  
+	      MSHR.remove_queue(&MSHR.entry[mshr_index]);
+	      MSHR.num_returned--;
+
+	      writes_available_this_cycle--;
+
+	      update_fill_cycle();
+	    }
+	  }
     }
+    else
+      {
+	return;
+      }
+
+    if(writes_available_this_cycle == 0)
+      {
+	return;
+      }
+  }
 }
 
 void CACHE::handle_writeback()
 {
+  for(uint32_t i=0; i<MAX_WRITE; i++) {
+
     // handle write
     uint32_t writeback_cpu = WQ.entry[WQ.head].cpu;
     if (writeback_cpu == NUM_CPUS)
@@ -291,6 +309,8 @@ void CACHE::handle_writeback()
 
             HIT[WQ.entry[index].type]++;
             ACCESS[WQ.entry[index].type]++;
+
+	    writes_available_this_cycle--;
 
             // remove this entry from WQ
             WQ.remove_queue(&WQ.entry[index]);
@@ -391,6 +411,8 @@ void CACHE::handle_writeback()
 
                     MISS[WQ.entry[index].type]++;
                     ACCESS[WQ.entry[index].type]++;
+
+		    writes_available_this_cycle--;
 
                     // remove this entry from WQ
                     WQ.remove_queue(&WQ.entry[index]);
@@ -516,12 +538,24 @@ void CACHE::handle_writeback()
                     MISS[WQ.entry[index].type]++;
                     ACCESS[WQ.entry[index].type]++;
 
+		    writes_available_this_cycle--;
+
                     // remove this entry from WQ
                     WQ.remove_queue(&WQ.entry[index]);
                 }
             }
         }
     }
+    else
+      {
+	return;
+      }
+
+    if(writes_available_this_cycle == 0)
+      {
+	return;
+      }
+  }
 }
 
 void CACHE::handle_read()
@@ -1060,8 +1094,16 @@ void CACHE::handle_prefetch()
 
 void CACHE::operate()
 {
+    // perform all writes
+    writes_available_this_cycle = MAX_WRITE;
     handle_fill();
-    handle_writeback();
+
+    if(WQ.occupancy && (writes_available_this_cycle > 0))
+      {
+	handle_writeback();
+      }
+
+    // perform all reads
     reads_available_this_cycle = MAX_READ;
     handle_read();
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -703,14 +703,15 @@ int main(int argc, char** argv)
         ooo_cpu[i].ITLB.cpu = i;
         ooo_cpu[i].ITLB.cache_type = IS_ITLB;
 	ooo_cpu[i].ITLB.MAX_READ = 2;
+	ooo_cpu[i].ITLB.MAX_WRITE = 2;
         ooo_cpu[i].ITLB.fill_level = FILL_L1;
         ooo_cpu[i].ITLB.extra_interface = &ooo_cpu[i].L1I;
         ooo_cpu[i].ITLB.lower_level = &ooo_cpu[i].STLB; 
 
         ooo_cpu[i].DTLB.cpu = i;
         ooo_cpu[i].DTLB.cache_type = IS_DTLB;
-        //ooo_cpu[i].DTLB.MAX_READ = (2 > MAX_READ_PER_CYCLE) ? MAX_READ_PER_CYCLE : 2;
         ooo_cpu[i].DTLB.MAX_READ = 2;
+        ooo_cpu[i].DTLB.MAX_WRITE = 2;
         ooo_cpu[i].DTLB.fill_level = FILL_L1;
         ooo_cpu[i].DTLB.extra_interface = &ooo_cpu[i].L1D;
         ooo_cpu[i].DTLB.lower_level = &ooo_cpu[i].STLB;
@@ -718,6 +719,7 @@ int main(int argc, char** argv)
         ooo_cpu[i].STLB.cpu = i;
         ooo_cpu[i].STLB.cache_type = IS_STLB;
         ooo_cpu[i].STLB.MAX_READ = 1;
+        ooo_cpu[i].STLB.MAX_WRITE = 1;
         ooo_cpu[i].STLB.fill_level = FILL_L2;
         ooo_cpu[i].STLB.upper_level_icache[i] = &ooo_cpu[i].ITLB;
         ooo_cpu[i].STLB.upper_level_dcache[i] = &ooo_cpu[i].DTLB;
@@ -725,8 +727,8 @@ int main(int argc, char** argv)
         // PRIVATE CACHE
         ooo_cpu[i].L1I.cpu = i;
         ooo_cpu[i].L1I.cache_type = IS_L1I;
-        //ooo_cpu[i].L1I.MAX_READ = (FETCH_WIDTH > MAX_READ_PER_CYCLE) ? MAX_READ_PER_CYCLE : FETCH_WIDTH;
         ooo_cpu[i].L1I.MAX_READ = 2;
+        ooo_cpu[i].L1I.MAX_WRITE = 2;
         ooo_cpu[i].L1I.fill_level = FILL_L1;
         ooo_cpu[i].L1I.lower_level = &ooo_cpu[i].L2C; 
         ooo_cpu[i].l1i_prefetcher_initialize();
@@ -735,13 +737,16 @@ int main(int argc, char** argv)
 
         ooo_cpu[i].L1D.cpu = i;
         ooo_cpu[i].L1D.cache_type = IS_L1D;
-        ooo_cpu[i].L1D.MAX_READ = (2 > MAX_READ_PER_CYCLE) ? MAX_READ_PER_CYCLE : 2;
+        ooo_cpu[i].L1D.MAX_READ = 2;
+        ooo_cpu[i].L1D.MAX_WRITE = 2;
         ooo_cpu[i].L1D.fill_level = FILL_L1;
         ooo_cpu[i].L1D.lower_level = &ooo_cpu[i].L2C; 
         ooo_cpu[i].L1D.l1d_prefetcher_initialize();
 
         ooo_cpu[i].L2C.cpu = i;
         ooo_cpu[i].L2C.cache_type = IS_L2C;
+        ooo_cpu[i].L2C.MAX_READ = 1;
+        ooo_cpu[i].L2C.MAX_WRITE = 1;
         ooo_cpu[i].L2C.fill_level = FILL_L2;
         ooo_cpu[i].L2C.upper_level_icache[i] = &ooo_cpu[i].L1I;
         ooo_cpu[i].L2C.upper_level_dcache[i] = &ooo_cpu[i].L1D;
@@ -752,6 +757,7 @@ int main(int argc, char** argv)
         uncore.LLC.cache_type = IS_LLC;
         uncore.LLC.fill_level = FILL_LLC;
         uncore.LLC.MAX_READ = NUM_CPUS;
+        uncore.LLC.MAX_WRITE = NUM_CPUS;
         uncore.LLC.upper_level_icache[i] = &ooo_cpu[i].L2C;
         uncore.LLC.upper_level_dcache[i] = &ooo_cpu[i].L2C;
         uncore.LLC.lower_level = &uncore.DRAM;

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -30,24 +30,6 @@ void O3_CPU::read_from_trace()
 
         if (knob_cloudsuite) {
             if (!fread(&current_cloudsuite_instr, instr_size, 1, trace_file)) {
-	      if((SINGLE_CORE_TRACE_END_EXIT==1) && (NUM_CPUS==1))
-		{
-		  cout << "*** Reached end of trace for Core: " << cpu << " Simulation complete." << endl << endl;
-		  if(warmup_complete[cpu] == 1)
-		    {
-		      ooo_cpu[cpu].simulation_instructions = ooo_cpu[cpu].num_retired - ooo_cpu[cpu].begin_sim_instr;
-		    }
-		  else
-		    {
-		      cout << "Reached the end of trace before completing the warmup period." << endl << endl;
-		      warmup_complete[cpu] = 1;
-		      all_warmup_complete = 2;
-		      ooo_cpu[cpu].begin_sim_instr = 0;
-		      ooo_cpu[cpu].simulation_instructions = ooo_cpu[cpu].num_retired - ooo_cpu[cpu].begin_sim_instr;
-		    }
-		  return;
-		}
-
                 // reached end of file for this trace
                 cout << "*** Reached end of trace for Core: " << cpu << " Repeating trace: " << trace_string << endl; 
 
@@ -165,24 +147,6 @@ void O3_CPU::read_from_trace()
 	    input_instr trace_read_instr;
             if (!fread(&trace_read_instr, instr_size, 1, trace_file))
 	      {
-		if((SINGLE_CORE_TRACE_END_EXIT==1) && (NUM_CPUS==1))
-		  {
-		    cout << "*** Reached end of trace for Core: " << cpu << " Simulation complete." << endl << endl;
-		    if(warmup_complete[cpu] == 1)
-		      {
-			ooo_cpu[cpu].simulation_instructions = ooo_cpu[cpu].num_retired - ooo_cpu[cpu].begin_sim_instr;
-		      }
-		    else
-		      {
-			cout << "Reached the end of trace before completing the warmup period." << endl << endl;
-			warmup_complete[cpu] = 1;
-			all_warmup_complete = 2;
-			ooo_cpu[cpu].begin_sim_instr = 0;
-			ooo_cpu[cpu].simulation_instructions = ooo_cpu[cpu].num_retired - ooo_cpu[cpu].begin_sim_instr;
-		      }
-		    return;
-		  }
-
                 // reached end of file for this trace
                 cout << "*** Reached end of trace for Core: " << cpu << " Repeating trace: " << trace_string << endl; 
 		

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -30,6 +30,24 @@ void O3_CPU::read_from_trace()
 
         if (knob_cloudsuite) {
             if (!fread(&current_cloudsuite_instr, instr_size, 1, trace_file)) {
+	      if((SINGLE_CORE_TRACE_END_EXIT==1) && (NUM_CPUS==1))
+		{
+		  cout << "*** Reached end of trace for Core: " << cpu << " Simulation complete." << endl << endl;
+		  if(warmup_complete[cpu] == 1)
+		    {
+		      ooo_cpu[cpu].simulation_instructions = ooo_cpu[cpu].num_retired - ooo_cpu[cpu].begin_sim_instr;
+		    }
+		  else
+		    {
+		      cout << "Reached the end of trace before completing the warmup period." << endl << endl;
+		      warmup_complete[cpu] = 1;
+		      all_warmup_complete = 2;
+		      ooo_cpu[cpu].begin_sim_instr = 0;
+		      ooo_cpu[cpu].simulation_instructions = ooo_cpu[cpu].num_retired - ooo_cpu[cpu].begin_sim_instr;
+		    }
+		  return;
+		}
+
                 // reached end of file for this trace
                 cout << "*** Reached end of trace for Core: " << cpu << " Repeating trace: " << trace_string << endl; 
 
@@ -147,6 +165,24 @@ void O3_CPU::read_from_trace()
 	    input_instr trace_read_instr;
             if (!fread(&trace_read_instr, instr_size, 1, trace_file))
 	      {
+		if((SINGLE_CORE_TRACE_END_EXIT==1) && (NUM_CPUS==1))
+		  {
+		    cout << "*** Reached end of trace for Core: " << cpu << " Simulation complete." << endl << endl;
+		    if(warmup_complete[cpu] == 1)
+		      {
+			ooo_cpu[cpu].simulation_instructions = ooo_cpu[cpu].num_retired - ooo_cpu[cpu].begin_sim_instr;
+		      }
+		    else
+		      {
+			cout << "Reached the end of trace before completing the warmup period." << endl << endl;
+			warmup_complete[cpu] = 1;
+			all_warmup_complete = 2;
+			ooo_cpu[cpu].begin_sim_instr = 0;
+			ooo_cpu[cpu].simulation_instructions = ooo_cpu[cpu].num_retired - ooo_cpu[cpu].begin_sim_instr;
+		      }
+		    return;
+		  }
+
                 // reached end of file for this trace
                 cout << "*** Reached end of trace for Core: " << cpu << " Repeating trace: " << trace_string << endl; 
 		


### PR DESCRIPTION
Cache write bandwidth can now be something other than 1 cache line per cycle.  It also makes it so that cache fill and write back operations both share the same limited resource, rather than each having their own dedicated, hard-coded 1/cycle.

In each cache, you can set MAX_WRITE, which does the same thing for fills and write backs that MAX_READ does for reads and prefetches.

Also, added a feature that automatically quits at the end of the trace for single core simulations, rather than wrapping back around to the beginning of the trace.  Multi-core simulations should be unaffected.