### PR TITLE
Prefetch stats

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -150,6 +150,13 @@ void reset_cache_stats(uint32_t cpu, CACHE *cache)
         cache->sim_miss[cpu][i] = 0;
     }
 
+    cache->pf_requested = 0;
+    cache->pf_issued = 0;
+    cache->pf_useful = 0;
+    cache->pf_useless = 0;
+    cache->pf_fill = 0;
+
+
     cache->total_miss_latency = 0;
 
     cache->RQ.ACCESS = 0;


### PR DESCRIPTION
A simple change to main.cc to reset the prefetch statistics after warm up. Prior to this, the number of useful/useless prefetches could exceed the number of actual prefetch requests recorded during the simulation period. 