### PR TITLE
Removed magic in instruction VA translation

### DIFF
--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -225,16 +225,6 @@ uint32_t O3_CPU::init_instruction(ooo_model_instr arch_instr)
 
     arch_instr.event_cycle = current_core_cycle[cpu];
 
-    // magically translate instructions
-    uint64_t instr_pa = vmem.va_to_pa(cpu, arch_instr.ip);
-    instr_pa >>= LOG2_PAGE_SIZE;
-    instr_pa <<= LOG2_PAGE_SIZE;
-    instr_pa |= (arch_instr.ip & ((1 << LOG2_PAGE_SIZE) - 1));  
-    arch_instr.instruction_pa = instr_pa;
-    arch_instr.translated = COMPLETED;
-    arch_instr.fetched = 0;
-    // end magic
-
     // Add to IFETCH_BUFFER
     assert(IFETCH_BUFFER.occupancy < IFETCH_BUFFER.SIZE);
     IFETCH_BUFFER.entry[IFETCH_BUFFER.tail] = arch_instr;


### PR DESCRIPTION
As I was making other changes, I noticed that the ITLB was receiving no requests, because instructions were entering the IFETCH_BUFFER magically translated. This change removes that magic in favor of actually using the TLB.