### PR TITLE
Implemented Decoupled Front End, plus cleanup Fetch, and fix a few bugs in Decoded Instruction Buffer

### DIFF
--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -318,7 +318,8 @@ void O3_CPU::fetch_instruction()
       if (way != dib_set.end())
       {
           // The cache line is in the L0, so we can mark this as complete
-          ifb_entry.fetched = COMPLETED;
+	  ifb_entry.translated = COMPLETED;
+	  ifb_entry.fetched = COMPLETED;
 
           // Also mark it as decoded
           ifb_entry.decoded = COMPLETED;
@@ -540,7 +541,7 @@ void O3_CPU::decode_and_dispatch()
 	  {
 	    // we have a miss in the DIB, so we need to replace something
 	    // find victim in DIB
-	    dib_t::value_type &dib_set = DIB[db_entry.ip % DIB_SET];
+	    dib_t::value_type &dib_set = DIB[(db_entry.ip >> LOG2_BLOCK_SIZE) % DIB_SET];
 	    auto way = std::find_if_not(dib_set.begin(), dib_set.end(), [](dib_entry_t x){ return x.valid; }); // search for invalid
 	    if (way == dib_set.end())
 	      way = std::max_element(dib_set.begin(), dib_set.end(), [](dib_entry_t x, dib_entry_t y){ return x.lru < y.lru;}); // search for LRU


### PR DESCRIPTION
Cleanup Fetch - the DIB lookup was happening in between seeing if the IFETCH_BUFFER instructions needed to be translated or fetched.  Now DIB lookup happens before checking to see if anything needs to be translated.  This will result in fewer unnecessary ITLB lookups.

Debug DIB - DIB set calculation was done with byte-address of instruction, rather than cache line address (>>6).  Also, instructions are now added to the DIB after they make it through the decode stage the first time, instead of immediately after they're fetched.

This still has the problem that once we add a cache line to the DIB that all instructions from that cache line will be magically fetched and decoded, including those we haven't actually seen yet.  I don't know how big of a problem that is, but this should still be a slight realism improvement over how it was before.

Performance should be very slightly improved by these changes.

Finally, I refactored a few of the loop conditions to make it more obvious how FETCH_WIDTH and DECODE_WIDTH influence what's happening, and I fixed the indentation of a few lines that were giving annoying compilation warnings.