### PR TITLE
Speed up warmup execution by ignoring register dependencies

### DIFF
--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -230,6 +230,21 @@ uint32_t O3_CPU::init_instruction(ooo_model_instr arch_instr)
 
     arch_instr.event_cycle = current_core_cycle[cpu];
 
+    // fast warmup eliminates register dependencies between instructions
+    // branch predictor, cache contents, and prefetchers are still warmed up
+    if(!warmup_complete[cpu])
+      {
+	for (int i=0; i<NUM_INSTR_SOURCES; i++)
+	  {
+	    arch_instr.source_registers[i] = 0;
+	  }
+	for (uint32_t i=0; i<MAX_INSTR_DESTINATIONS; i++)
+	  {
+	    arch_instr.destination_registers[i] = 0;
+	  }
+	arch_instr.num_reg_ops = 0;
+      }
+
     // Add to IFETCH_BUFFER
     assert(IFETCH_BUFFER.occupancy < IFETCH_BUFFER.SIZE);
     IFETCH_BUFFER.entry[IFETCH_BUFFER.tail] = arch_instr;


### PR DESCRIPTION
This commit eliminates register dependencies until the warmup phase is complete.  This causes the warmup phase's IPC to be much higher, leading to faster warmup times.  Warmup phase IPC is already meaningless, so I imagine making it even more meaningless isn't a bad thing.  Branch predictors, cache replacement algorithms, cache contents, and prefetchers are all warmed up as normal.  The final reported IPC of the simulation phase, as well as all other reported metrics, should be very similar to they were before this commit, but not identical.

Please experiment with this and see how much it changes the metrics you care about.  If this doesn't harm anyone else's work, then it might as well be merged in, but it's not a huge deal either way.