### PR TITLE
Added support for user-defined BTBs, and provided a sample Basic BTB

### DIFF
--- a/branch/bimodal/bimodal.cc
+++ b/branch/bimodal/bimodal.cc
@@ -13,20 +13,39 @@ void O3_CPU::initialize_branch_predictor()
         bimodal_table[cpu][i] = 0;
 }
 
-uint8_t O3_CPU::predict_branch(uint64_t ip)
+uint64_t O3_CPU::predict_branch(uint64_t ip, uint8_t branch_type)
 {
-    uint32_t hash = ip % BIMODAL_PRIME;
-    uint8_t prediction = (bimodal_table[cpu][hash] >= ((MAX_COUNTER + 1)/2)) ? 1 : 0;
+  uint8_t always_taken;
+  uint64_t target = btb_prediction(ip, branch_type, always_taken);
 
-    return prediction;
+  if(always_taken)
+    {
+      return target;
+    }
+
+  if(branch_type == BRANCH_CONDITIONAL)
+    {
+      uint32_t hash = ip % BIMODAL_PRIME;
+      if((bimodal_table[cpu][hash] < ((MAX_COUNTER + 1)/2)))
+	{
+	  target = 0;
+	}
+    }
+
+  return target;
 }
 
-void O3_CPU::last_branch_result(uint64_t ip, uint8_t taken)
+void O3_CPU::last_branch_result(uint64_t ip, uint64_t branch_target, uint8_t taken, uint8_t branch_type)
 {
-    uint32_t hash = ip % BIMODAL_PRIME;
+  update_btb(ip, branch_target, taken, branch_type);
 
-    if (taken && (bimodal_table[cpu][hash] < MAX_COUNTER))
+  if(branch_type == BRANCH_CONDITIONAL)
+    {
+      uint32_t hash = ip % BIMODAL_PRIME;
+
+      if (taken && (bimodal_table[cpu][hash] < MAX_COUNTER))
         bimodal_table[cpu][hash]++;
-    else if ((taken == 0) && (bimodal_table[cpu][hash] > 0))
+      else if ((taken == 0) && (bimodal_table[cpu][hash] > 0))
         bimodal_table[cpu][hash]--;
+    }
 }

--- a/branch/bimodal/bimodal.cc
+++ b/branch/bimodal/bimodal.cc
@@ -13,39 +13,20 @@ void O3_CPU::initialize_branch_predictor()
         bimodal_table[cpu][i] = 0;
 }
 
-uint64_t O3_CPU::predict_branch(uint64_t ip, uint8_t branch_type)
+uint8_t O3_CPU::predict_branch(uint64_t ip, uint64_t predicted_target, uint8_t always_taken, uint8_t branch_type)
 {
-  uint8_t always_taken;
-  uint64_t target = btb_prediction(ip, branch_type, always_taken);
+    uint32_t hash = ip % BIMODAL_PRIME;
+    uint8_t prediction = (bimodal_table[cpu][hash] >= ((MAX_COUNTER + 1)/2)) ? 1 : 0;
 
-  if(always_taken)
-    {
-      return target;
-    }
-
-  if(branch_type == BRANCH_CONDITIONAL)
-    {
-      uint32_t hash = ip % BIMODAL_PRIME;
-      if((bimodal_table[cpu][hash] < ((MAX_COUNTER + 1)/2)))
-	{
-	  target = 0;
-	}
-    }
-
-  return target;
+    return prediction;
 }
 
 void O3_CPU::last_branch_result(uint64_t ip, uint64_t branch_target, uint8_t taken, uint8_t branch_type)
 {
-  update_btb(ip, branch_target, taken, branch_type);
+    uint32_t hash = ip % BIMODAL_PRIME;
 
-  if(branch_type == BRANCH_CONDITIONAL)
-    {
-      uint32_t hash = ip % BIMODAL_PRIME;
-
-      if (taken && (bimodal_table[cpu][hash] < MAX_COUNTER))
+    if (taken && (bimodal_table[cpu][hash] < MAX_COUNTER))
         bimodal_table[cpu][hash]++;
-      else if ((taken == 0) && (bimodal_table[cpu][hash] > 0))
+    else if ((taken == 0) && (bimodal_table[cpu][hash] > 0))
         bimodal_table[cpu][hash]--;
-    }
 }

--- a/branch/gshare/gshare.cc
+++ b/branch/gshare/gshare.cc
@@ -29,24 +29,44 @@ unsigned int gs_table_hash(uint64_t ip, int bh_vector)
     return hash;
 }
 
-uint8_t O3_CPU::predict_branch(uint64_t ip)
+uint64_t O3_CPU::predict_branch(uint64_t ip, uint8_t branch_type)
 {
+  uint8_t always_taken;
+  uint64_t target = btb_prediction(ip, branch_type, always_taken);
+
+  if(always_taken)
+    {
+      return target;
+    }
+
     int prediction = 1;
 
     int gs_hash = gs_table_hash(ip, branch_history_vector[cpu]);
 
     if(gs_history_table[cpu][gs_hash] >= 2)
+      {
         prediction = 1;
+      }
     else
+      {
         prediction = 0;
+	target = 0;
+      }
 
     my_last_prediction[cpu] = prediction;
 
-    return prediction;
+    return target;
 }
 
-void O3_CPU::last_branch_result(uint64_t ip, uint8_t taken)
+void O3_CPU::last_branch_result(uint64_t ip, uint64_t branch_target, uint8_t taken, uint8_t branch_type)
 {
+  update_btb(ip, branch_target, taken, branch_type);
+
+  if(branch_type != BRANCH_CONDITIONAL)
+    {
+      return;
+    }
+
     int gs_hash = gs_table_hash(ip, branch_history_vector[cpu]);
 
     if(taken == 1) {

--- a/branch/gshare/gshare.cc
+++ b/branch/gshare/gshare.cc
@@ -29,44 +29,24 @@ unsigned int gs_table_hash(uint64_t ip, int bh_vector)
     return hash;
 }
 
-uint64_t O3_CPU::predict_branch(uint64_t ip, uint8_t branch_type)
+uint8_t O3_CPU::predict_branch(uint64_t ip, uint64_t predicted_target, uint8_t always_taken, uint8_t branch_type)
 {
-  uint8_t always_taken;
-  uint64_t target = btb_prediction(ip, branch_type, always_taken);
-
-  if(always_taken)
-    {
-      return target;
-    }
-
     int prediction = 1;
 
     int gs_hash = gs_table_hash(ip, branch_history_vector[cpu]);
 
     if(gs_history_table[cpu][gs_hash] >= 2)
-      {
         prediction = 1;
-      }
     else
-      {
         prediction = 0;
-	target = 0;
-      }
 
     my_last_prediction[cpu] = prediction;
 
-    return target;
+    return prediction;
 }
 
 void O3_CPU::last_branch_result(uint64_t ip, uint64_t branch_target, uint8_t taken, uint8_t branch_type)
 {
-  update_btb(ip, branch_target, taken, branch_type);
-
-  if(branch_type != BRANCH_CONDITIONAL)
-    {
-      return;
-    }
-
     int gs_hash = gs_table_hash(ip, branch_history_vector[cpu]);
 
     if(taken == 1) {

--- a/branch/hashed_perceptron/hashed_perceptron.cc
+++ b/branch/hashed_perceptron/hashed_perceptron.cc
@@ -119,7 +119,10 @@ void O3_CPU::initialize_branch_predictor () {
 	for (int i=0; i<NUM_CPUS; i++) theta[i] = 10;
 }
 
-uint8_t O3_CPU::predict_branch(uint64_t pc) {
+uint64_t O3_CPU::predict_branch(uint64_t pc, uint8_t branch_type) {
+
+  uint8_t always_taken;
+  uint64_t target = btb_prediction(pc, branch_type, always_taken);
 
 	// initialize perceptron sum
 
@@ -170,10 +173,17 @@ uint8_t O3_CPU::predict_branch(uint64_t pc) {
 
 		yout[cpu] += tables[cpu][i][x];
 	}
-	return yout[cpu] >= 1;
+
+	if(yout[cpu] >= 1)
+	  {
+	    return target;
+	  }
+
+	return 0;
 }
 
-void O3_CPU::last_branch_result(uint64_t pc, uint8_t taken) {
+void O3_CPU::last_branch_result(uint64_t pc, uint64_t branch_target, uint8_t taken, uint8_t branch_type) {
+    update_btb(pc, branch_target, taken, branch_type);
 
 	// was this prediction correct?
 

--- a/branch/hashed_perceptron/hashed_perceptron.cc
+++ b/branch/hashed_perceptron/hashed_perceptron.cc
@@ -119,10 +119,7 @@ void O3_CPU::initialize_branch_predictor () {
 	for (int i=0; i<NUM_CPUS; i++) theta[i] = 10;
 }
 
-uint64_t O3_CPU::predict_branch(uint64_t pc, uint8_t branch_type) {
-
-  uint8_t always_taken;
-  uint64_t target = btb_prediction(pc, branch_type, always_taken);
+uint8_t O3_CPU::predict_branch(uint64_t pc, uint64_t predicted_target, uint8_t always_taken, uint8_t branch_type) {
 
 	// initialize perceptron sum
 
@@ -173,17 +170,10 @@ uint64_t O3_CPU::predict_branch(uint64_t pc, uint8_t branch_type) {
 
 		yout[cpu] += tables[cpu][i][x];
 	}
-
-	if(yout[cpu] >= 1)
-	  {
-	    return target;
-	  }
-
-	return 0;
+	return yout[cpu] >= 1;
 }
 
 void O3_CPU::last_branch_result(uint64_t pc, uint64_t branch_target, uint8_t taken, uint8_t branch_type) {
-    update_btb(pc, branch_target, taken, branch_type);
 
 	// was this prediction correct?
 

--- a/branch/perceptron/perceptron.cc
+++ b/branch/perceptron/perceptron.cc
@@ -167,11 +167,8 @@ void O3_CPU::initialize_branch_predictor()
         initialize_perceptron (&perceptrons[cpu][i]);
 }
 
-uint64_t O3_CPU::predict_branch(uint64_t ip, uint8_t branch_type)
+uint8_t O3_CPU::predict_branch(uint64_t ip, uint64_t predicted_target, uint8_t always_taken, uint8_t branch_type)
 {
-  uint8_t always_taken;
-  uint64_t target = btb_prediction(ip, branch_type, always_taken);
-
     uint64_t address = ip;
 
     int	
@@ -234,18 +231,11 @@ uint64_t O3_CPU::predict_branch(uint64_t ip, uint8_t branch_type)
 
     spec_global_history[cpu] <<= 1;
     spec_global_history[cpu] |= u[cpu]->prediction;
-
-    if(u[cpu]->prediction == 0)
-      {
-	return 0;
-      }
-    return target;
+    return u[cpu]->prediction;
 }
 
 void O3_CPU::last_branch_result(uint64_t ip, uint64_t branch_target, uint8_t taken, uint8_t branch_type)
 {
-  update_btb(ip, branch_target, taken, branch_type);
-
     int	
         i,
         y, 

--- a/branch/perceptron/perceptron.cc
+++ b/branch/perceptron/perceptron.cc
@@ -167,8 +167,11 @@ void O3_CPU::initialize_branch_predictor()
         initialize_perceptron (&perceptrons[cpu][i]);
 }
 
-uint8_t O3_CPU::predict_branch(uint64_t ip)
+uint64_t O3_CPU::predict_branch(uint64_t ip, uint8_t branch_type)
 {
+  uint8_t always_taken;
+  uint64_t target = btb_prediction(ip, branch_type, always_taken);
+
     uint64_t address = ip;
 
     int	
@@ -231,11 +234,18 @@ uint8_t O3_CPU::predict_branch(uint64_t ip)
 
     spec_global_history[cpu] <<= 1;
     spec_global_history[cpu] |= u[cpu]->prediction;
-    return u[cpu]->prediction;
+
+    if(u[cpu]->prediction == 0)
+      {
+	return 0;
+      }
+    return target;
 }
 
-void O3_CPU::last_branch_result(uint64_t ip, uint8_t taken)
+void O3_CPU::last_branch_result(uint64_t ip, uint64_t branch_target, uint8_t taken, uint8_t branch_type)
 {
+  update_btb(ip, branch_target, taken, branch_type);
+
     int	
         i,
         y, 

--- a/btb/basic_btb/basic_btb.cc
+++ b/btb/basic_btb/basic_btb.cc
@@ -1,0 +1,191 @@
+
+/*
+ * This file implements a basic Branch Target Buffer (BTB) structure.
+ * It uses a set-associative BTB to predict the targets of non-return branches,
+ * and it uses a small Return Address Stack (RAS) to predict the target of
+ * returns.
+ */
+
+#include "ooo_cpu.h"
+
+#define BASIC_BTB_SETS 1024
+#define BASIC_BTB_WAYS 8
+#define BASIC_BTB_RAS_SIZE 32
+
+struct BASIC_BTB_ENTRY {
+  uint64_t ip_tag;
+  uint64_t target;
+  uint8_t always_taken;
+  uint64_t lru;
+};
+
+BASIC_BTB_ENTRY basic_btb[NUM_CPUS][BASIC_BTB_SETS][BASIC_BTB_WAYS];
+uint64_t basic_btb_lru_counter[NUM_CPUS];
+
+uint64_t basic_btb_ras[NUM_CPUS][BASIC_BTB_RAS_SIZE];
+int basic_btb_ras_index[NUM_CPUS];
+/*
+ * The following two variables are used to automatically identify the
+ * size of call instructions, in bytes, which tells us the appropriate
+ * target for a call's corresponding return.
+ * They exist because ChampSim does not model a specific ISA, and
+ * different ISAs could use different sizes for call instructions.
+ * Furthermore, if the ISA you're looking at has variable-sized call
+ * instructions, then the following solution would be insufficient
+ * to always get it right.
+ */
+uint64_t basic_btb_last_return_target[NUM_CPUS];
+uint64_t basic_btb_ras_call_return_offset[NUM_CPUS];
+
+uint64_t basic_btb_set_index(uint64_t ip) { return (ip >> 2) % BASIC_BTB_SETS; }
+
+BASIC_BTB_ENTRY *basic_btb_find_entry(uint8_t cpu, uint64_t ip) {
+  uint64_t set = basic_btb_set_index(ip);
+  for (uint32_t i = 0; i < BASIC_BTB_WAYS; i++) {
+    if (basic_btb[cpu][set][i].ip_tag == ip) {
+      return &(basic_btb[cpu][set][i]);
+    }
+  }
+
+  return NULL;
+}
+
+BASIC_BTB_ENTRY *basic_btb_get_lru_entry(uint8_t cpu, uint64_t set) {
+  uint32_t lru_way = 0;
+  uint64_t lru_value = basic_btb[cpu][set][lru_way].lru;
+  for (uint32_t i = 0; i < BASIC_BTB_WAYS; i++) {
+    if (basic_btb[cpu][set][i].lru < lru_value) {
+      lru_way = i;
+      lru_value = basic_btb[cpu][set][lru_way].lru;
+    }
+  }
+
+  return &(basic_btb[cpu][set][lru_way]);
+}
+
+void basic_btb_update_lru(uint8_t cpu, BASIC_BTB_ENTRY *btb_entry) {
+  btb_entry->lru = basic_btb_lru_counter[cpu];
+  basic_btb_lru_counter[cpu]++;
+}
+
+void push_basic_btb_ras(uint8_t cpu, uint64_t ip) {
+  basic_btb_ras[cpu][basic_btb_ras_index[cpu]] =
+      ip + basic_btb_ras_call_return_offset[cpu];
+  basic_btb_ras_index[cpu]++;
+  if (basic_btb_ras_index[cpu] == BASIC_BTB_RAS_SIZE) {
+    basic_btb_ras_index[cpu] = 0;
+  }
+}
+
+uint64_t pop_basic_btb_ras(uint8_t cpu) {
+  basic_btb_ras_index[cpu]--;
+  if (basic_btb_ras_index[cpu] == -1) {
+    basic_btb_ras_index[cpu] += BASIC_BTB_RAS_SIZE;
+  }
+
+  uint64_t target = basic_btb_ras[cpu][basic_btb_ras_index[cpu]];
+  basic_btb_ras[cpu][basic_btb_ras_index[cpu]] = 0;
+
+  return target;
+}
+
+void O3_CPU::initialize_btb() {
+  std::cout << "Basic BTB sets: " << BASIC_BTB_SETS
+            << " ways: " << BASIC_BTB_WAYS
+            << " RAS size: " << BASIC_BTB_RAS_SIZE << std::endl;
+
+  for (uint32_t i = 0; i < BASIC_BTB_SETS; i++) {
+    for (uint32_t j = 0; j < BASIC_BTB_WAYS; j++) {
+      basic_btb[cpu][i][j].ip_tag = 0;
+      basic_btb[cpu][i][j].target = 0;
+      basic_btb[cpu][i][j].always_taken = 0;
+      basic_btb[cpu][i][j].lru = 0;
+    }
+  }
+  basic_btb_lru_counter[cpu] = 0;
+
+  for (uint32_t i = 0; i < BASIC_BTB_RAS_SIZE; i++) {
+    basic_btb_ras[cpu][i] = 0;
+  }
+  basic_btb_ras_index[cpu] = 0;
+  basic_btb_last_return_target[cpu] = 0;
+  basic_btb_ras_call_return_offset[cpu] = 0;
+}
+
+uint64_t O3_CPU::btb_prediction(uint64_t ip, uint8_t branch_type,
+                                uint8_t &always_taken) {
+  if (branch_type != BRANCH_CONDITIONAL) {
+    always_taken = true;
+  }
+
+  if ((branch_type == BRANCH_DIRECT_CALL) ||
+      (branch_type == BRANCH_INDIRECT_CALL)) {
+    // add something to the RAS
+    push_basic_btb_ras(cpu, ip);
+  }
+
+  if (branch_type == BRANCH_RETURN) {
+    // pop something off the RAS
+    uint64_t target = pop_basic_btb_ras(cpu);
+    // record the latest prediction from the RAS
+    basic_btb_last_return_target[cpu] = target;
+
+    return target;
+  } else {
+    // use BTB for all branches + calls
+    auto btb_entry = basic_btb_find_entry(cpu, ip);
+
+    if (btb_entry == NULL) {
+      // no prediction for this IP
+      always_taken = 1;
+      return 0;
+    }
+
+    always_taken = btb_entry->always_taken;
+    basic_btb_update_lru(cpu, btb_entry);
+
+    return btb_entry->target;
+  }
+
+  return 0;
+}
+
+void O3_CPU::update_btb(uint64_t ip, uint64_t branch_target, uint8_t taken,
+                        uint8_t branch_type) {
+  if (branch_type == BRANCH_RETURN) {
+    // recalibrate call-return offset
+    // if our return prediction got us into the right cache line, but not the
+    // right byte target, then adjust our offset up or down, accordingly
+    if ((basic_btb_last_return_target[cpu] >> 6) == (branch_target >> 6)) {
+      if (basic_btb_last_return_target[cpu] > branch_target) {
+        // current offset is too high, so lower it
+        basic_btb_ras_call_return_offset[cpu]--;
+      } else if (basic_btb_last_return_target[cpu] < branch_target) {
+        // current offset is too low, so increase it
+        basic_btb_ras_call_return_offset[cpu]++;
+      }
+    }
+  } else {
+    // use BTB
+    auto btb_entry = basic_btb_find_entry(cpu, ip);
+
+    if (btb_entry == NULL) {
+      if ((branch_target != 0) && taken) {
+        // no prediction for this entry so far, so allocate one
+        uint64_t set = basic_btb_set_index(ip);
+        auto repl_entry = basic_btb_get_lru_entry(cpu, set);
+
+        repl_entry->ip_tag = ip;
+        repl_entry->target = branch_target;
+        repl_entry->always_taken = 1;
+        basic_btb_update_lru(cpu, repl_entry);
+      }
+    } else {
+      // update an existing entry
+      btb_entry->target = branch_target;
+      if (!taken) {
+        btb_entry->always_taken = 0;
+      }
+    }
+  }
+}

--- a/btb/basic_btb/basic_btb.cc
+++ b/btb/basic_btb/basic_btb.cc
@@ -47,7 +47,7 @@ uint64_t basic_btb_abs_addr_dist(uint64_t addr1, uint64_t addr2) {
   return addr2 - addr1;
 }
 
-uint64_t basic_btb_set_index(uint64_t ip) { return (ip >> 2) % BASIC_BTB_SETS; }
+uint64_t basic_btb_set_index(uint64_t ip) { return ((ip >> 2) & (BASIC_BTB_SETS-1)); }
 
 BASIC_BTB_ENTRY *basic_btb_find_entry(uint8_t cpu, uint64_t ip) {
   uint64_t set = basic_btb_set_index(ip);
@@ -80,7 +80,7 @@ void basic_btb_update_lru(uint8_t cpu, BASIC_BTB_ENTRY *btb_entry) {
 
 uint64_t basic_btb_indirect_hash(uint8_t cpu, uint64_t ip) {
   uint64_t hash = (ip >> 2) ^ (basic_btb_conditional_history[cpu]);
-  return hash % BASIC_BTB_INDIRECT_SIZE;
+  return (hash & (BASIC_BTB_INDIRECT_SIZE-1));
 }
 
 void push_basic_btb_ras(uint8_t cpu, uint64_t ip) {
@@ -109,7 +109,7 @@ uint64_t pop_basic_btb_ras(uint8_t cpu) {
 }
 
 uint64_t basic_btb_call_size_tracker_hash(uint64_t ip) {
-  return ip%BASIC_BTB_CALL_INSTR_SIZE_TRACKERS;
+  return (ip & (BASIC_BTB_CALL_INSTR_SIZE_TRACKERS-1));
 }
 
 uint64_t basic_btb_get_call_size(uint8_t cpu, uint64_t ip) {

--- a/champsim_config.json
+++ b/champsim_config.json
@@ -24,7 +24,8 @@
             "decode_latency": 2,
             "schedule_latency": 0,
             "execute_latency": 0,
-            "branch_predictor": "bimodal"
+            "branch_predictor": "bimodal",
+            "btb": "basic_btb"
         }
     ],
 

--- a/inc/ooo_cpu.h
+++ b/inc/ooo_cpu.h
@@ -221,7 +221,7 @@ class O3_CPU {
     uint8_t mem_reg_dependence_resolved(uint32_t rob_index);
 
   // branch predictor
-  uint64_t predict_branch(uint64_t ip, uint8_t branch_type);
+  uint8_t predict_branch(uint64_t ip, uint64_t predicted_target, uint8_t always_taken, uint8_t branch_type);
   void initialize_branch_predictor(),
     last_branch_result(uint64_t ip, uint64_t branch_target, uint8_t taken, uint8_t branch_type);
 

--- a/inc/ooo_cpu.h
+++ b/inc/ooo_cpu.h
@@ -75,6 +75,7 @@ class O3_CPU {
     uint64_t num_branch, branch_mispredictions;
     uint64_t total_rob_occupancy_at_branch_mispredict;
   uint64_t total_branch_types[8];
+  uint64_t branch_type_misses[8];
 
     // TLBs and caches
     CACHE ITLB{"ITLB", ITLB_SET, ITLB_WAY, ITLB_SET*ITLB_WAY, ITLB_WQ_SIZE, ITLB_RQ_SIZE, ITLB_PQ_SIZE, ITLB_MSHR_SIZE},
@@ -126,6 +127,7 @@ class O3_CPU {
 	for(uint32_t i=0; i<8; i++)
 	  {
 	    total_branch_types[i] = 0;
+	    branch_type_misses[i] = 0;
 	  }
 	
         for (uint32_t i=0; i<STA_SIZE; i++)

--- a/inc/ooo_cpu.h
+++ b/inc/ooo_cpu.h
@@ -25,7 +25,6 @@ class O3_CPU {
     char gunzip_command[1024];
 
     // instruction
-    input_instr next_instr;
     input_instr current_instr;
     cloudsuite_instr current_cloudsuite_instr;
     uint64_t instr_unique_id, completed_executions, 
@@ -219,10 +218,15 @@ class O3_CPU {
 
     uint8_t mem_reg_dependence_resolved(uint32_t rob_index);
 
-    // branch predictor
-    uint8_t predict_branch(uint64_t ip);
-    void    initialize_branch_predictor(),
-            last_branch_result(uint64_t ip, uint8_t taken);
+  // branch predictor
+  uint64_t predict_branch(uint64_t ip, uint8_t branch_type);
+  void initialize_branch_predictor(),
+    last_branch_result(uint64_t ip, uint64_t branch_target, uint8_t taken, uint8_t branch_type);
+
+  // btb
+  uint64_t btb_prediction(uint64_t ip, uint8_t branch_type, uint8_t &always_taken);
+  void initialize_btb(),
+    update_btb(uint64_t ip, uint64_t branch_target, uint8_t taken, uint8_t branch_type);
 
   // code prefetching
   void l1i_prefetcher_initialize();

--- a/src/main.cc
+++ b/src/main.cc
@@ -112,7 +112,8 @@ void print_branch_stats()
         cout << (100.0*(ooo_cpu[i].num_branch - ooo_cpu[i].branch_mispredictions)) / ooo_cpu[i].num_branch;
         cout << "% MPKI: " << (1000.0*ooo_cpu[i].branch_mispredictions)/(ooo_cpu[i].num_retired - ooo_cpu[i].warmup_instructions);
 	cout << " Average ROB Occupancy at Mispredict: " << (1.0*ooo_cpu[i].total_rob_occupancy_at_branch_mispredict)/ooo_cpu[i].branch_mispredictions << endl << endl;
-	
+
+	/*
 	cout << "Branch types" << endl;
 	cout << "NOT_BRANCH: " << ooo_cpu[i].total_branch_types[0] << " " << (100.0*ooo_cpu[i].total_branch_types[0])/(ooo_cpu[i].num_retired - ooo_cpu[i].begin_sim_instr) << "%" << endl;
 	cout << "BRANCH_DIRECT_JUMP: " << ooo_cpu[i].total_branch_types[1] << " " << (100.0*ooo_cpu[i].total_branch_types[1])/(ooo_cpu[i].num_retired - ooo_cpu[i].begin_sim_instr) << "%" << endl;
@@ -122,6 +123,15 @@ void print_branch_stats()
 	cout << "BRANCH_INDIRECT_CALL: " << ooo_cpu[i].total_branch_types[5] << " " << (100.0*ooo_cpu[i].total_branch_types[5])/(ooo_cpu[i].num_retired - ooo_cpu[i].begin_sim_instr) << "%" << endl;
 	cout << "BRANCH_RETURN: " << ooo_cpu[i].total_branch_types[6] << " " << (100.0*ooo_cpu[i].total_branch_types[6])/(ooo_cpu[i].num_retired - ooo_cpu[i].begin_sim_instr) << "%" << endl;
 	cout << "BRANCH_OTHER: " << ooo_cpu[i].total_branch_types[7] << " " << (100.0*ooo_cpu[i].total_branch_types[7])/(ooo_cpu[i].num_retired - ooo_cpu[i].begin_sim_instr) << "%" << endl << endl;
+	*/
+
+	cout << "Branch type misses per kilo-instruction" << endl;
+	cout << "BRANCH_DIRECT_JUMP: " << (1000.0*ooo_cpu[i].branch_type_misses[1]/(ooo_cpu[i].num_retired - ooo_cpu[i].begin_sim_instr)) << endl;
+	cout << "BRANCH_INDIRECT: " << (1000.0*ooo_cpu[i].branch_type_misses[2]/(ooo_cpu[i].num_retired - ooo_cpu[i].begin_sim_instr)) << endl;
+	cout << "BRANCH_CONDITIONAL: " << (1000.0*ooo_cpu[i].branch_type_misses[3]/(ooo_cpu[i].num_retired - ooo_cpu[i].begin_sim_instr)) << endl;
+	cout << "BRANCH_DIRECT_CALL: " << (1000.0*ooo_cpu[i].branch_type_misses[4]/(ooo_cpu[i].num_retired - ooo_cpu[i].begin_sim_instr)) << endl;
+	cout << "BRANCH_INDIRECT_CALL: " << (1000.0*ooo_cpu[i].branch_type_misses[5]/(ooo_cpu[i].num_retired - ooo_cpu[i].begin_sim_instr)) << endl;
+	cout << "BRANCH_RETURN: " << (1000.0*ooo_cpu[i].branch_type_misses[6]/(ooo_cpu[i].num_retired - ooo_cpu[i].begin_sim_instr)) << endl << endl;
     }
 }
 
@@ -205,6 +215,7 @@ void finish_warmup()
 	for(uint32_t j=0; j<8; j++)
 	  {
 	    ooo_cpu[i].total_branch_types[j] = 0;
+	    ooo_cpu[i].branch_type_misses[j] = 0;
 	  }
 	
         reset_cache_stats(i, &ooo_cpu[i].L1I);

--- a/src/main.cc
+++ b/src/main.cc
@@ -111,7 +111,7 @@ void print_branch_stats()
         cout << endl << "CPU " << i << " Branch Prediction Accuracy: ";
         cout << (100.0*(ooo_cpu[i].num_branch - ooo_cpu[i].branch_mispredictions)) / ooo_cpu[i].num_branch;
         cout << "% MPKI: " << (1000.0*ooo_cpu[i].branch_mispredictions)/(ooo_cpu[i].num_retired - ooo_cpu[i].warmup_instructions);
-	cout << " Average ROB Occupancy at Mispredict: " << (1.0*ooo_cpu[i].total_rob_occupancy_at_branch_mispredict)/ooo_cpu[i].branch_mispredictions << endl << endl;
+	cout << " Average ROB Occupancy at Mispredict: " << (1.0*ooo_cpu[i].total_rob_occupancy_at_branch_mispredict)/ooo_cpu[i].branch_mispredictions << endl;
 
 	/*
 	cout << "Branch types" << endl;
@@ -125,7 +125,7 @@ void print_branch_stats()
 	cout << "BRANCH_OTHER: " << ooo_cpu[i].total_branch_types[7] << " " << (100.0*ooo_cpu[i].total_branch_types[7])/(ooo_cpu[i].num_retired - ooo_cpu[i].begin_sim_instr) << "%" << endl << endl;
 	*/
 
-	cout << "Branch type misses per kilo-instruction" << endl;
+	cout << "Branch type MPKI" << endl;
 	cout << "BRANCH_DIRECT_JUMP: " << (1000.0*ooo_cpu[i].branch_type_misses[1]/(ooo_cpu[i].num_retired - ooo_cpu[i].begin_sim_instr)) << endl;
 	cout << "BRANCH_INDIRECT: " << (1000.0*ooo_cpu[i].branch_type_misses[2]/(ooo_cpu[i].num_retired - ooo_cpu[i].begin_sim_instr)) << endl;
 	cout << "BRANCH_CONDITIONAL: " << (1000.0*ooo_cpu[i].branch_type_misses[3]/(ooo_cpu[i].num_retired - ooo_cpu[i].begin_sim_instr)) << endl;

--- a/src/main.cc
+++ b/src/main.cc
@@ -440,8 +440,9 @@ int main(int argc, char** argv)
         // ROB
         ooo_cpu[i].ROB.cpu = i;
 
-        // BRANCH PREDICTOR
+        // BRANCH PREDICTOR & BTB
         ooo_cpu[i].initialize_branch_predictor();
+        ooo_cpu[i].initialize_btb();
 
         // TLBs
         ooo_cpu[i].ITLB.cpu = i;

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -205,6 +205,7 @@ uint32_t O3_CPU::init_instruction(ooo_model_instr arch_instr)
         {
             branch_mispredictions++;
             total_rob_occupancy_at_branch_mispredict += ROB.occupancy;
+	    branch_type_misses[arch_instr.branch_type]++;
             if(warmup_complete[cpu])
             {
                 fetch_stall = 1;

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -196,7 +196,13 @@ uint32_t O3_CPU::init_instruction(ooo_model_instr arch_instr)
 
         num_branch++;
 
-	uint64_t predicted_branch_target = predict_branch(arch_instr.ip, arch_instr.branch_type);
+	uint8_t always_taken;
+	uint64_t predicted_branch_target = btb_prediction(arch_instr.ip, arch_instr.branch_type, always_taken);
+	uint8_t branch_prediction = predict_branch(arch_instr.ip, predicted_branch_target, always_taken, arch_instr.branch_type);
+	if((branch_prediction == 0) && (always_taken == 0))
+	  {
+	    predicted_branch_target = 0;
+	  }
 
         // call code prefetcher every time the branch predictor is used
         l1i_prefetcher_branch_operate(arch_instr.ip, arch_instr.branch_type, predicted_branch_target);
@@ -222,6 +228,7 @@ uint32_t O3_CPU::init_instruction(ooo_model_instr arch_instr)
             }
         }
 
+	update_btb(arch_instr.ip, arch_instr.branch_target, arch_instr.branch_taken, arch_instr.branch_type);
         last_branch_result(arch_instr.ip, arch_instr.branch_target, arch_instr.branch_taken, arch_instr.branch_type);
     }
 

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -562,6 +562,18 @@ void O3_CPU::decode_and_dispatch()
         ROB.entry[ROB.tail] = db_entry;
         ROB.entry[ROB.tail].event_cycle = current_core_cycle[cpu];
 
+	if (ROB.entry[ROB.tail].branch_mispredicted)
+	  {
+	    // if we're adding a mispredicted branch to the ROB, and its misprediction could have been cleared up at decode, then resume fetch
+	    if ((ROB.entry[ROB.tail].branch_type == BRANCH_DIRECT_JUMP) || (ROB.entry[ROB.tail].branch_type == BRANCH_DIRECT_CALL))
+	      {
+		// clear the branch_mispredicted bit so we don't attempt to resume fetch again at execute
+		ROB.entry[ROB.tail].branch_mispredicted = 0;
+		// pay misprediction penalty
+		fetch_resume_cycle = current_core_cycle[cpu] + BRANCH_MISPREDICT_PENALTY;
+	      }
+	  }
+
         ROB.tail++;
         if (ROB.tail >= ROB.SIZE)
             ROB.tail = 0;


### PR DESCRIPTION
This is not ready for prime time yet, but I wanted to get some eyeballs on it early as I'm expecting it to go through plenty of iteration.  I would appreciate help not only with code, style, and simulator architecture, but also branch target prediction architectures in general.  I'm a BTB novice.

This PR adds non-perfect BTBs to ChampSim.  How this fits in ChampSim is that the branch predictor is now expected to return either 0 for non-taken branches, or the specific byte address of the branch target for taken branches.  The branch predictor can get help coming up with the specific target address from the BTB.  Basically how I'm imagining this will work is that the first line of the branch predictor will call the BTB to get its target prediction, and then the branch predictor can decide whether or not it wants to use that target prediction.  If the branch predictor predicts a branch as not taken, then it can just discard the output of the BTB.

The included basic_btb implements a fairly straightforward 8K entry BTB + 32-entry return address stack. From my testing, it appears to work correctly for direct and conditional branches and direct calls and returns, but it doesn't do anything special for indirect branches or calls, so it mostly gets those wrong.  I have lots of ideas about how indirect branches and calls could be predicted more effectively, but one of my goals for basic_btb is for it to be ... well, basic.  I don't want to invent anything new, and I don't know what the basic version of indirect branch prediction is.  That's something I would appreciate help deciding.

As far as performance goes, basic_btb is so much worse than the previous perfect BTB ChampSim had that it almost makes it irrelevant which branch predictor you use alongside it.  The hashed_perceptron branch predictor is still a little bit better than gshare, but not by nearly as much as it was with a perfect BTB.  I'm imagining that once basic_btb starts to do something about indirect branches that a lot of the performance difference will return.

I'm looking for suggestions about how BTBs should be integrated with ChampSim in general, as well as suggestions for improvements to the particular sample basic_btb I included, while still making sure it remains basic.

Finally, I ran basic_btb.cc through clang-format using llvm style before I commited it, so you can see what that looks like in action if you're unfamiliar with it.