### PR TITLE
btb_prediction() now returns a std::pair<> to return target and alway…

### DIFF
--- a/inc/ooo_cpu.h
+++ b/inc/ooo_cpu.h
@@ -234,7 +234,7 @@ class O3_CPU {
     last_branch_result(uint64_t ip, uint64_t branch_target, uint8_t taken, uint8_t branch_type);
 
   // btb
-  uint64_t btb_prediction(uint64_t ip, uint8_t branch_type, uint8_t &always_taken);
+  std::pair<uint64_t, uint8_t> btb_prediction(uint64_t ip, uint8_t branch_type);
   void initialize_btb(),
     update_btb(uint64_t ip, uint64_t branch_target, uint8_t taken, uint8_t branch_type);
 

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -196,8 +196,9 @@ uint32_t O3_CPU::init_instruction(ooo_model_instr arch_instr)
 
         num_branch++;
 
-	uint8_t always_taken;
-	uint64_t predicted_branch_target = btb_prediction(arch_instr.ip, arch_instr.branch_type, always_taken);
+	std::pair<uint64_t, uint8_t> btb_result = btb_prediction(arch_instr.ip, arch_instr.branch_type);
+	uint64_t predicted_branch_target = btb_result.first;
+	uint8_t always_taken = btb_result.second;
 	uint8_t branch_prediction = predict_branch(arch_instr.ip, predicted_branch_target, always_taken, arch_instr.branch_type);
 	if((branch_prediction == 0) && (always_taken == 0))
 	  {


### PR DESCRIPTION
This PR replaces pass-by-reference of the always_taken variable in the BTB interface with instead just returning a std::pair<>.  This is probably the more C++-like way of doing things.  Reported IPC is identical, and simulator performance is basically the same, so it's really just a style choice.

It's totally fine if we don't go this route, and this PR is rejected.  Please share your opinions on the style choice, and if everyone likes it, it's fine to merge it.