### PR TITLE
Declutter source code directories after compilation

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -253,7 +253,7 @@ with open('Makefile', 'wt') as wfp:
     wfp.write('.phony: all clean\n\n')
     wfp.write('all: ' + config_file['executable_name'] + '\n\n')
     wfp.write('clean: \n\t find . -name \*.o -delete\n\t find . -name \*.d -delete\n\t $(RM) -r obj\n\n')
-    wfp.write(config_file['executable_name'] + ': $(patsubst %.cc,%.o,$(wildcard src/*.cc)) ' + ' '.join('obj/' + k for k in libfilenames) + '\n')
+    wfp.write(config_file['executable_name'] + ': $(patsubst src/%.cc,obj/%.o,$(wildcard src/*.cc)) ' + ' '.join('obj/' + k for k in libfilenames) + '\n')
     wfp.write('\t$(CXX) $(LDFLAGS) -o $@ $^ $(LDLIBS)\n\n')
 
     for kv in libfilenames.items():


### PR DESCRIPTION
I noticed that the Makefile that config.sh generates dumps all of the .o and .d files back into the source directories of the corresponding .cc files, and I thought this made the directories too messy.  In this commit, I changed the config.sh script to generate a Makefile that puts all of the .d and .o files from src/ into obj/ instead.

I know almost nothing about make files, and I'm not great at scripting either, and this was the best I could do, but the real goal that I'm hoping someone else will help me to achieve is to declutter ALL of the source code directories in this same manner.  Currently, all of the user-definable modules like prefetchers, btb, replacement, etc., still have their .d and .o files dumped into the same directories as the .cc files, and I want help changing this.

Could someone who knows about make files and scripting please push another commit to this branch to make it so that all .d and .o files end up in the same place, out of the source code directories?