### PR TITLE
Created main.yml to automatically lint commits

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+name: lint
+  
+on:
+  # Triggers the workflow on push or pull request events for master and develop
+  push:
+    branches: [ master,develop ]
+  pull_request:
+    branches: [ master,develop ]
+
+jobs:
+  build: 
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: DoozyX/clang-format-lint-action@v0.11
+        with:
+          source: 'src inc prefetcher branch replacement btb'
+          style: llvm
+          inplace: True
+      - uses: EndBug/add-and-commit@v4
+        with:
+          author_name: Auto-Formatter
+          author_email: format@example.com
+          message: 'Formatted with clang-format'
+          add: 'src inc prefetcher branch replacement btb'


### PR DESCRIPTION
Resolves #84.

This workflow is triggered on pushes and PRs to the master and develop branches. It checks out the code, runs clang-format with llvm formatting (this can be later changed to a .clang-format file in the repository), then commits the resulting formatted code.

I have made this PR to master, not to develop, so that the changes will take effect immediately.