### PR TITLE
Implemented the stack pointer folding technique to boost IPC

### DIFF
--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -552,9 +552,25 @@ void O3_CPU::decode_and_dispatch()
 	    way->lru = 0;
 	    way->addr = db_entry.ip;
 
-        // Add to ROB
-        ROB.entry[ROB.tail] = db_entry;
-        ROB.entry[ROB.tail].event_cycle = current_core_cycle[cpu];
+	    // Stack Pointer Folding
+	    if(db_entry.is_branch == 0)
+	      {
+		// the exact, true value of the stack pointer for any given instruction can
+		// be determined immediately after the instruction is decoded without
+		// waiting for the stack pointer's dependency chain to be resolved
+		for (int i=0; i<NUM_INSTR_SOURCES; i++)
+		  {
+		    if(db_entry.source_registers[i] == REG_STACK_POINTER)
+		      {
+			db_entry.source_registers[i] = 0;
+			db_entry.num_reg_ops--;
+		      }
+		  }
+	      }
+
+	    // Add to ROB
+	    ROB.entry[ROB.tail] = db_entry;
+	    ROB.entry[ROB.tail].event_cycle = current_core_cycle[cpu];
 
 	if (ROB.entry[ROB.tail].branch_mispredicted)
 	  {


### PR DESCRIPTION
This PR implements a ChampSim version of stack pointer folding, which is an old technique that breaks dependencies on the stack pointer.  The idea is that the true value of the stack pointer can be calculated as soon as an instruction is decoded, because pushes, pops, calls, and returns all have behavior that is fixed at decode time.  In the ChampSim version, we're really just saying that stack pointer reads don't have to wait for the latest write to the stack pointer for the dependency to be satisfied.

This PR greatly improves performance of the DPC3 traces, or anything else that was generated with the Intel Pin tool.  It does not, however, improve the performance of the IPC-1 traces at all.  I suspect that this is because the IPC-1 traces were converted from ARM traces, and the hacks that were used to generate calls & returns in the IPC-1 traces were not universally applied to all instructions that read and write the stack pointer.  I'm hoping @djimeneth can weigh in on that.