### PR TITLE
Implements a ChampSim-friendly version of stack pointer folding

### DIFF
--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -186,6 +186,31 @@ uint32_t O3_CPU::init_instruction(ooo_model_instr arch_instr)
 	arch_instr.branch_target = 0;
       }
 
+    // Stack Pointer Folding
+    // The exact, true value of the stack pointer for any given instruction can
+    // usually be determined immediately after the instruction is decoded without
+    // waiting for the stack pointer's dependency chain to be resolved.
+    // We're doing it here because we already have writes_sp and reads_other handy,
+    // and in ChampSim it doesn't matter where before execution you do it.
+    if(writes_sp)
+      {
+       // Avoid creating register dependencies on the stack pointer for calls, returns, pushes,
+       // and pops, but not for variable-sized changes in the stack pointer position.
+       // reads_other indicates that the stack pointer is being changed by a variable amount,
+       // which can't be determined before execution.
+       if((arch_instr.is_branch != 0) || (arch_instr.num_mem_ops > 0) || (!reads_other))
+         {
+           for (uint32_t i=0; i<MAX_INSTR_DESTINATIONS; i++)
+             {
+               if(arch_instr.destination_registers[i] == REG_STACK_POINTER)
+                 {
+                   arch_instr.destination_registers[i] = 0;
+                   arch_instr.num_reg_ops--;
+                 }
+             }
+         }
+      }
+
     // add this instruction to the IFETCH_BUFFER
 
     // handle branch prediction


### PR DESCRIPTION
This is a do-over of #94.  Sorry.

This PR implements a ChampSim-friendly version of the concept of stack pointer folding.  The idea is that for most instructions that manipulate the stack pointer, the new value of the stack pointer can be accurately determined before the instruction is executed.  For example, pushes, pops, calls, and returns all move the stack pointer in predictable ways, and we don't need to execute one of these instructions before knowing what the stack pointer will be as input to the next.  This lets us break the dependency chain created by the stack pointer.

However, it is possible to directly modify the stack pointer by a variable amount without using one of the above instructions.  In this case, you do need to wait on the execution of this instruction before subsequent instructions can read the stack pointer.  This PR covers both cases.

This PR improves the performance of some traces by a lot, others by a little, and some not at all.  The more register spilling and function calls that a program has, the more this will help.  However, the IPC-1 traces, which were originally converted from ARM traces, used a hack to generate calls and returns in the ChampSim traces, so other references to the stack pointer don't use the same register number.  This could be fixed by either re-generating the IPC-1 traces, or perhaps by doing something similar to #32.