### PR TITLE
Fix for 4-core simulation crashing

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -440,6 +440,9 @@ int main(int argc, char** argv)
 
     srand(seed_number);
     champsim_seed = seed_number;
+
+    ooo_cpu.reserve(NUM_CPUS);
+
     for (int i=0; i<NUM_CPUS; i++) {
         ooo_cpu.emplace_back(i, warmup_instructions, simulation_instructions);
         ooo_cpu.at(i).L1I.l1i_prefetcher_cache_operate = cpu_l1i_prefetcher_cache_operate;


### PR DESCRIPTION
I found that 4-core simulation was crashing at initialization due to attempting to free memory not allocated when adding multiple CPU's to the CPU list in main. Reserving the space ahead of initialization seems to fix the problem for the mixes I tested. This PR doesn't address any deadlocks that may occur, just the initialization failure.