### PR TITLE
Small update to tracer and REAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ Get this version of Pin:
 wget http://software.intel.com/sites/landingpage/pintool/downloads/pin-3.2-81205-gcc-linux.tar.gz
 ```
 
+Once downloaded, open tracer/make_tracer.sh and change PIN_ROOT to Pin's location.
+Run ./make_tracer.sh to generate champsim_tracer.so.
+
 **Use the Pin tool like this**
 ```
 pin -t obj-intel64/champsim_tracer.so -- <your program here>

--- a/tracer/champsim_tracer.cpp
+++ b/tracer/champsim_tracer.cpp
@@ -14,6 +14,8 @@
 #define NUM_INSTR_DESTINATIONS 2
 #define NUM_INSTR_SOURCES 4
 
+using namespace std;
+
 typedef struct trace_instr_format {
     unsigned long long int ip;  // instruction pointer (program counter) value
 

--- a/tracer/make_tracer.sh
+++ b/tracer/make_tracer.sh
@@ -1,3 +1,3 @@
-export PIN_ROOT=/home/grads/c/cienlux/task/pin-3.2-81205-gcc-linux
+export PIN_ROOT=/your/pin/directory/
 mkdir -p obj-intel64
 make obj-intel64/champsim_tracer.so

--- a/tracer/quick_make.sh
+++ b/tracer/quick_make.sh
@@ -1,1 +1,0 @@
-make PIN_ROOT=/home/grads/c/cienlux/cienlux/task/pin-3.0-76991-gcc-linux obj-intel64/champsim_tracer.so


### PR DESCRIPTION
This updates the README to direct trace-users to change the tracer building script to point to the Pintool directory (#100). I've also addressed the namespace error brought up in (#50). This can probably be pushed directly into master since it doesn't directly affect ChampSim's functionality.