### PR TITLE
Added note in README on ChampSim tracer & PIN tool compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ Get this version of Pin:
 wget http://software.intel.com/sites/landingpage/pintool/downloads/pin-3.2-81205-gcc-linux.tar.gz
 ```
 
+**Note on compatibility**: If you are using newer linux kernels/Ubuntu versions (eg. 20.04LTS), you might run into issues (such as [[1](https://github.com/ChampSim/ChampSim/issues/102)],[[2](https://stackoverflow.com/questions/55698095/intel-pin-tools-32-bit-processsectionheaders-560-assertion-failed)],[[3](https://stackoverflow.com/questions/43589174/pin-tool-segmentation-fault-for-ubuntu-17-04)]) with the PIN3.2. ChampSim tracer works fine with newer PIN tool versions that can be downloaded from [here](https://software.intel.com/content/www/us/en/develop/articles/pin-a-binary-instrumentation-tool-downloads.html). PIN3.17 is [confirmed](https://github.com/ChampSim/ChampSim/issues/102) to work with Ubuntu 20.04.1 LTS.
+
+
 **Use the Pin tool like this**
 ```
 pin -t obj-intel64/champsim_tracer.so -- <your program here>

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Execute `run_champsim.sh` with proper input arguments. The default `TRACE_DIR` i
 
 ```
 Usage: ./run_champsim.sh [BINARY] [N_WARM] [N_SIM] [TRACE] [OPTION]
-$ ./run_champsim.sh bimodal-no-no-no-lru-1core 1 10 400.perlbench-41B.champsimtrace.xz
+$ ./run_champsim.sh bimodal-no-no-no-no-lru-1core 1 10 400.perlbench-41B.champsimtrace.xz
 
 ${BINARY}: ChampSim binary compiled by "build_champsim.sh" (bimodal-no-no-lru-1core)
 ${N_WARM}: number of instructions for warmup (1 million)


### PR DESCRIPTION
Newer PIN tool versions can be made use of, since 3.2 is dated. Using a newer PIN tool version is necessary when working on newer linux kernels.