### PR TITLE
Added cache bandwidths to constructors

### DIFF
--- a/champsim_config.json
+++ b/champsim_config.json
@@ -46,6 +46,8 @@
         "pq_size": 32,
         "mshr_size": 8,
         "latency": 4,
+        "max_read": 2,
+        "max_write": 2,
         "prefetcher": "no_l1i"
     },
 
@@ -57,6 +59,8 @@
         "pq_size": 8,
         "mshr_size": 16,
         "latency": 5,
+        "max_read": 2,
+        "max_write": 2,
         "prefetcher": "no_l1d"
     },
 
@@ -68,6 +72,8 @@
         "pq_size": 16,
         "mshr_size": 32,
         "latency": 10,
+        "max_read": 1,
+        "max_write": 1,
         "prefetcher": "no_l2c"
     },
 
@@ -78,7 +84,9 @@
         "wq_size": 16,
         "pq_size": 0,
         "mshr_size": 8,
-        "latency": 1
+        "latency": 1,
+        "max_read": 2,
+        "max_write": 2
     },
 
     "DTLB": {
@@ -88,7 +96,9 @@
         "wq_size": 16,
         "pq_size": 0,
         "mshr_size": 8,
-        "latency": 1
+        "latency": 1,
+        "max_read": 2,
+        "max_write": 2
     },
 
     "STLB": {
@@ -98,7 +108,9 @@
         "wq_size": 32,
         "pq_size": 0,
         "mshr_size": 16,
-        "latency": 8
+        "latency": 8,
+        "max_read": 1,
+        "max_write": 1
     },
 
     "LLC": {
@@ -109,6 +121,8 @@
         "pq_size": 32,
         "mshr_size": 64,
         "latency": 20,
+        "max_read": 1,
+        "max_write": 1,
         "prefetcher": "no_llc",
         "replacement": "lru_llc"
     },
@@ -128,4 +142,3 @@
         "num_levels": 5
     }
 }
-

--- a/config.sh
+++ b/config.sh
@@ -26,7 +26,7 @@ config_cache_name = '.champsimconfig_cache'
 # Begin format strings
 ###
 
-llc_fmtstr = 'CACHE {name}("{name}", {attrs[sets]}, {attrs[ways]}, {attrs[wq_size]}, {attrs[rq_size]}, {attrs[pq_size]}, {attrs[mshr_size]});\n'
+llc_fmtstr = 'CACHE {name}("{name}", {attrs[sets]}, {attrs[ways]}, {attrs[wq_size]}, {attrs[rq_size]}, {attrs[pq_size]}, {attrs[mshr_size]}, {attrs[max_read]}, {attrs[max_write]});\n'
 
 cpu_fmtstr = 'O3_CPU cpu{cpu}({cpu}, {attrs[ifetch_buffer_size]}, {attrs[decode_buffer_size]}, {attrs[dispatch_buffer_size]}, {attrs[rob_size]}, {attrs[lq_size]}, {attrs[sq_size]}, {attrs[fetch_width]}, {attrs[decode_width]}, {attrs[dispatch_width]}, {attrs[execute_width]}, {attrs[retire_width]}, {attrs[mispredict_penalty]}, {attrs[decode_latency]}, {attrs[dispatch_latency]}, {attrs[schedule_latency]}, {attrs[execute_latency]}, {attrs[DIB][window_size]}, {attrs[DIB][sets]}, {attrs[DIB][ways]}, &cpu{cpu}L1I, &cpu{cpu}L1D, &cpu{cpu}L2C, &cpu{cpu}ITLB, &cpu{cpu}DTLB, &cpu{cpu}STLB);\n'
 
@@ -37,7 +37,7 @@ module_make_fmtstr = 'obj/{}: $(patsubst %.cc,%.o,$(wildcard {}/*.cc))\n\t@mkdir
 
 define_fmtstr = '#define {{names[{name}]}} {{config[{name}]}}u\n'
 define_log_fmtstr = '#define LOG2_{{names[{name}]}} lg2({{names[{name}]}})\n'
-cache_define_fmtstr = '#define {name}_SET {attrs[sets]}u\n#define {name}_WAY {attrs[ways]}u\n#define {name}_WQ_SIZE {attrs[wq_size]}u\n#define {name}_RQ_SIZE {attrs[rq_size]}u\n#define {name}_PQ_SIZE {attrs[pq_size]}u\n#define {name}_MSHR_SIZE {attrs[mshr_size]}u\n#define {name}_LATENCY {attrs[latency]}u\n'
+cache_define_fmtstr = '#define {name}_SET {attrs[sets]}u\n#define {name}_WAY {attrs[ways]}u\n#define {name}_WQ_SIZE {attrs[wq_size]}u\n#define {name}_RQ_SIZE {attrs[rq_size]}u\n#define {name}_PQ_SIZE {attrs[pq_size]}u\n#define {name}_MSHR_SIZE {attrs[mshr_size]}u\n#define {name}_LATENCY {attrs[latency]}u\n#define {name}_MAX_READ {attrs[max_read]}\n#define {name}_MAX_WRITE {attrs[max_write]}'
 
 ###
 # Begin named constants
@@ -95,13 +95,13 @@ config_file = merge_dicts(default_root, config_file) # doing this early because 
 
 default_core = { 'ifetch_buffer_size': 64, 'decode_buffer_size': 32, 'dispatch_buffer_size': 32, 'rob_size': 352, 'lq_size': 128, 'sq_size': 72, 'fetch_width' : 6, 'decode_width' : 6, 'dispatch_width' : 6, 'execute_width' : 4, 'lq_width' : 2, 'sq_width' : 2, 'retire_width' : 5, 'mispredict_penalty' : 1, 'scheduler_size' : 128, 'decode_latency' : 1, 'dispatch_latency' : 1, 'schedule_latency' : 0, 'execute_latency' : 0, 'branch_predictor': 'bimodal', 'btb': 'basic_btb' }
 default_dib  = { 'window_size': 16,'sets': 32, 'ways': 8 }
-default_l1i  = { 'sets': 64, 'ways': 8, 'rq_size': 64, 'wq_size': 64, 'pq_size': 32, 'mshr_size': 8, 'latency': 4, 'prefetcher': 'no_l1i' }
-default_l1d  = { 'sets': 64, 'ways': 12, 'rq_size': 64, 'wq_size': 64, 'pq_size': 8, 'mshr_size': 16, 'latency': 5, 'prefetcher': 'no_l1d' }
-default_l2c  = { 'sets': 1024, 'ways': 8, 'rq_size': 32, 'wq_size': 32, 'pq_size': 16, 'mshr_size': 32, 'latency': 10, 'prefetcher': 'no_l2c' }
-default_itlb = { 'sets': 16, 'ways': 4, 'rq_size': 16, 'wq_size': 16, 'pq_size': 0, 'mshr_size': 8, 'latency': 1 }
-default_dtlb = { 'sets': 16, 'ways': 4, 'rq_size': 16, 'wq_size': 16, 'pq_size': 0, 'mshr_size': 8, 'latency': 1 }
-default_stlb = { 'sets': 128, 'ways': 12, 'rq_size': 32, 'wq_size': 32, 'pq_size': 0, 'mshr_size': 16, 'latency': 8 }
-default_llc  = { 'sets': 2048*config_file['num_cores'], 'ways': 16, 'rq_size': 32*config_file['num_cores'], 'wq_size': 32*config_file['num_cores'], 'pq_size': 32*config_file['num_cores'], 'mshr_size': 64*config_file['num_cores'], 'latency': 20, 'prefetcher': 'no_llc', 'replacement': 'lru_llc' }
+default_l1i  = { 'sets': 64, 'ways': 8, 'rq_size': 64, 'wq_size': 64, 'pq_size': 32, 'mshr_size': 8, 'latency': 4, 'max_read': 2, 'max_write': 2, 'prefetcher': 'no_l1i' }
+default_l1d  = { 'sets': 64, 'ways': 12, 'rq_size': 64, 'wq_size': 64, 'pq_size': 8, 'mshr_size': 16, 'latency': 5, 'max_read': 2, 'max_write': 2, 'prefetcher': 'no_l1d' }
+default_l2c  = { 'sets': 1024, 'ways': 8, 'rq_size': 32, 'wq_size': 32, 'pq_size': 16, 'mshr_size': 32, 'latency': 10, 'max_read': 1, 'max_write': 1, 'prefetcher': 'no_l2c' }
+default_itlb = { 'sets': 16, 'ways': 4, 'rq_size': 16, 'wq_size': 16, 'pq_size': 0, 'mshr_size': 8, 'latency': 1, 'max_read': 2, 'max_write': 2 }
+default_dtlb = { 'sets': 16, 'ways': 4, 'rq_size': 16, 'wq_size': 16, 'pq_size': 0, 'mshr_size': 8, 'latency': 1, 'max_read': 2, 'max_write': 2 }
+default_stlb = { 'sets': 128, 'ways': 12, 'rq_size': 32, 'wq_size': 32, 'pq_size': 0, 'mshr_size': 16, 'latency': 8, 'max_read': 1, 'max_write': 1 }
+default_llc  = { 'sets': 2048*config_file['num_cores'], 'ways': 16, 'rq_size': 32*config_file['num_cores'], 'wq_size': 32*config_file['num_cores'], 'pq_size': 32*config_file['num_cores'], 'mshr_size': 64*config_file['num_cores'], 'latency': 20, 'max_read': config_file['num_cores'], 'max_write': config_file['num_cores'], 'prefetcher': 'no_llc', 'replacement': 'lru_llc' }
 default_pmem = { 'frequency': 3200, 'channels': 1, 'ranks': 1, 'banks': 8, 'rows': 65536, 'columns': 128, 'row_size': 8 }
 default_vmem = { 'size': 8589934592, 'num_levels': 5 }
 

--- a/inc/cache.h
+++ b/inc/cache.h
@@ -31,7 +31,7 @@ class CACHE : public MemoryRequestConsumer, public MemoryRequestProducer {
     uint32_t LATENCY = 0;
     std::vector<BLOCK> block{NUM_SET*NUM_WAY};
     int fill_level = -1;
-    uint32_t MAX_READ = 1, MAX_WRITE = 1;
+    const uint32_t MAX_READ, MAX_WRITE;
     uint32_t reads_available_this_cycle, writes_available_this_cycle;
     uint8_t cache_type;
 
@@ -60,8 +60,8 @@ class CACHE : public MemoryRequestConsumer, public MemoryRequestProducer {
     uint64_t total_miss_latency = 0;
     
     // constructor
-    CACHE(std::string v1, uint32_t v2, int v3, uint32_t v5, uint32_t v6, uint32_t v7, uint32_t v8)
-        : NAME(v1), NUM_SET(v2), NUM_WAY(v3), WQ_SIZE(v5), RQ_SIZE(v6), PQ_SIZE(v7), MSHR_SIZE(v8) {
+    CACHE(std::string v1, uint32_t v2, int v3, uint32_t v5, uint32_t v6, uint32_t v7, uint32_t v8, uint32_t max_read, uint32_t max_write)
+        : NAME(v1), NUM_SET(v2), NUM_WAY(v3), WQ_SIZE(v5), RQ_SIZE(v6), PQ_SIZE(v7), MSHR_SIZE(v8), MAX_READ(max_read), MAX_WRITE(max_write) {
     }
 
     // functions

--- a/inc/ooo_cpu.h
+++ b/inc/ooo_cpu.h
@@ -89,12 +89,12 @@ class O3_CPU {
     uint64_t branch_type_misses[8] = {};
 
     // TLBs and caches
-    CACHE ITLB{"ITLB", ITLB_SET, ITLB_WAY, ITLB_WQ_SIZE, ITLB_RQ_SIZE, ITLB_PQ_SIZE, ITLB_MSHR_SIZE},
-          DTLB{"DTLB", DTLB_SET, DTLB_WAY, DTLB_WQ_SIZE, DTLB_RQ_SIZE, DTLB_PQ_SIZE, DTLB_MSHR_SIZE},
-          STLB{"STLB", STLB_SET, STLB_WAY, STLB_WQ_SIZE, STLB_RQ_SIZE, STLB_PQ_SIZE, STLB_MSHR_SIZE},
-          L1I{"L1I", L1I_SET, L1I_WAY, L1I_WQ_SIZE, L1I_RQ_SIZE, L1I_PQ_SIZE, L1I_MSHR_SIZE},
-          L1D{"L1D", L1D_SET, L1D_WAY, L1D_WQ_SIZE, L1D_RQ_SIZE, L1D_PQ_SIZE, L1D_MSHR_SIZE},
-          L2C{"L2C", L2C_SET, L2C_WAY, L2C_WQ_SIZE, L2C_RQ_SIZE, L2C_PQ_SIZE, L2C_MSHR_SIZE};
+    CACHE ITLB{"ITLB", ITLB_SET, ITLB_WAY, ITLB_WQ_SIZE, ITLB_RQ_SIZE, ITLB_PQ_SIZE, ITLB_MSHR_SIZE, ITLB_MAX_READ, ITLB_MAX_WRITE},
+          DTLB{"DTLB", DTLB_SET, DTLB_WAY, DTLB_WQ_SIZE, DTLB_RQ_SIZE, DTLB_PQ_SIZE, DTLB_MSHR_SIZE, DTLB_MAX_READ, DTLB_MAX_WRITE},
+          STLB{"STLB", STLB_SET, STLB_WAY, STLB_WQ_SIZE, STLB_RQ_SIZE, STLB_PQ_SIZE, STLB_MSHR_SIZE, STLB_MAX_READ, STLB_MAX_WRITE},
+          L1I{"L1I", L1I_SET, L1I_WAY, L1I_WQ_SIZE, L1I_RQ_SIZE, L1I_PQ_SIZE, L1I_MSHR_SIZE, L1I_MAX_READ, L1I_MAX_WRITE},
+          L1D{"L1D", L1D_SET, L1D_WAY, L1D_WQ_SIZE, L1D_RQ_SIZE, L1D_PQ_SIZE, L1D_MSHR_SIZE, L1D_MAX_READ, L1D_MAX_WRITE},
+          L2C{"L2C", L2C_SET, L2C_WAY, L2C_WQ_SIZE, L2C_RQ_SIZE, L2C_PQ_SIZE, L2C_MSHR_SIZE, L2C_MAX_READ, L2C_MAX_WRITE};
 
     CacheBus ITLB_bus{&ITLB}, DTLB_bus{&DTLB}, L1I_bus{&L1I}, L1D_bus{&L1D};
   
@@ -127,43 +127,31 @@ class O3_CPU {
         // TLBs
         ITLB.cpu = this->cpu;
         ITLB.cache_type = IS_ITLB;
-        ITLB.MAX_READ = 2;
-        ITLB.MAX_WRITE = 2;
         ITLB.fill_level = FILL_L1;
         ITLB.lower_level = &STLB;
 
         DTLB.cpu = this->cpu;
         DTLB.cache_type = IS_DTLB;
-        DTLB.MAX_READ = LQ_WIDTH;
-        DTLB.MAX_WRITE = LQ_WIDTH;
         DTLB.fill_level = FILL_L1;
         DTLB.lower_level = &STLB;
 
         STLB.cpu = this->cpu;
         STLB.cache_type = IS_STLB;
-        STLB.MAX_READ = 1;
-        STLB.MAX_WRITE = 1;
         STLB.fill_level = FILL_L2;
 
         // PRIVATE CACHE
         L1I.cpu = this->cpu;
         L1I.cache_type = IS_L1I;
-        L1I.MAX_READ = 2;
-        L1I.MAX_WRITE = 2;
         L1I.fill_level = FILL_L1;
         L1I.lower_level = &L2C;
 
         L1D.cpu = this->cpu;
         L1D.cache_type = IS_L1D;
-        L1D.MAX_READ = LQ_WIDTH;
-        L1D.MAX_WRITE = SQ_WIDTH;
         L1D.fill_level = FILL_L1;
         L1D.lower_level = &L2C;
 
         L2C.cpu = this->cpu;
         L2C.cache_type = IS_L2C;
-        L2C.MAX_READ = 1;
-        L2C.MAX_WRITE = 1;
         L2C.fill_level = FILL_L2;
 
         l1i_prefetcher_initialize();

--- a/src/main.cc
+++ b/src/main.cc
@@ -452,8 +452,6 @@ int main(int argc, char** argv)
         // SHARED CACHE
         LLC.cache_type = IS_LLC;
         LLC.fill_level = FILL_LLC;
-        LLC.MAX_READ = NUM_CPUS;
-        LLC.MAX_WRITE = NUM_CPUS;
         LLC.lower_level = &DRAM;
 
         using namespace std::placeholders;


### PR DESCRIPTION
This patch moves the number of reads and writes per cycle into the constructor of the caches and adds support for changing them to the configuration file. Previously, these values were hard-coded in the constructor of the core model.