### PR TITLE
Moved DRAM configuration to config file

### DIFF
--- a/champsim_config.json
+++ b/champsim_config.json
@@ -120,7 +120,13 @@
         "banks": 8,
         "rows": 65536,
         "columns": 128,
-        "row_size": 8
+        "row_size": 8,
+        "channel_width": 8,
+        "wq_size": 64,
+        "rq_size": 64,
+        "tRP": 12.5,
+        "tRCD": 12.5,
+        "tCAS": 12.5
     },
 
     "virtual_memory": {
@@ -128,4 +134,3 @@
         "num_levels": 5
     }
 }
-

--- a/inc/dram_controller.h
+++ b/inc/dram_controller.h
@@ -1,17 +1,9 @@
 #ifndef DRAM_H
 #define DRAM_H
 
+#include "champsim_constants.h"
 #include "memory_class.h"
 #include "champsim.h"
-
-// DRAM configuration
-#define DRAM_CHANNEL_WIDTH 8 // 8B
-#define DRAM_WQ_SIZE 64
-#define DRAM_RQ_SIZE 64
-
-#define tRP_DRAM_NANOSECONDS  12.5
-#define tRCD_DRAM_NANOSECONDS 12.5
-#define tCAS_DRAM_NANOSECONDS 12.5
 
 // the data bus must wait this amount of time when switching between reads and writes, and vice versa
 #define DRAM_DBUS_TURN_AROUND_TIME ((15*CPU_FREQ)/2000) // 7.5 ns 


### PR DESCRIPTION
This patch moves six more DRAM configuration items to the config file.

In the future, I want to make these members of the `MEMORY_CONTROLLER` class, but leaving them as preprocessor defines will work for now.