### PR TITLE
Allowed CACHE::WQ to merge entries if the queue is full

### DIFF
--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -1866,7 +1866,6 @@ void O3_CPU::retire_rob()
         }
 
         if (num_store) {
-            if ((L1D.WQ.occupancy + num_store) <= L1D.WQ.SIZE) {
                 for (uint32_t i=0; i<MAX_INSTR_DESTINATIONS; i++) {
                     if (ROB.entry[ROB.head].destination_memory[i]) {
 
@@ -1891,17 +1890,12 @@ void O3_CPU::retire_rob()
                         data_packet.asid[1] = SQ.entry[sq_index].asid[1];
                         data_packet.event_cycle = current_core_cycle[cpu];
 
-                        L1D_bus.lower_level->add_wq(&data_packet);
-                    }
+                        auto result = L1D_bus.lower_level->add_wq(&data_packet);
+                        if (result != -2)
+                            ROB.entry[ROB.head].destination_memory[i] = 0;
+                        else
+                            return;
                 }
-            }
-            else {
-                DP ( if (warmup_complete[cpu]) {
-                cout << "[ROB] " << __func__ << " instr_id: " << ROB.entry[ROB.head].instr_id << " L1D WQ is full" << endl; });
-
-                L1D.WQ.FULL++;
-
-                return;
             }
         }
 


### PR DESCRIPTION
In the cache hierarchy, the write queue was the only queue that could not check itself for duplicates when it was full. This patch allows it to do that. It has some effect on write-heavy programs, since some store instructions that stalled at the head of the ROB due to a full L1D write queue are now able to merge their stores.

Note: This technically violates in-order stores. However, since the L1D read queue checks the write queue for forwarding on insert, I think the conditions for this to be problematic are extremely narrow. If that is a concern, let me know.