### PR TITLE
Allowed module declarations to be path-like

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -166,24 +166,66 @@ config_file['ooo_cpu'] = list(itertools.islice(itertools.repeat(*config_file['oo
 libfilenames = {}
 for i,cpu in enumerate(config_file['ooo_cpu'][:1]):
     if cpu['L1I']['prefetcher'] is not None:
-        libfilenames['cpu' + str(i) + 'l1iprefetcher.a'] = 'prefetcher/' + cpu['L1I']['prefetcher']
-    if cpu['L1D']['prefetcher'] is not None:
-        libfilenames['cpu' + str(i) + 'l1dprefetcher.a'] = 'prefetcher/' + cpu['L1D']['prefetcher']
-    if cpu['L2C']['prefetcher'] is not None:
-        libfilenames['cpu' + str(i) + 'l2cprefetcher.a'] = 'prefetcher/' + cpu['L2C']['prefetcher']
-    if cpu['branch_predictor'] is not None:
-        libfilenames['cpu' + str(i) + 'branch_predictor.a'] = 'branch/' + cpu['branch_predictor']
-    if cpu['btb'] is not None:
-        libfilenames['cpu' + str(i) + 'btb.a'] = 'btb/' + cpu['btb']
-if config_file['LLC']['prefetcher'] is not None:
-    libfilenames['llprefetcher.a'] = 'prefetcher/' + config_file['LLC']['prefetcher']
-if config_file['LLC']['replacement'] is not None:
-    libfilenames['llreplacement.a'] = 'replacement/' + config_file['LLC']['replacement']
+        if os.path.exists('prefetcher/' + cpu['L1I']['prefetcher']):
+            libfilenames['cpu' + str(i) + 'l1iprefetcher.a'] = 'prefetcher/' + cpu['L1I']['prefetcher']
+        elif os.path.exists(os.path.normpath(os.path.expanduser(cpu['L1I']['prefetcher']))):
+            libfilenames['cpu' + str(i) + 'l1iprefetcher.a'] = os.path.normpath(os.path.expanduser(cpu['L1I']['prefetcher']))
+        else:
+            print('Path to L1I prefetcher does not exist. Exiting...')
+            sys.exit(1)
 
-# Assert module paths exist
-for path in libfilenames.values():
-    if not os.path.exists(path):
-        print('Path "' + path + '" does not exist. Exiting...')
+    if cpu['L1D']['prefetcher'] is not None:
+        if os.path.exists('prefetcher/' + cpu['L1D']['prefetcher']):
+            libfilenames['cpu' + str(i) + 'l1dprefetcher.a'] = 'prefetcher/' + cpu['L1D']['prefetcher']
+        elif os.path.exists(os.path.normpath(os.path.expanduser(cpu['L1D']['prefetcher']))):
+            libfilenames['cpu' + str(i) + 'l1dprefetcher.a'] = os.path.normpath(os.path.expanduser(cpu['L1D']['prefetcher']))
+        else:
+            print('Path to L1D prefetcher does not exist. Exiting...')
+            sys.exit(1)
+
+    if cpu['L2C']['prefetcher'] is not None:
+        if os.path.exists('prefetcher/' + cpu['L2C']['prefetcher']):
+            libfilenames['cpu' + str(i) + 'l2cprefetcher.a'] = 'prefetcher/' + cpu['L2C']['prefetcher']
+        elif os.path.exists(os.path.normpath(os.path.expanduser(cpu['L2C']['prefetcher']))):
+            libfilenames['cpu' + str(i) + 'l2cprefetcher.a'] = os.path.normpath(os.path.expanduser(cpu['L2C']['prefetcher']))
+        else:
+            print('Path to L2C prefetcher does not exist. Exiting...')
+            sys.exit(1)
+
+    if cpu['branch_predictor'] is not None:
+        if os.path.exists('branch/' + cpu['branch_predictor']):
+            libfilenames['cpu' + str(i) + 'branch_predictor.a'] = 'branch/' + cpu['branch_predictor']
+        elif os.path.exists(os.path.normpath(os.path.expanduser(cpu['branch_predictor']))):
+            libfilenames['cpu' + str(i) + 'branch_predictor.a'] = os.path.normpath(os.path.expanduser(cpu['branch_predictor']))
+        else:
+            print('Path to branch predictor does not exist. Exiting...')
+            sys.exit(1)
+
+    if cpu['btb'] is not None:
+        if os.path.exists('btb/' + cpu['btb']):
+            libfilenames['cpu' + str(i) + 'btb.a'] = 'btb/' + cpu['btb']
+        elif os.path.exists(os.path.normpath(os.path.expanduser(cpu['btb']))):
+            libfilenames['cpu' + str(i) + 'btb.a'] = os.path.normpath(os.path.expanduser(cpu['btb']))
+        else:
+            print('Path to BTB does not exist. Exiting...')
+            sys.exit(1)
+
+if config_file['LLC']['prefetcher'] is not None:
+    if os.path.exists('prefetcher/' + config_file['LLC']['prefetcher']):
+        libfilenames['cpu' + str(i) + 'llprefetcher.a'] = 'prefetcher/' + config_file['LLC']['prefetcher']
+    elif os.path.exists(os.path.normpath(os.path.expanduser(config_file['LLC']['prefetcher']))):
+        libfilenames['cpu' + str(i) + 'llprefetcher.a'] = os.path.normpath(os.path.expanduser(config_file['LLC']['prefetcher']))
+    else:
+        print('Path to LLC prefetcher does not exist. Exiting...')
+        sys.exit(1)
+
+if config_file['LLC']['replacement'] is not None:
+    if os.path.exists('replacement/' + config_file['LLC']['replacement']):
+        libfilenames['cpu' + str(i) + 'llreplacement.a'] = 'replacement/' + config_file['LLC']['replacement']
+    elif os.path.exists(os.path.normpath(os.path.expanduser(config_file['LLC']['replacement']))):
+        libfilenames['cpu' + str(i) + 'llreplacement.a'] = os.path.normpath(os.path.expanduser(config_file['LLC']['replacement']))
+    else:
+        print('Path to LLC replacement does not exist. Exiting...')
         sys.exit(1)
 
 # Check cache of previous configuration

--- a/config.sh
+++ b/config.sh
@@ -319,7 +319,10 @@ with open('Makefile', 'wt') as wfp:
     wfp.write('\n')
     wfp.write('.phony: all clean\n\n')
     wfp.write('all: ' + config_file['executable_name'] + '\n\n')
-    wfp.write('clean: \n\t find . -name \*.o -delete\n\t find . -name \*.d -delete\n\t $(RM) -r obj\n\n')
+    wfp.write('clean: \n\t find . -name \*.o -delete\n\t find . -name \*.d -delete\n\t $(RM) -r obj\n')
+    for v in libfilenames.values():
+        wfp.write('\t find {0} -name \*.o -delete\n\t find {0} -name \*.d -delete\n'.format(v))
+    wfp.write('\n')
     wfp.write(config_file['executable_name'] + ': $(patsubst %.cc,%.o,$(wildcard src/*.cc)) ' + ' '.join('obj/' + k for k in libfilenames) + '\n')
     wfp.write('\t$(CXX) $(LDFLAGS) -o $@ $^ $(LDLIBS)\n\n')
 


### PR DESCRIPTION
This patch allows module declarations in the configuration file to be paths, either absolute or relative to the root of the repository.

This will allow users to keep their modules under separate version control. This was previously only possible by symlinking the directory into `prefetcher/`, or other module directory.