### PR TITLE
Update to C++17

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -270,7 +270,7 @@ with open('Makefile', 'wt') as wfp:
     wfp.write('CC := ' + config_file.get('CC', 'gcc') + '\n')
     wfp.write('CXX := ' + config_file.get('CXX', 'g++') + '\n')
     wfp.write('CFLAGS := ' + config_file.get('CFLAGS', '-Wall -O3') + ' -std=gnu99\n')
-    wfp.write('CXXFLAGS := ' + config_file.get('CXXFLAGS', '-Wall -O3') + ' -std=c++11\n')
+    wfp.write('CXXFLAGS := ' + config_file.get('CXXFLAGS', '-Wall -O3') + ' -std=c++17\n')
     wfp.write('CPPFLAGS := ' + config_file.get('CPPFLAGS', '') + ' -Iinc -MMD -MP\n')
     wfp.write('LDFLAGS := ' + config_file.get('LDFLAGS', '') + '\n')
     wfp.write('LDLIBS := ' + config_file.get('LDLIBS', '') + '\n')


### PR DESCRIPTION
Resolves #44.

About 7 weeks from today, Ubuntu 16.04 will reach end of life. It will have been the last operating system for which GCC 5, which does not support C++17, is the default. With its passing, it is an appropriate time to update to the next major feature set of C++. Not to do this would be unnecessarily locking us out of the feature set.