### PR TITLE
Fixed widths of bitmasks

### DIFF
--- a/inc/util.h
+++ b/inc/util.h
@@ -10,7 +10,7 @@ constexpr unsigned lg2(uint64_t n)
 
 constexpr uint64_t bitmask(std::size_t begin, std::size_t end = 0)
 {
-    return ((1 << (begin - end))-1) << end;
+    return ((1ull << (begin - end))-1) << end;
 }
 
 constexpr uint64_t splice_bits(uint64_t upper, uint64_t lower, std::size_t bits)

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -409,7 +409,7 @@ bool CACHE::filllike_miss(std::size_t set, std::size_t way, PACKET &handle_pkt)
 
     // update prefetcher
     if (cache_type == IS_L1I)
-        l1i_prefetcher_cache_fill(handle_pkt.cpu, handle_pkt.ip & ~(BLOCK_SIZE-1), set, way, handle_pkt.type == PREFETCH, evicting_l1i_v_addr & ~(BLOCK_SIZE-1));
+        l1i_prefetcher_cache_fill(handle_pkt.cpu, handle_pkt.ip & ~bitmask(LOG2_BLOCK_SIZE), set, way, handle_pkt.type == PREFETCH, evicting_l1i_v_addr & ~bitmask(LOG2_BLOCK_SIZE));
     if (cache_type == IS_L1D)
         l1d_prefetcher_cache_fill(handle_pkt.full_v_addr, handle_pkt.full_addr, set, way, handle_pkt.type == PREFETCH, evicting_address << LOG2_BLOCK_SIZE, handle_pkt.pf_metadata);
     if  (cache_type == IS_L2C)
@@ -462,7 +462,7 @@ void CACHE::operate_reads()
 
 uint32_t CACHE::get_set(uint64_t address)
 {
-    return (uint32_t) (address & ((1 << lg2(NUM_SET)) - 1)); 
+    return (uint32_t) (address & bitmask(lg2(NUM_SET)));
 }
 
 uint32_t CACHE::get_way(uint64_t address, uint32_t set)

--- a/src/vmem.cc
+++ b/src/vmem.cc
@@ -93,7 +93,7 @@ uint32_t VirtualMemory::get_paget_table_level_count()
 uint64_t VirtualMemory::va_to_pa(uint32_t cpu_num, uint64_t vaddr)
 {
   uint64_t vpage = vaddr>>lg2(page_size);
-  uint64_t voffset = vaddr&((1<<lg2(page_size))-1);
+  uint64_t voffset = vaddr & bitmask(lg2(page_size));
 
   if(vpage_to_ppage_map[cpu_num].find(vpage) == vpage_to_ppage_map[cpu_num].end())
     {
@@ -107,7 +107,7 @@ uint64_t VirtualMemory::va_to_pa(uint32_t cpu_num, uint64_t vaddr)
 uint64_t VirtualMemory::get_pte_pa(uint32_t cpu_num, uint64_t vaddr, uint32_t level)
 {
   uint64_t vpage = vaddr>>lg2(page_size);
-  uint64_t pte_offset = vpage&511;
+  uint64_t pte_offset = vpage & bitmask(9);
   
   uint32_t shift_bits = 9 + (9*(pt_levels-1-level));
   uint64_t pt_lookup_tag = vpage>>shift_bits;


### PR DESCRIPTION
Gino brought this bug to my attention today. There was an instance in cache.cc where the upper bits were getting chopped because the bitmask was only 32 bits long. This patch addresses that issue and also fixes an instance in vmem.cc where it might have also been occurring.