### PR TITLE
Improved performance of MSHR filling

### DIFF
--- a/inc/block.h
+++ b/inc/block.h
@@ -29,7 +29,6 @@ class PACKET {
     uint32_t pf_metadata;
 
     uint8_t  is_producer = 0, 
-             returned = 0,
              asid[2] = {std::numeric_limits<uint8_t>::max(), std::numeric_limits<uint8_t>::max()},
              type = 0;
 

--- a/inc/cache.h
+++ b/inc/cache.h
@@ -53,7 +53,7 @@ class CACHE : public MemoryRequestConsumer, public MemoryRequestProducer {
                                   VAPQ{PQ_SIZE, VA_PREFETCH_TRANSLATION_LATENCY}, // virtual address prefetch queue
                                   WQ{WQ_SIZE, HIT_LATENCY}; // write queue
 
-    std::list<PACKET> MSHR{MSHR_SIZE}; // MSHR
+    std::list<PACKET> MSHR; // MSHR
 
     uint64_t sim_access[NUM_CPUS][NUM_TYPES] = {},
              sim_hit[NUM_CPUS][NUM_TYPES] = {},

--- a/inc/cache.h
+++ b/inc/cache.h
@@ -159,15 +159,6 @@ class CACHE : public MemoryRequestConsumer, public MemoryRequestProducer {
     void lru_final_stats();
 };
 
-class min_fill_index
-{
-    public:
-    bool operator() (PACKET lhs, PACKET rhs)
-    {
-        return rhs.returned != COMPLETED || (lhs.returned == COMPLETED && lhs.event_cycle < rhs.event_cycle);
-    }
-};
-
 template <>
 struct is_valid<PACKET>
 {

--- a/inc/ptw.h
+++ b/inc/ptw.h
@@ -79,7 +79,7 @@ class PageTableWalker : public MemoryRequestConsumer, public MemoryRequestProduc
 									  WQ{WQ_SIZE, LATENCY},
 									  PQ{PQ_SIZE, LATENCY};
 
-		std::list<PACKET> MSHR{MSHR_SIZE};
+		std::list<PACKET> MSHR;
 
     uint64_t RQ_ACCESS = 0,
              RQ_MERGED = 0,

--- a/inc/util.h
+++ b/inc/util.h
@@ -91,5 +91,18 @@ struct lru_updater
     }
 };
 
+template <typename T, typename U=T>
+struct ord_event_cycle
+{
+    using first_argument_type = T;
+    using second_argument_type = U;
+    bool operator() (const first_argument_type &lhs, const second_argument_type &rhs)
+    {
+        is_valid<first_argument_type> first_validtest;
+        is_valid<second_argument_type> second_validtest;
+        return !second_validtest(rhs) || (first_validtest(lhs) && lhs.event_cycle < rhs.event_cycle);
+    }
+};
+
 #endif
 

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -53,7 +53,7 @@ void CACHE::handle_fill()
         *fill_mshr = empty;
 
         writes_available_this_cycle--;
-        MSHR.sort(min_fill_index());
+        MSHR.splice(std::end(MSHR), MSHR, std::begin(MSHR));
     }
 }
 
@@ -735,7 +735,7 @@ void CACHE::return_data(PACKET *packet)
             std::cout << " index: " << std::distance(MSHR.begin(), mshr_entry) << " occupancy: " << get_occupancy(0,0);
             std::cout << " event: " << mshr_entry->event_cycle << " current: " << current_core_cycle[packet->cpu] << std::endl; });
 
-    MSHR.sort(min_fill_index());
+    MSHR.splice(std::lower_bound(std::begin(MSHR), std::end(MSHR), *mshr_entry, min_fill_index()), MSHR, mshr_entry);
 }
 
 uint32_t CACHE::get_occupancy(uint8_t queue_type, uint64_t address)


### PR DESCRIPTION
I had a conversation with Dr. Jimenez where he pointed out to me that the develop branch had a significant performance degradation for certain traces. I traced this back to the `std::list<>::sort()` function. It implements a merge sort. However, in the `CACHE::handle_fill()` function, we have a situation where the first element needs to be reordered to the last, and merge sort is not well-suited to handle this case.

I fixed the problem by changing the MSHRs in the caches to never hold invalid entries. When an MSHR is filled, it is removed from the head of the list. When a packet is returned, its MSHR is promoted to a point where it follows all earlier returns, but precedes outstanding requests. I suppose this is an insertion sort optimized for the case where only one item is unsorted.

Thus, we perform an O(n) operation (on a smaller list) on a packet return and an O(1) operation on a packet fill, rather than an O(n log(n)) operation in both cases, and the operations appear to be faster in addition to being less complex.

I also updated the page table walker, which was modeled after the cache, to use the same technique, though it did not see enough traffic to incur a slowdown itself.