### PR TITLE
Changed ROB to be a champsim::circular_buffer

### DIFF
--- a/inc/block.h
+++ b/inc/block.h
@@ -147,7 +147,7 @@ struct LSQ_ENTRY {
              ip = 0,
              event_cycle = 0;
 
-    ooo_model_instr* rob_index = NULL;
+    champsim::circular_buffer<ooo_model_instr>::iterator rob_index;
 
     uint8_t translated = 0,
             fetched = 0,
@@ -162,26 +162,6 @@ class is_valid<LSQ_ENTRY>
         {
             return test.virtual_address != 0;
         }
-};
-
-// reorder buffer
-template <typename T>
-struct CORE_BUFFER {
-    const string NAME;
-    const uint32_t SIZE;
-    uint32_t head = 0, tail = 0, occupancy = 0;
-
-    T *entry;
-
-    // constructor
-    CORE_BUFFER(string v1, uint32_t v2) : NAME(v1), SIZE(v2) {
-        entry = new T[SIZE];
-    };
-
-    // destructor
-    ~CORE_BUFFER() {
-        delete[] entry;
-    };
 };
 
 #endif

--- a/inc/block.h
+++ b/inc/block.h
@@ -33,7 +33,8 @@ class PACKET {
              asid[2] = {std::numeric_limits<uint8_t>::max(), std::numeric_limits<uint8_t>::max()},
              type = 0;
 
-    std::list<LSQ_ENTRY*> lq_index_depend_on_me = {}, sq_index_depend_on_me = {};
+    std::list<std::vector<LSQ_ENTRY>::iterator> lq_index_depend_on_me = {};
+    std::list<std::vector<LSQ_ENTRY>::iterator> sq_index_depend_on_me = {};
     std::list<champsim::circular_buffer<ooo_model_instr>::iterator> instr_depend_on_me;
 
     uint32_t cpu = NUM_CPUS;

--- a/inc/instruction.h
+++ b/inc/instruction.h
@@ -92,7 +92,7 @@ struct ooo_model_instr {
     uint8_t source_registers[NUM_INSTR_SOURCES] = {}; // input registers 
 
     // these are indices of instructions in the ROB that depend on me
-    std::vector<ooo_model_instr*> registers_instrs_depend_on_me, memory_instrs_depend_on_me;
+    std::vector<champsim::circular_buffer<ooo_model_instr>::iterator> registers_instrs_depend_on_me, memory_instrs_depend_on_me;
 
     // memory addresses that may cause dependencies between instructions
     uint64_t instruction_pa = 0;

--- a/inc/instruction.h
+++ b/inc/instruction.h
@@ -1,10 +1,13 @@
 #ifndef INSTRUCTION_H
 #define INSTRUCTION_H
 
+#include <array>
 #include <cstdint>
 #include <iostream>
 #include <limits>
 #include <vector>
+
+#include "circular_buffer.hpp"
 
 // instruction format
 #define NUM_INSTR_DESTINATIONS_SPARC 4
@@ -96,7 +99,8 @@ struct ooo_model_instr {
     uint64_t destination_memory[NUM_INSTR_DESTINATIONS_SPARC] = {}; // output memory
     uint64_t source_memory[NUM_INSTR_SOURCES] = {}; // input memory
 
-    LSQ_ENTRY *lq_index[NUM_INSTR_SOURCES] = {}, *sq_index[NUM_INSTR_DESTINATIONS_SPARC] = {};
+    std::array<std::vector<LSQ_ENTRY>::iterator, NUM_INSTR_SOURCES> lq_index = {};
+    std::array<std::vector<LSQ_ENTRY>::iterator, NUM_INSTR_DESTINATIONS_SPARC> sq_index = {};
 
     ooo_model_instr() = default;
 

--- a/inc/ooo_cpu.h
+++ b/inc/ooo_cpu.h
@@ -64,7 +64,8 @@ class O3_CPU {
     champsim::delay_queue<ooo_model_instr> DISPATCH_BUFFER{DISPATCH_BUFFER_SIZE, DISPATCH_LATENCY};
     champsim::delay_queue<ooo_model_instr> DECODE_BUFFER{DECODE_BUFFER_SIZE, DECODE_LATENCY};
     CORE_BUFFER<ooo_model_instr> ROB{"ROB", ROB_SIZE};
-    CORE_BUFFER<LSQ_ENTRY> LQ{"LQ", LQ_SIZE}, SQ{"SQ", SQ_SIZE};
+    std::vector<LSQ_ENTRY> LQ{LQ_SIZE};
+    std::vector<LSQ_ENTRY> SQ{SQ_SIZE};
 
     // store array, this structure is required to properly handle store instructions
     uint64_t STA[STA_SIZE], STA_head = 0, STA_tail = 0;
@@ -73,10 +74,10 @@ class O3_CPU {
     std::queue<ooo_model_instr*> ready_to_execute;
 
     // Ready-To-Load
-    std::queue<LSQ_ENTRY*> RTL0, RTL1;
+    std::queue<std::vector<LSQ_ENTRY>::iterator> RTL0, RTL1;
 
     // Ready-To-Store
-    std::queue<LSQ_ENTRY*> RTS0, RTS1;
+    std::queue<std::vector<LSQ_ENTRY>::iterator> RTS0, RTS1;
 
     // branch
     int branch_mispredict_stall_fetch = 0; // flag that says that we should stall because a branch prediction was wrong
@@ -200,11 +201,11 @@ class O3_CPU {
 
     void initialize_core();
     void add_load_queue(uint32_t rob_index, uint32_t data_index),
-         add_store_queue(uint32_t rob_index, uint32_t data_index),
-         execute_store(LSQ_ENTRY *sq_it);
-    int  execute_load(LSQ_ENTRY *lq_it);
-    int  do_translate_store(LSQ_ENTRY *sq_it);
-    int  do_translate_load(LSQ_ENTRY *lq_it);
+         add_store_queue(uint32_t rob_index, uint32_t data_index);
+    void execute_store(std::vector<LSQ_ENTRY>::iterator sq_it);
+    int  execute_load(std::vector<LSQ_ENTRY>::iterator lq_it);
+    int  do_translate_store(std::vector<LSQ_ENTRY>::iterator sq_it);
+    int  do_translate_load(std::vector<LSQ_ENTRY>::iterator sq_it);
     void check_dependency(int prior, int current);
     void operate_cache();
     void complete_inflight_instruction();

--- a/src/main.cc
+++ b/src/main.cc
@@ -246,13 +246,14 @@ void finish_warmup()
 
 void print_deadlock(uint32_t i)
 {
-    cout << "DEADLOCK! CPU " << i << " instr_id: " << ooo_cpu[i].ROB.entry[ooo_cpu[i].ROB.head].instr_id;
-    cout << " translated: " << +ooo_cpu[i].ROB.entry[ooo_cpu[i].ROB.head].translated;
-    cout << " fetched: " << +ooo_cpu[i].ROB.entry[ooo_cpu[i].ROB.head].fetched;
-    cout << " scheduled: " << +ooo_cpu[i].ROB.entry[ooo_cpu[i].ROB.head].scheduled;
-    cout << " executed: " << +ooo_cpu[i].ROB.entry[ooo_cpu[i].ROB.head].executed;
-    cout << " is_memory: " << +ooo_cpu[i].ROB.entry[ooo_cpu[i].ROB.head].is_memory;
-    cout << " event: " << ooo_cpu[i].ROB.entry[ooo_cpu[i].ROB.head].event_cycle;
+    cout << "DEADLOCK! CPU " << i << " instr_id: " << ooo_cpu[i].ROB.front().instr_id;
+    cout << " translated: " << +ooo_cpu[i].ROB.front().translated;
+    cout << " fetched: " << +ooo_cpu[i].ROB.front().fetched;
+    cout << " scheduled: " << +ooo_cpu[i].ROB.front().scheduled;
+    cout << " executed: " << +ooo_cpu[i].ROB.front().executed;
+    cout << " is_memory: " << +ooo_cpu[i].ROB.front().is_memory;
+    cout << " num_reg_dependent: " << +ooo_cpu[i].ROB.front().num_reg_dependent;
+    cout << " event: " << ooo_cpu[i].ROB.front().event_cycle;
     cout << " current: " << current_core_cycle[i] << endl;
 
     // print LQ entry
@@ -540,7 +541,7 @@ int main(int argc, char** argv)
             }
 
             // check for deadlock
-            if (ooo_cpu[i].ROB.entry[ooo_cpu[i].ROB.head].ip && (ooo_cpu[i].ROB.entry[ooo_cpu[i].ROB.head].event_cycle + DEADLOCK_CYCLE) <= current_core_cycle[i])
+            if (!ooo_cpu[i].ROB.empty() && (ooo_cpu[i].ROB.front().event_cycle + DEADLOCK_CYCLE) <= current_core_cycle[i])
                 print_deadlock(i);
 
             // check for warmup

--- a/src/main.cc
+++ b/src/main.cc
@@ -258,13 +258,13 @@ void print_deadlock(uint32_t i)
     // print LQ entry
     cout << endl << "Load Queue Entry" << endl;
     for (uint32_t j=0; j<LQ_SIZE; j++) {
-        cout << "[LQ] entry: " << j << " instr_id: " << ooo_cpu[i].LQ.entry[j].instr_id << " address: " << hex << ooo_cpu[i].LQ.entry[j].physical_address << dec << " translated: " << +ooo_cpu[i].LQ.entry[j].translated << " fetched: " << +ooo_cpu[i].LQ.entry[i].fetched << endl;
+        cout << "[LQ] entry: " << j << " instr_id: " << ooo_cpu[i].LQ[j].instr_id << " address: " << hex << ooo_cpu[i].LQ[j].physical_address << dec << " translated: " << +ooo_cpu[i].LQ[j].translated << " fetched: " << +ooo_cpu[i].LQ[i].fetched << endl;
     }
 
     // print SQ entry
     cout << endl << "Store Queue Entry" << endl;
     for (uint32_t j=0; j<SQ_SIZE; j++) {
-        cout << "[SQ] entry: " << j << " instr_id: " << ooo_cpu[i].SQ.entry[j].instr_id << " address: " << hex << ooo_cpu[i].SQ.entry[j].physical_address << dec << " translated: " << +ooo_cpu[i].SQ.entry[j].translated << " fetched: " << +ooo_cpu[i].SQ.entry[i].fetched << endl;
+        cout << "[SQ] entry: " << j << " instr_id: " << ooo_cpu[i].SQ[j].instr_id << " address: " << hex << ooo_cpu[i].SQ[j].physical_address << dec << " translated: " << +ooo_cpu[i].SQ[j].translated << " fetched: " << +ooo_cpu[i].SQ[i].fetched << endl;
     }
 
     // print L1D MSHR entry

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -589,7 +589,7 @@ void O3_CPU::do_scheduling(champsim::circular_buffer<ooo_model_instr>::iterator 
         if (src_reg) {
             champsim::circular_buffer<ooo_model_instr>::reverse_iterator prior{rob_it};
             prior = std::find_if(prior, ROB.rend(), instr_reg_will_produce(src_reg));
-            if (prior != ROB.rend())
+            if (prior != ROB.rend() && (prior->registers_instrs_depend_on_me.empty() || prior->registers_instrs_depend_on_me.back() != rob_it))
             {
                 prior->registers_instrs_depend_on_me.push_back(rob_it);
                 rob_it->num_reg_dependent++;


### PR DESCRIPTION
This patch spells the demise of the `CORE_BUFFER` class.

I've been meaning to get around to this for a while now, but here it is. This patch converts the ROB to use the `circular_buffer` class, where it can use proper iterators and algorithms. The place where this is most evident is in the `O3_CPU::do_scheduling()` and `O3_CPU::add_load_queue()` functions, where dependency resolution is now a reverse iteration given a functor. This improves readability and actually gives some speed improvement in my tests.