### PR TITLE
PTE/VMEM refactor to support large pages

### DIFF
--- a/champsim_config.json
+++ b/champsim_config.json
@@ -50,6 +50,7 @@
         "max_write": 2,
         "prefetch_as_load": false,
         "virtual_prefetch": true,
+        "prefetch_activate": "LOAD,PREFETCH",
         "prefetcher": "no_l1i"
     },
 
@@ -65,6 +66,7 @@
         "max_write": 2,
         "prefetch_as_load": false,
         "virtual_prefetch": false,
+        "prefetch_activate": "LOAD,PREFETCH",
         "prefetcher": "no_l1d"
     },
 
@@ -80,6 +82,7 @@
         "max_write": 1,
         "prefetch_as_load": false,
         "virtual_prefetch": false,
+        "prefetch_activate": "LOAD,PREFETCH",
         "prefetcher": "no_l2c"
     },
 
@@ -150,6 +153,7 @@
         "max_write": 1,
         "prefetch_as_load": false,
         "virtual_prefetch": false,
+        "prefetch_activate": "LOAD,PREFETCH",
         "prefetcher": "no_llc",
         "replacement": "lru_llc"
     },

--- a/champsim_config.json
+++ b/champsim_config.json
@@ -177,6 +177,7 @@
 
     "virtual_memory": {
         "size": 8589934592,
-        "num_levels": 5
+        "num_levels": 5,
+        "minor_fault_penalty": 200
     }
 }

--- a/config.sh
+++ b/config.sh
@@ -29,12 +29,12 @@ config_cache_name = '.champsimconfig_cache'
 
 llc_fmtstr = 'CACHE {name}("{name}", {attrs[frequency]}, {attrs[sets]}, {attrs[ways]}, {attrs[wq_size]}, {attrs[rq_size]}, {attrs[pq_size]}, {attrs[mshr_size]}, {attrs[hit_latency]}, {attrs[fill_latency]}, {attrs[max_read]}, {attrs[max_write]}, {attrs[prefetch_as_load]:b}, {attrs[virtual_prefetch]:b}, {attrs[prefetch_activate_mask]}, {ll});\n'
 cache_fmtstr = 'CACHE cpu{cpu}{name}("{name}", {attrs[frequency]}, {attrs[sets]}, {attrs[ways]}, {attrs[wq_size]}, {attrs[rq_size]}, {attrs[pq_size]}, {attrs[mshr_size]}, {attrs[hit_latency]}, {attrs[fill_latency]}, {attrs[max_read]}, {attrs[max_write]}, {attrs[prefetch_as_load]:b}, {attrs[virtual_prefetch]:b}, {attrs[prefetch_activate_mask]}, {ll});\n'
-ptw_fmtstr = 'PageTableWalker {name}("{name}", {pscl5_set}, {pscl5_way}, {pscl4_set}, {pscl4_way}, {pscl3_set}, {pscl3_way}, {pscl2_set}, {pscl2_way}, {ptw_rq_size}, {ptw_mshr_size}, {ptw_max_read}, {ptw_max_write}, {lower_level});\n'
+ptw_fmtstr = 'PageTableWalker {name}("{name}", {cpu}, {pscl5_set}, {pscl5_way}, {pscl4_set}, {pscl4_way}, {pscl3_set}, {pscl3_way}, {pscl2_set}, {pscl2_way}, {ptw_rq_size}, {ptw_mshr_size}, {ptw_max_read}, {ptw_max_write}, 0, {lower_level});\n'
 
 cpu_fmtstr = 'O3_CPU cpu{cpu}_inst({cpu}, {attrs[frequency]}, {attrs[DIB][sets]}, {attrs[DIB][ways]}, {attrs[DIB][window_size]}, {attrs[ifetch_buffer_size]}, {attrs[dispatch_buffer_size]}, {attrs[decode_buffer_size]}, {attrs[rob_size]}, {attrs[lq_size]}, {attrs[sq_size]}, {attrs[fetch_width]}, {attrs[decode_width]}, {attrs[dispatch_width]}, {attrs[scheduler_size]}, {attrs[execute_width]}, {attrs[lq_width]}, {attrs[sq_width]}, {attrs[retire_width]}, {attrs[mispredict_penalty]}, {attrs[decode_latency]}, {attrs[dispatch_latency]}, {attrs[schedule_latency]}, {attrs[execute_latency]}, &cpu{cpu}ITLB, &cpu{cpu}DTLB, &cpu{cpu}L1I, &cpu{cpu}L1D, &cpu{cpu}PTW);\n'
 
 pmem_fmtstr = 'MEMORY_CONTROLLER DRAM({attrs[frequency]});\n'
-vmem_fmtstr = 'VirtualMemory vmem(NUM_CPUS, {attrs[size]}, PAGE_SIZE, {attrs[num_levels]}, 1);\n'
+vmem_fmtstr = 'VirtualMemory vmem({attrs[size]}, 1 << 12, {attrs[num_levels]}, 1);\n'
 
 module_make_fmtstr = '{1}/%.o: CFLAGS += -I{1}\n{1}/%.o: CXXFLAGS += -I{1}\nobj/{0}: $(patsubst %.cc,%.o,$(wildcard {1}/*.cc)) $(patsubst %.c,%.o,$(wildcard {1}/*.c))\n\t@mkdir -p $(dir $@)\n\tar -rcs $@ $^\n\n'
 
@@ -112,7 +112,10 @@ for i in range(len(config_file['ooo_cpu'])):
     config_file['ooo_cpu'][i]['DTLB'] = merge_dicts(default_dtlb, config_file.get('DTLB', {}), config_file['ooo_cpu'][i].get('DTLB',{}))
     config_file['ooo_cpu'][i]['STLB'] = merge_dicts(default_stlb, config_file.get('STLB', {}), config_file['ooo_cpu'][i].get('STLB',{}))
     config_file['ooo_cpu'][i]['PTW'] = merge_dicts(default_ptw, config_file.get('PTW', {}), config_file['ooo_cpu'][i].get('PTW',{}))
-    
+
+# Associate PTW with core
+for i in range(len(config_file['ooo_cpu'])):
+    config_file['ooo_cpu'][i]['PTW']['cpu'] = i
 
 # LLC operates at maximum freqency of cores, if not already specified
 config_file['LLC'] = merge_dicts(default_llc, {'frequency': max(cpu['frequency'] for cpu in config_file['ooo_cpu'])}, config_file.get('LLC',{}))

--- a/config.sh
+++ b/config.sh
@@ -34,7 +34,7 @@ ptw_fmtstr = 'PageTableWalker {name}("{name}", {cpu}, {pscl5_set}, {pscl5_way}, 
 cpu_fmtstr = 'O3_CPU cpu{cpu}_inst({cpu}, {attrs[frequency]}, {attrs[DIB][sets]}, {attrs[DIB][ways]}, {attrs[DIB][window_size]}, {attrs[ifetch_buffer_size]}, {attrs[dispatch_buffer_size]}, {attrs[decode_buffer_size]}, {attrs[rob_size]}, {attrs[lq_size]}, {attrs[sq_size]}, {attrs[fetch_width]}, {attrs[decode_width]}, {attrs[dispatch_width]}, {attrs[scheduler_size]}, {attrs[execute_width]}, {attrs[lq_width]}, {attrs[sq_width]}, {attrs[retire_width]}, {attrs[mispredict_penalty]}, {attrs[decode_latency]}, {attrs[dispatch_latency]}, {attrs[schedule_latency]}, {attrs[execute_latency]}, &cpu{cpu}ITLB, &cpu{cpu}DTLB, &cpu{cpu}L1I, &cpu{cpu}L1D, &cpu{cpu}PTW);\n'
 
 pmem_fmtstr = 'MEMORY_CONTROLLER DRAM({attrs[frequency]});\n'
-vmem_fmtstr = 'VirtualMemory vmem({attrs[size]}, 1 << 12, {attrs[num_levels]}, 1);\n'
+vmem_fmtstr = 'VirtualMemory vmem({attrs[size]}, 1 << 12, {attrs[num_levels]}, 1, {attrs[minor_fault_penalty]});\n'
 
 module_make_fmtstr = '{1}/%.o: CFLAGS += -I{1}\n{1}/%.o: CXXFLAGS += -I{1}\nobj/{0}: $(patsubst %.cc,%.o,$(wildcard {1}/*.cc)) $(patsubst %.c,%.o,$(wildcard {1}/*.c))\n\t@mkdir -p $(dir $@)\n\tar -rcs $@ $^\n\n'
 
@@ -86,7 +86,7 @@ default_dtlb = { 'sets': 16, 'ways': 4, 'rq_size': 16, 'wq_size': 16, 'pq_size':
 default_stlb = { 'sets': 128, 'ways': 12, 'rq_size': 32, 'wq_size': 32, 'pq_size': 0, 'mshr_size': 16, 'latency': 8, 'fill_latency': 1, 'max_read': 1, 'max_write': 1, 'prefetch_as_load': False, 'virtual_prefetch': False, 'prefetch_activate': 'LOAD,PREFETCH' }
 default_llc  = { 'sets': 2048*config_file['num_cores'], 'ways': 16, 'rq_size': 32*config_file['num_cores'], 'wq_size': 32*config_file['num_cores'], 'pq_size': 32*config_file['num_cores'], 'mshr_size': 64*config_file['num_cores'], 'latency': 20, 'fill_latency': 1, 'max_read': config_file['num_cores'], 'max_write': config_file['num_cores'], 'prefetch_as_load': False, 'virtual_prefetch': False, 'prefetch_activate': 'LOAD,PREFETCH', 'prefetcher': 'no_llc', 'replacement': 'lru_llc' }
 default_pmem = { 'frequency': 3200, 'channels': 1, 'ranks': 1, 'banks': 8, 'rows': 65536, 'columns': 128, 'row_size': 8, 'channel_width': 8, 'wq_size': 64, 'rq_size': 64, 'tRP': 12.5, 'tRCD': 12.5, 'tCAS': 12.5, 'turn_around_time': 7.5 }
-default_vmem = { 'size': 8589934592, 'num_levels': 5 }
+default_vmem = { 'size': 8589934592, 'num_levels': 5, 'minor_fault_penalty': 200 }
 default_ptw = { 'pscl5_set' : 1, 'pscl5_way' : 2, 'pscl4_set' : 1, 'pscl4_way': 4, 'pscl3_set' : 2, 'pscl3_way' : 4, 'pscl2_set' : 4, 'pscl2_way': 8, 'ptw_rq_size': 16, 'ptw_mshr_size': 5, 'ptw_max_read': 2, 'ptw_max_write': 2}
 ###
 # Ensure directories are present

--- a/inc/cache.h
+++ b/inc/cache.h
@@ -40,6 +40,7 @@ class CACHE : public champsim::operable, public MemoryRequestConsumer, public Me
     uint8_t cache_type;
     const bool prefetch_as_load;
     const bool virtual_prefetch;
+    const unsigned pref_activate_mask = (1 << static_cast<int>(LOAD)) | (1 << static_cast<int>(PREFETCH));
 
     // prefetch stats
     uint64_t pf_requested = 0,
@@ -81,9 +82,10 @@ class CACHE : public champsim::operable, public MemoryRequestConsumer, public Me
     
     // constructor
   CACHE(std::string v1, double freq_scale, uint32_t v2, int v3, uint32_t v5, uint32_t v6, uint32_t v7, uint32_t v8,
-            uint32_t hit_lat, uint32_t fill_lat, uint32_t max_read, uint32_t max_write, bool pref_load, bool va_pref, MemoryRequestConsumer *ll)
+            uint32_t hit_lat, uint32_t fill_lat, uint32_t max_read, uint32_t max_write, bool pref_load, bool va_pref, unsigned pref_act_mask, MemoryRequestConsumer *ll)
         : champsim::operable(freq_scale), MemoryRequestProducer(ll), NAME(v1), NUM_SET(v2), NUM_WAY(v3), WQ_SIZE(v5), RQ_SIZE(v6), PQ_SIZE(v7), MSHR_SIZE(v8),
-        HIT_LATENCY(hit_lat), FILL_LATENCY(fill_lat), MAX_READ(max_read), MAX_WRITE(max_write), prefetch_as_load(pref_load), virtual_prefetch(va_pref)
+        HIT_LATENCY(hit_lat), FILL_LATENCY(fill_lat), MAX_READ(max_read), MAX_WRITE(max_write), prefetch_as_load(pref_load), virtual_prefetch(va_pref),
+        pref_activate_mask(pref_act_mask)
     {
     }
 
@@ -118,6 +120,8 @@ class CACHE : public champsim::operable, public MemoryRequestConsumer, public Me
     void readlike_hit(std::size_t set, std::size_t way, PACKET &handle_pkt);
     bool readlike_miss(PACKET &handle_pkt);
     bool filllike_miss(std::size_t set, std::size_t way, PACKET &handle_pkt);
+
+    bool should_activate_prefetcher(int type);
 
     void prefetcher_operate    (uint64_t v_addr, uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type),
          (*l1i_prefetcher_cache_operate)(uint32_t, uint64_t, uint8_t, uint8_t),

--- a/inc/circular_buffer.hpp
+++ b/inc/circular_buffer.hpp
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <iostream>
 #include <iterator>
+#include <limits>
 #include <type_traits>
 #include <vector>
 

--- a/inc/ooo_cpu.h
+++ b/inc/ooo_cpu.h
@@ -87,8 +87,8 @@ class O3_CPU : public champsim::operable {
     uint64_t branch_type_misses[8] = {};
 
     CacheBus ITLB_bus, DTLB_bus, L1I_bus, L1D_bus;
-  
-	PageTableWalker *PTW;
+
+    PageTableWalker *PTW;
 
     // constructor
     O3_CPU(uint32_t cpu, double freq_scale, std::size_t dib_set, std::size_t dib_way, std::size_t dib_window,
@@ -122,9 +122,6 @@ class O3_CPU : public champsim::operable {
         static_cast<CACHE*>(dtlb->lower_level)->cpu = this->cpu;
         static_cast<CACHE*>(dtlb->lower_level)->cache_type = IS_STLB;
         static_cast<CACHE*>(dtlb->lower_level)->fill_level = FILL_L2;
-
-        ptw->cpu = this->cpu;
-        ptw->cache_type = IS_PTW;
 
         // PRIVATE CACHE
         l1i->cpu = this->cpu;

--- a/inc/ptw.h
+++ b/inc/ptw.h
@@ -2,146 +2,65 @@
 #define PTW_H
 
 #include <map>
-
-#define IS_PSCL5 11
-#define IS_PSCL4 12
-#define IS_PSCL3 13
-#define IS_PSCL2 14
-
-#define NUM_ENTRIES_PER_PAGE 512
-
-#define IS_PTL1 1
-#define IS_PTL2 2
-#define IS_PTL3 3
-#define IS_PTL4 4
-#define IS_PTL5 5
-
-//Virtual Address: 57 bit (9+9+9+9+9+12), rest MSB bits will be used to generate a unique VA per CPU.
-//PTL5->PTL4->PTL3->PTL2->PTL1->PFN
-
-class PageTablePage
-{
-	public:
-		PageTablePage* entry[NUM_ENTRIES_PER_PAGE];
-		uint64_t next_level_base_addr[NUM_ENTRIES_PER_PAGE];
-
-	PageTablePage()
-	{
-		for(int i = 0; i < NUM_ENTRIES_PER_PAGE; i++)
-		{
-			entry[i] = NULL;
-			next_level_base_addr[i] = UINT64_MAX;
-		}
-	}
-
-	~PageTablePage()
-	{
-		for(int i = 0; i < NUM_ENTRIES_PER_PAGE; i++)
-		{
-			if(entry[i] != NULL)
-				delete(entry[i]);
-		}
-	}
-};
+#include <optional>
 
 class PagingStructureCache
 {
-	public:
-		const string NAME;
-		const uint32_t NUM_SET, NUM_WAY;
-		std::vector<BLOCK> block{NUM_SET*NUM_WAY};
-		uint8_t cache_type;
+    struct block_t
+    {
+        bool valid = false;
+        uint64_t address;
+        uint64_t data;
+        uint32_t lru = std::numeric_limits<uint32_t>::max() >> 1;
+    };
 
-		PagingStructureCache(string v1, uint8_t v2, uint32_t v3, uint32_t v4) : NAME(v1), NUM_SET(v3), NUM_WAY(v4), cache_type(v2) {}
+    const string NAME;
+    const uint32_t NUM_SET, NUM_WAY;
+    std::vector<block_t> block{NUM_SET*NUM_WAY};
 
-		uint32_t get_set(uint64_t address);
-		uint64_t get_index(uint64_t address);
-		uint64_t check_hit(uint64_t address);
-		void fill_cache(uint64_t next_level_base_addr, PACKET *packet);
+    public:
+        const std::size_t level;
+        PagingStructureCache(string v1, uint8_t v2, uint32_t v3, uint32_t v4) : NAME(v1), NUM_SET(v3), NUM_WAY(v4), level(v2) {}
+
+        std::optional<uint64_t> check_hit(uint64_t address);
+        void fill_cache(uint64_t next_level_paddr, uint64_t vaddr);
 };
 
 class PageTableWalker : public champsim::operable, public MemoryRequestConsumer, public MemoryRequestProducer
 {
-	public:
-		const string NAME;
-		uint32_t cpu;
-		uint8_t cache_type;
+    public:
+        const string NAME;
+        const uint32_t cpu;
+        const uint32_t MSHR_SIZE, MAX_READ, MAX_FILL;
 
-		uint8_t LATENCY = 0;
+        champsim::delay_queue<PACKET> RQ;
 
-		const uint32_t VAL_PSCL5_SET, VAL_PSCL5_WAY, VAL_PSCL4_SET, VAL_PSCL4_WAY, VAL_PSCL3_SET, VAL_PSCL3_WAY, VAL_PSCL2_SET, VAL_PSCL2_WAY;
+        std::list<PACKET> MSHR;
 
-		const uint32_t RQ_SIZE, WQ_SIZE = 0, PQ_SIZE = 0, MSHR_SIZE, MAX_READ, MAX_FILL;
-		
-		uint64_t next_translation_virtual_address = 0xf000000f00000000;
+        uint64_t total_miss_latency = 0;
 
-		champsim::delay_queue<PACKET> RQ{RQ_SIZE, LATENCY},
-									  WQ{WQ_SIZE, LATENCY},
-									  PQ{PQ_SIZE, LATENCY};
+        PagingStructureCache PSCL5, PSCL4, PSCL3, PSCL2;
 
-		std::list<PACKET> MSHR;
+        const uint64_t CR3_addr;
+        std::map<std::pair<uint64_t, std::size_t>, uint64_t> page_table;
 
-    uint64_t RQ_ACCESS = 0,
-             RQ_MERGED = 0,
-             RQ_FULL = 0,
-             RQ_TO_CACHE = 0,
-             PQ_ACCESS = 0,
-             PQ_MERGED = 0,
-             PQ_FULL = 0,
-             PQ_TO_CACHE = 0,
-             WQ_ACCESS = 0,
-             WQ_MERGED = 0,
-             WQ_FULL = 0,
-             WQ_FORWARD = 0,
-             WQ_TO_CACHE = 0;
+        PageTableWalker(string v1, uint32_t cpu, uint32_t v2, uint32_t v3, uint32_t v4, uint32_t v5, uint32_t v6, uint32_t v7, uint32_t v8, uint32_t v9, uint32_t v10, uint32_t v11, uint32_t v12, uint32_t v13, unsigned latency, MemoryRequestConsumer* ll);
 
-    uint64_t total_miss_latency = 0;
-  
+        // functions
+        int add_rq(PACKET *packet);
+        int add_wq(PACKET *packet) { assert(0); }
+        int add_pq(PACKET *packet) { assert(0); }
 
-	PagingStructureCache PSCL5{"PSCL5", IS_PSCL5, VAL_PSCL5_SET, VAL_PSCL5_WAY}, //Translation from L5->L4
-          PSCL4{"PSCL4", IS_PSCL4, VAL_PSCL4_SET, VAL_PSCL4_WAY}, //Translation from L5->L3
-          PSCL3{"PSCL3", IS_PSCL3, VAL_PSCL3_SET, VAL_PSCL3_WAY}, //Translation from L5->L2
-          PSCL2{"PSCL2", IS_PSCL2, VAL_PSCL2_SET, VAL_PSCL2_WAY}; //Translation from L5->L1
+        void return_data(PACKET *packet),
+             operate();
 
-    PageTablePage *L5; //CR3 register points to the base of this page.
-    uint64_t CR3_addr; //This address will not have page offset bits.
+        void handle_read(), handle_fill();
+        void increment_WQ_FULL(uint64_t address) {}
 
-	PageTableWalker(string v1, uint32_t v2, uint32_t v3, uint32_t v4, uint32_t v5, uint32_t v6, uint32_t v7, uint32_t v8, uint32_t v9, uint32_t v10, uint32_t v11, uint32_t v12, uint32_t v13, MemoryRequestConsumer* ll) : champsim::operable(1), MemoryRequestProducer(ll), NAME(v1), VAL_PSCL5_SET(v2), VAL_PSCL5_WAY(v3),  VAL_PSCL4_SET(v4), VAL_PSCL4_WAY(v5), VAL_PSCL3_SET(v6), VAL_PSCL3_WAY(v7), VAL_PSCL2_SET(v8), VAL_PSCL2_WAY(v9), RQ_SIZE(v10), MSHR_SIZE(v11), MAX_READ(v12), MAX_FILL(v13) 
-	{
-		CR3_addr = map_translation_page(0,0);
-		L5 = new PageTablePage();
-	}
+        uint32_t get_occupancy(uint8_t queue_type, uint64_t address),
+                 get_size(uint8_t queue_type, uint64_t address);
 
-	~PageTableWalker()
-	{
-		if(L5 != NULL)
-			delete L5;
-	}
-
-	// functions
-    int  add_rq(PACKET *packet),
-         add_wq(PACKET *packet),
-         add_pq(PACKET *packet);
-
-    void return_data(PACKET *packet),
-         operate(),
-         increment_WQ_FULL(uint64_t address),
-         add_mshr(PACKET *packet);
-
-	void handle_read(),
-		 handle_fill();
-
-    uint32_t get_occupancy(uint8_t queue_type, uint64_t address),
-             get_size(uint8_t queue_type, uint64_t address);
-
-    uint64_t get_index(uint64_t address, uint8_t cache_type),
-             get_offset(uint64_t address, uint8_t pt_level);
-	void     handle_page_fault(PageTablePage* page, PACKET *packet, uint8_t pt_level);
-
-    uint64_t map_translation_page(uint64_t full_virtual_address, uint8_t level),
-         map_data_page(uint64_t instr_id, uint64_t full_virtual_address);
-
-    void write_translation_page(uint64_t next_level_base_addr, PACKET *packet, uint8_t pt_level);
+        uint64_t get_shamt(uint8_t pt_level);
 };
 
-#endif	
+#endif

--- a/inc/vmem.h
+++ b/inc/vmem.h
@@ -1,7 +1,7 @@
 #ifndef VMEM_H
 #define VMEM_H
 
-#include <iostream>
+#include <cstdint>
 #include <deque>
 #include <map>
 
@@ -9,29 +9,32 @@
 // reserve 1MB of space
 #define VMEM_RESERVE_CAPACITY 1048576
 
+#define PTE_BYTES 8
+
+//Virtual Address: 57 bit (9+9+9+9+9+12), rest MSB bits will be used to generate a unique VA per CPU.
+//PTL5->PTL4->PTL3->PTL2->PTL1->PFN
+
+constexpr uint64_t MINOR_FAULT_PENALTY = 200;
+
 class VirtualMemory
 {
- private:
-  uint32_t num_cpus;
-  uint32_t page_size;
-  uint32_t log2_page_size;
-  uint64_t num_ppages;
-  std::deque<uint64_t> ppage_free_list;
-  uint64_t get_next_free_ppage();
+    private:
+        std::map<std::pair<uint32_t, uint64_t>, uint64_t> vpage_to_ppage_map;
+        std::map<std::tuple<uint32_t, uint64_t, uint32_t>, uint64_t> page_table;
 
-  std::map<uint64_t, uint64_t>* vpage_to_ppage_map;
-  
-  uint32_t pt_levels;
-  std::map<uint64_t, uint64_t>** page_table;
-  
-  uint64_t rand_state;
-  uint64_t vmem_rand();
- public:
-  // capacity and pg_size are measured in bytes, and capacity must be a multiple of pg_size
-  VirtualMemory(uint32_t number_of_cpus, uint64_t capacity, uint64_t pg_size, uint32_t page_table_levels, uint64_t random_seed);
-  uint32_t get_paget_table_level_count();
-  uint64_t va_to_pa(uint32_t cpu_num, uint64_t vaddr);
-  uint64_t get_pte_pa(uint32_t cpu_num, uint64_t vaddr, uint32_t level);
+        uint64_t next_pte_page;
+
+    public:
+        const uint32_t pt_levels;
+        const uint32_t page_size; // Size of a PTE page
+        std::deque<uint64_t> ppage_free_list;
+
+        // capacity and pg_size are measured in bytes, and capacity must be a multiple of pg_size
+        VirtualMemory(uint64_t capacity, uint64_t pg_size, uint32_t page_table_levels, uint64_t random_seed);
+        uint64_t shamt(uint32_t level) const;
+        uint64_t get_offset(uint64_t vaddr, uint32_t level) const;
+        std::pair<uint64_t, bool> va_to_pa(uint32_t cpu_num, uint64_t vaddr);
+        std::pair<uint64_t, bool> get_pte_pa(uint32_t cpu_num, uint64_t vaddr, uint32_t level);
 };
 
 #endif

--- a/inc/vmem.h
+++ b/inc/vmem.h
@@ -10,8 +10,6 @@
 
 #define PTE_BYTES 8
 
-constexpr uint64_t MINOR_FAULT_PENALTY = 200;
-
 class VirtualMemory
 {
     private:
@@ -21,12 +19,13 @@ class VirtualMemory
         uint64_t next_pte_page;
 
     public:
+        const uint64_t minor_fault_penalty;
         const uint32_t pt_levels;
         const uint32_t page_size; // Size of a PTE page
         std::deque<uint64_t> ppage_free_list;
 
         // capacity and pg_size are measured in bytes, and capacity must be a multiple of pg_size
-        VirtualMemory(uint64_t capacity, uint64_t pg_size, uint32_t page_table_levels, uint64_t random_seed);
+        VirtualMemory(uint64_t capacity, uint64_t pg_size, uint32_t page_table_levels, uint64_t random_seed, uint64_t minor_fault_penalty);
         uint64_t shamt(uint32_t level) const;
         uint64_t get_offset(uint64_t vaddr, uint32_t level) const;
         std::pair<uint64_t, bool> va_to_pa(uint32_t cpu_num, uint64_t vaddr);

--- a/inc/vmem.h
+++ b/inc/vmem.h
@@ -5,14 +5,10 @@
 #include <deque>
 #include <map>
 
-#define VMEM_RAND_FACTOR 91827349653
 // reserve 1MB of space
 #define VMEM_RESERVE_CAPACITY 1048576
 
 #define PTE_BYTES 8
-
-//Virtual Address: 57 bit (9+9+9+9+9+12), rest MSB bits will be used to generate a unique VA per CPU.
-//PTL5->PTL4->PTL3->PTL2->PTL1->PFN
 
 constexpr uint64_t MINOR_FAULT_PENALTY = 200;
 

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -181,7 +181,7 @@ void CACHE::readlike_hit(std::size_t set, std::size_t way, PACKET &handle_pkt)
     handle_pkt.data = hit_block.data;
 
     // update prefetcher on load instruction
-    if (handle_pkt.type == LOAD || (handle_pkt.type == PREFETCH && handle_pkt.pf_origin_level < fill_level))
+    if (should_activate_prefetcher(handle_pkt.type) && handle_pkt.pf_origin_level < fill_level)
     {
         if(cache_type == IS_L1I)
             l1i_prefetcher_cache_operate(handle_pkt.cpu, virtual_prefetch ? handle_pkt.full_v_addr : handle_pkt.full_addr, 1, hit_block.prefetch);
@@ -275,7 +275,7 @@ bool CACHE::readlike_miss(PACKET &handle_pkt)
     }
 
     // update prefetcher on load instructions and prefetches from upper levels
-    if (handle_pkt.type == LOAD || (handle_pkt.type == PREFETCH && handle_pkt.pf_origin_level < fill_level))
+    if (should_activate_prefetcher(handle_pkt.type) && handle_pkt.pf_origin_level < fill_level)
     {
         if(cache_type == IS_L1I)
             l1i_prefetcher_cache_operate(handle_pkt.cpu, virtual_prefetch ? handle_pkt.full_v_addr : handle_pkt.full_addr, 0, 0);
@@ -739,5 +739,10 @@ uint32_t CACHE::get_size(uint8_t queue_type, uint64_t address)
         return PQ.size();
 
     return 0;
+}
+
+bool CACHE::should_activate_prefetcher(int type)
+{
+    return (1 << static_cast<int>(type)) & pref_activate_mask;
 }
 

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -608,7 +608,7 @@ void CACHE::va_translate_prefetches()
     // TEMPORARY SOLUTION: mark prefetches as translated after a fixed latency
     if (VAPQ.has_ready())
     {
-        VAPQ.front().full_addr = vmem.va_to_pa(cpu, VAPQ.front().full_v_addr);
+        VAPQ.front().full_addr = vmem.va_to_pa(cpu, VAPQ.front().full_v_addr).first;
         VAPQ.front().address   = VAPQ.front().full_addr >> LOG2_BLOCK_SIZE;
 
         // move the translated prefetch over to the regular PQ

--- a/src/main.cc
+++ b/src/main.cc
@@ -376,6 +376,12 @@ int main(int argc, char** argv)
     cout << "LLC ways: " << LLC.NUM_WAY << endl;
     std::cout << "Off-chip DRAM Size: " << (DRAM_CHANNELS*DRAM_RANKS*DRAM_BANKS*DRAM_ROWS*DRAM_ROW_SIZE/1024) << " MB Channels: " << DRAM_CHANNELS << " Width: " << 8*DRAM_CHANNEL_WIDTH << "-bit Data Rate: " << DRAM_IO_FREQ << " MT/s" << std::endl;
 
+
+    std::cout << std::endl;
+    std::cout << "VirtualMemory physical capacity: " << std::size(vmem.ppage_free_list) * vmem.page_size;
+    std::cout << " num_ppages: " << std::size(vmem.ppage_free_list) << std::endl;
+    std::cout << "VirtualMemory page size: " << PAGE_SIZE << " log2_page_size: " << LOG2_PAGE_SIZE << std::endl;
+
     // end consequence of knobs
 
     // search through the argv for "-traces"

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -1049,7 +1049,7 @@ void O3_CPU::handle_memory_return()
               {
                   it->translated = COMPLETED;
                   // recalculate a physical address for this cache line based on the translated physical page address
-                  it->instruction_pa = splice_bits(itlb_entry.data << LOG2_PAGE_SIZE, it->ip, LOG2_PAGE_SIZE);
+                  it->instruction_pa = splice_bits(itlb_entry.data, it->ip, LOG2_PAGE_SIZE);
               }
 
               available_fetch_bandwidth--;
@@ -1102,7 +1102,7 @@ void O3_CPU::handle_memory_return()
 
 	  for (auto sq_merged : dtlb_entry.sq_index_depend_on_me)
 	    {
-	      sq_merged->physical_address = splice_bits(dtlb_entry.data << LOG2_PAGE_SIZE, sq_merged->virtual_address, LOG2_PAGE_SIZE); // translated address
+	      sq_merged->physical_address = splice_bits(dtlb_entry.data, sq_merged->virtual_address, LOG2_PAGE_SIZE); // translated address
 	      sq_merged->translated = COMPLETED;
 	      sq_merged->event_cycle = current_cycle;
 
@@ -1111,7 +1111,7 @@ void O3_CPU::handle_memory_return()
 
 	  for (auto lq_merged : dtlb_entry.lq_index_depend_on_me)
 	    {
-	      lq_merged->physical_address = splice_bits(dtlb_entry.data << LOG2_PAGE_SIZE, lq_merged->virtual_address, LOG2_PAGE_SIZE); // translated address
+	      lq_merged->physical_address = splice_bits(dtlb_entry.data, lq_merged->virtual_address, LOG2_PAGE_SIZE); // translated address
 	      lq_merged->translated = COMPLETED;
 	      lq_merged->event_cycle = current_cycle;
 

--- a/src/ptw.cc
+++ b/src/ptw.cc
@@ -5,302 +5,183 @@
 
 extern VirtualMemory vmem;
 extern uint8_t  warmup_complete[NUM_CPUS];
-extern uint8_t knob_cloudsuite;
+
+PageTableWalker::PageTableWalker(string v1, uint32_t cpu, uint32_t v2, uint32_t v3, uint32_t v4, uint32_t v5, uint32_t v6, uint32_t v7, uint32_t v8, uint32_t v9, uint32_t v10, uint32_t v11, uint32_t v12, uint32_t v13, unsigned latency, MemoryRequestConsumer* ll)
+ : champsim::operable(1), MemoryRequestProducer(ll),
+    NAME(v1), cpu(cpu), MSHR_SIZE(v11), MAX_READ(v12), MAX_FILL(v13),
+    RQ{v10, latency},
+    PSCL5{"PSCL5", 4, v2, v3}, //Translation from L5->L4
+    PSCL4{"PSCL4", 3, v4, v5}, //Translation from L5->L3
+    PSCL3{"PSCL3", 2, v6, v7}, //Translation from L5->L2
+    PSCL2{"PSCL2", 1, v8, v9}, //Translation from L5->L1
+    CR3_addr(vmem.get_pte_pa(cpu, 0, vmem.pt_levels).first)
+{
+}
 
 void PageTableWalker::handle_read()
 {
-	int reads_this_cycle = MAX_READ;
+    int reads_this_cycle = MAX_READ;
 
-	while(reads_this_cycle > 0)
-	{
-        bool mshr_full = (MSHR.size() == MSHR_SIZE);
+    while (reads_this_cycle > 0 && RQ.has_ready() && std::size(MSHR) != MSHR_SIZE)
+    {
+        PACKET &handle_pkt = RQ.front();
 
-		if(!RQ.has_ready() || mshr_full || (((CACHE*)lower_level)->RQ.occupancy() == ((CACHE*)lower_level)->RQ.size())) //PTW lower level is L1D
-			break;
+        assert((handle_pkt.full_addr >> 32) != 0xf000000f); //Page table is stored at this address
+        assert(handle_pkt.full_v_addr != 0);
 
-			PACKET &handle_pkt = RQ.front();
-			
-			assert((handle_pkt.full_addr >> 32) != 0xf000000f); //Page table is stored at this address
-			assert(handle_pkt.full_v_addr != 0);
+        PACKET packet = handle_pkt;
+        packet.fill_level = FILL_L1; //This packet will be sent from L1 to PTW.
+        packet.cpu = cpu;
+        packet.type = TRANSLATION;
+        packet.instr_id = handle_pkt.instr_id;
+        packet.ip = handle_pkt.ip;
+        packet.full_v_addr = handle_pkt.full_addr;
+        packet.init_translation_level = vmem.pt_levels - 1;
+        packet.full_addr = splice_bits(CR3_addr, vmem.get_offset(handle_pkt.full_addr, vmem.pt_levels - 1) * PTE_BYTES, LOG2_PAGE_SIZE);
 
-			uint64_t address_pscl5 = PSCL5.check_hit(handle_pkt.full_addr);
-			uint64_t address_pscl4 = PSCL4.check_hit(handle_pkt.full_addr);
-			uint64_t address_pscl3 = PSCL3.check_hit(handle_pkt.full_addr);
-			uint64_t address_pscl2 = PSCL2.check_hit(handle_pkt.full_addr);
+        if (auto address_pscl5 = PSCL5.check_hit(handle_pkt.full_addr); address_pscl5.has_value())
+        {
+            packet.full_addr = address_pscl5.value();
+            packet.init_translation_level = PSCL5.level - 1;
+        }
 
+        if (auto address_pscl4 = PSCL4.check_hit(handle_pkt.full_addr); address_pscl4.has_value())
+        {
+            packet.full_addr = address_pscl4.value();
+            packet.init_translation_level = PSCL4.level - 1;
+        }
 
-			PACKET packet = handle_pkt;
+        if (auto address_pscl3 = PSCL3.check_hit(handle_pkt.full_addr); address_pscl3.has_value())
+        {
+            packet.full_addr = address_pscl3.value();
+            packet.init_translation_level = PSCL3.level - 1;
+        }
 
-            packet.fill_level = FILL_L1; //This packet will be sent from L1 to PTW.
-            packet.cpu = cpu;
-			packet.type = TRANSLATION;
-            packet.instr_id = handle_pkt.instr_id;
-            packet.ip = handle_pkt.ip;
-            packet.full_v_addr = handle_pkt.full_addr;
+        if (auto address_pscl2 = PSCL2.check_hit(handle_pkt.full_addr); address_pscl2.has_value())
+        {
+            packet.full_addr = address_pscl2.value();
+            packet.init_translation_level = PSCL2.level - 1;
+        }
 
-            uint64_t next_address = UINT64_MAX;
+        packet.translation_level = packet.init_translation_level;
+        packet.address = packet.full_addr >> LOG2_BLOCK_SIZE;
+        packet.to_return = {this};
 
-			if(address_pscl2 != UINT64_MAX)
-			{
-				next_address = address_pscl2 << LOG2_PAGE_SIZE | (get_offset(handle_pkt.full_addr,IS_PTL1) << 3);				
-            	packet.translation_level = 1;
-			}
-			else if(address_pscl3 != UINT64_MAX)
-			{
-				next_address = address_pscl3 << LOG2_PAGE_SIZE | (get_offset(handle_pkt.full_addr,IS_PTL2) << 3);				
-            	packet.translation_level = 2;
-            }
-			else if(address_pscl4 != UINT64_MAX)
-			{
-				next_address = address_pscl4 << LOG2_PAGE_SIZE | (get_offset(handle_pkt.full_addr,IS_PTL3) << 3);				
-            	packet.translation_level = 3;
-            }
-			else if(address_pscl5 != UINT64_MAX)
-			{
-				next_address = address_pscl5 << LOG2_PAGE_SIZE | (get_offset(handle_pkt.full_addr,IS_PTL4) << 3);				
-            	packet.translation_level = 4;
-            }
-            else
-            {
-            	next_address = CR3_addr << LOG2_PAGE_SIZE | (get_offset(handle_pkt.full_addr,IS_PTL5) << 3);				
-            	packet.translation_level = 5;
-            }
+        int rq_index = lower_level->add_rq(&packet);
+        if (rq_index == -2)
+            return;
 
-            packet.init_translation_level = packet.translation_level;
-			packet.address = next_address >> LOG2_BLOCK_SIZE;
-            packet.full_addr = next_address;
+        packet.to_return = handle_pkt.to_return; //Set the return for MSHR packet same as read packet.
+        packet.type = handle_pkt.type;
 
-			packet.to_return.clear();
-			packet.to_return = {this}; //Return this packet to PTW after completion.
+        auto it = MSHR.insert(std::end(MSHR), packet);
+        it->cycle_enqueued = current_cycle;
+        it->event_cycle = std::numeric_limits<uint64_t>::max();
 
-			int rq_index = lower_level->add_rq(&packet);
-		    assert(rq_index > -2);
-			
-			packet.to_return = handle_pkt.to_return; //Set the return for MSHR packet same as read packet.
-			packet.type = handle_pkt.type;
-
-            auto it = MSHR.insert(std::end(MSHR), packet);
-            it->cycle_enqueued = current_cycle;
-            it->event_cycle = std::numeric_limits<uint64_t>::max();
-
-		    RQ.pop_front();
-			reads_this_cycle--;
-	}
+        RQ.pop_front();
+        reads_this_cycle--;
+    }
 }
 
 void PageTableWalker::handle_fill()
 {
-	int fill_this_cycle = MAX_FILL;
+    int fill_this_cycle = MAX_FILL;
 
-	while(fill_this_cycle > 0) //Handle pending request
-	{
-		auto fill_mshr = MSHR.begin();
-		if (fill_mshr == std::end(MSHR) || (fill_mshr->event_cycle > current_cycle)) //Check if current level translation complete
-			break;
+    while (fill_this_cycle > 0 && !std::empty(MSHR) && MSHR.front().event_cycle <= current_cycle)
+    {
+        auto fill_mshr = MSHR.begin();
+        if (fill_mshr->translation_level == 0) //If translation complete
+        {
+            //Return the translated physical address to STLB. Does not contain last 12 bits
+            auto [addr, fault] = vmem.va_to_pa(cpu, fill_mshr->full_v_addr);
+            if (warmup_complete[cpu] && fault)
+            {
+                fill_mshr->event_cycle = current_cycle + MINOR_FAULT_PENALTY;
+                MSHR.sort(ord_event_cycle<PACKET>{});
+            }
+            else
+            {
+                fill_mshr->data      = addr;
+                fill_mshr->full_addr = fill_mshr->full_v_addr;
+                fill_mshr->address   = fill_mshr->full_addr >> LOG2_PAGE_SIZE;
 
-			assert(CR3_addr != UINT64_MAX);
-			PageTablePage* curr_page = L5; //Start wth the L5 page
-			uint64_t next_level_base_addr = UINT64_MAX;
-			bool page_fault = false;
+                for (auto ret: fill_mshr->to_return)
+                    ret->return_data(&(*fill_mshr));
 
-			for (int i = 5; i > fill_mshr->translation_level; i--)
-			{
-				uint64_t offset = get_offset(fill_mshr->full_v_addr, i); //Get offset according to page table level
-				assert(curr_page != NULL);
-				next_level_base_addr = curr_page->next_level_base_addr[offset];
-				if(next_level_base_addr == UINT64_MAX)
-				{
-					handle_page_fault(curr_page, &(*fill_mshr), i); //i means next level does not exist.
-					page_fault = true;
-					fill_mshr->translation_level = 0; //In page fault, All levels are translated.
-					break;
-				}
-				curr_page = curr_page->entry[offset];
-			}
-
-			if(fill_mshr->translation_level == 0) //If translation complete
-			{
-				curr_page = L5;
-				next_level_base_addr = UINT64_MAX;
-				for (int i = 5; i > 1; i--) //Walk the page table and fill MMU caches
-				{
-					uint64_t offset = get_offset(fill_mshr->full_v_addr, i);
-					assert(curr_page != NULL);
-					next_level_base_addr = curr_page->next_level_base_addr[offset];
-					assert(next_level_base_addr != UINT64_MAX);
-					curr_page = curr_page->entry[offset];
-
-					if(fill_mshr->init_translation_level - i >= 0) //Check which translation levels needs to filled
-					{
-						switch(i)
-						{
-							case 5: PSCL5.fill_cache(next_level_base_addr, &(*fill_mshr));
-									break;
-							case 4: PSCL4.fill_cache(next_level_base_addr, &(*fill_mshr));
-									break;
-							case 3: PSCL3.fill_cache(next_level_base_addr, &(*fill_mshr));
-									break;
-							case 2: PSCL2.fill_cache(next_level_base_addr, &(*fill_mshr));
-									break;
-						}
-					}
-				}
-
-				uint64_t offset = get_offset(fill_mshr->full_v_addr, IS_PTL1);
-				next_level_base_addr = curr_page->next_level_base_addr[offset];
-
-				fill_mshr->data = next_level_base_addr; //Return the translated physical address to STLB. Does not contain last 12 bits
-		
-				fill_mshr->full_addr = fill_mshr->full_v_addr;
-				fill_mshr->address = fill_mshr->full_addr >> LOG2_PAGE_SIZE;
-
-				for(auto ret: fill_mshr->to_return)
-					ret->return_data(&(*fill_mshr));
-
-				if(warmup_complete[cpu])
-			      {
-					uint64_t current_miss_latency = (current_cycle - fill_mshr->cycle_enqueued);	
-					total_miss_latency += current_miss_latency;
-			      }
+                if(warmup_complete[cpu])
+                    total_miss_latency += current_cycle - fill_mshr->cycle_enqueued;
 
                 MSHR.erase(fill_mshr);
-			}
-			else
-			{
-				assert(!page_fault); //If page fault was there, then all levels of translation should have be done.
+            }
+        }
+        else
+        {
+            auto [addr, fault] = vmem.get_pte_pa(cpu, fill_mshr->full_v_addr, fill_mshr->translation_level);
+            if (warmup_complete[cpu] && fault)
+            {
+                fill_mshr->event_cycle = current_cycle + MINOR_FAULT_PENALTY;
+                MSHR.sort(ord_event_cycle<PACKET>{});
+            }
+            else
+            {
+                if (fill_mshr->translation_level == PSCL5.level)
+                    PSCL5.fill_cache(addr, fill_mshr->full_v_addr);
+                if (fill_mshr->translation_level == PSCL4.level)
+                    PSCL4.fill_cache(addr, fill_mshr->full_v_addr);
+                if (fill_mshr->translation_level == PSCL2.level)
+                    PSCL3.fill_cache(addr, fill_mshr->full_v_addr);
+                if (fill_mshr->translation_level == PSCL2.level)
+                    PSCL2.fill_cache(addr, fill_mshr->full_v_addr);
 
-				if((((CACHE*)lower_level)->RQ.occupancy() < ((CACHE*)lower_level)->RQ.size())) //Lower level of PTW is L1D. If L1D RQ has space then send the next level of translation.
-				{
-					PACKET packet = *fill_mshr;
-					packet.cpu = cpu; 
-					packet.type = TRANSLATION;
-					packet.full_addr = next_level_base_addr << LOG2_PAGE_SIZE | (get_offset(fill_mshr->full_v_addr, fill_mshr->translation_level) << 3);
-					packet.address = packet.full_addr >> LOG2_BLOCK_SIZE;
-					
-					packet.to_return.clear();
-					packet.to_return = {this};					
+                PACKET packet = *fill_mshr;
+                packet.cpu = cpu;
+                packet.type = TRANSLATION;
+                packet.full_addr = addr;
+                packet.address = packet.full_addr >> LOG2_BLOCK_SIZE;
+                packet.to_return = {this};
+                packet.translation_level = fill_mshr->translation_level - 1;
 
+                int rq_index = lower_level->add_rq(&packet);
+                if (rq_index != -2)
+                {
                     fill_mshr->event_cycle = std::numeric_limits<uint64_t>::max();
-
-					int rq_index = lower_level->add_rq(&packet);
-					assert(rq_index > -2);
-
-					fill_mshr->address = packet.address;
-					fill_mshr->full_addr = packet.full_addr;
+                    fill_mshr->address = packet.address;
+                    fill_mshr->full_addr = packet.full_addr;
+                    fill_mshr->translation_level--;
 
                     MSHR.splice(std::end(MSHR), MSHR, fill_mshr);
-				}
-				else
-					RQ_FULL++;
-			}
+                }
+            }
+        }
 
-		fill_this_cycle--;
-	}
+        fill_this_cycle--;
+    }
 }
 
 void PageTableWalker::operate()
-{	
-	handle_fill();
-	handle_read();
+{
+    handle_fill();
+    handle_read();
     RQ.operate();
-}
-
-void PageTableWalker::handle_page_fault(PageTablePage* page, PACKET *packet, uint8_t pt_level)
-{
-	assert(pt_level <= 5);
-
-	while(pt_level > 1)
-	{
-		uint64_t offset = get_offset(packet->full_v_addr, pt_level);
-		
-		assert(page != NULL && page->entry[offset] == NULL);
-		
-		page->entry[offset] =  new PageTablePage();
-		page->next_level_base_addr[offset] = map_translation_page(packet->full_v_addr, pt_level);
-		write_translation_page(page->next_level_base_addr[offset], packet, pt_level);
-		page = page->entry[offset];
-		pt_level--;
-	}
-
-	uint64_t offset = get_offset(packet->full_v_addr, pt_level);
-		
-	assert(page != NULL && page->next_level_base_addr[offset] == UINT64_MAX);
-
-	page->next_level_base_addr[offset] = map_data_page(packet->instr_id, packet->full_v_addr);
-}
-
-uint64_t PageTableWalker::map_translation_page(uint64_t full_v_addr, uint8_t pt_level)
-{
-	uint64_t physical_address = vmem.va_to_pa(cpu, next_translation_virtual_address);
-	next_translation_virtual_address = ( (next_translation_virtual_address >> LOG2_PAGE_SIZE) + 1 ) << LOG2_PAGE_SIZE;
-	
-	return physical_address >> LOG2_PAGE_SIZE;
-}
-
-uint64_t PageTableWalker::map_data_page(uint64_t instr_id, uint64_t full_v_addr)
-{
-	uint64_t physical_address = vmem.va_to_pa(cpu, full_v_addr);
-    return physical_address >> LOG2_PAGE_SIZE;
-}
-
-void PageTableWalker::write_translation_page(uint64_t next_level_base_addr, PACKET *packet, uint8_t pt_level)
-{
-}
-
-uint64_t PageTableWalker::get_offset(uint64_t full_virtual_addr, uint8_t pt_level)
-{
-	full_virtual_addr = full_virtual_addr & ( (1L<<57) -1); //Extract Last 57 bits
-
-	int shift = 12;
-
-	switch(pt_level)
-	{
-		case IS_PTL5: shift+= 9+9+9+9;
-					   break;
-		case IS_PTL4: shift+= 9+9+9;
-					   break;
-		case IS_PTL3: shift+= 9+9;
-					   break;
-	   	case IS_PTL2: shift+= 9;
-	   				   break;
-	}
-
-	uint64_t offset = (full_virtual_addr >> shift) & 0x1ff; //Extract the offset to generate next physical address
-
-	return offset; 
 }
 
 int  PageTableWalker::add_rq(PACKET *packet)
 {
-	assert(packet->address != 0);
+    assert(packet->address != 0);
 
-	// check for duplicates in the read queue
+    // check for duplicates in the read queue
     auto found_rq = std::find_if(RQ.begin(), RQ.end(), eq_addr<PACKET>(packet->address));
     assert(found_rq == RQ.end()); //Duplicate request should not be sent.
-    
+
     // check occupancy
     if (RQ.full()) {
-        RQ_FULL++;
         return -2; // cannot handle this request
     }
 
     // if there is no duplicate, add it to RQ
     RQ.push_back(*packet);
 
-    RQ_TO_CACHE++;
-    RQ_ACCESS++;
-
     return RQ.occupancy();
-}
-
-int PageTableWalker::add_wq(PACKET *packet)
-{
-	assert(0); //No request is added to WQ
-}
-
-int PageTableWalker::add_pq(PACKET *packet)
-{
-	assert(0); //No request is added to PQ
 }
 
 void PageTableWalker::return_data(PACKET *packet)
@@ -309,11 +190,9 @@ void PageTableWalker::return_data(PACKET *packet)
     {
         if (mshr_entry.address == packet->address && mshr_entry.translation_level == packet->translation_level)
         {
-            assert(mshr_entry.translation_level > 0);
-            mshr_entry.translation_level--;
             mshr_entry.event_cycle = current_cycle;
 
-            DP (if (warmup_complete[packet->cpu]) {
+            DP (if (warmup_complete[cpu]) {
                     std::cout << "[" << NAME << "_MSHR] " <<  __func__ << " instr_id: " << mshr_entry.instr_id;
                     std::cout << " address: " << std::hex << mshr_entry.address << " full_addr: " << mshr_entry.full_addr;
                     std::cout << " full_v_addr: " << mshr_entry.full_v_addr;
@@ -326,104 +205,45 @@ void PageTableWalker::return_data(PACKET *packet)
     MSHR.sort(ord_event_cycle<PACKET>());
 }
 
-void PageTableWalker::increment_WQ_FULL(uint64_t address)
-{
-	WQ_FULL++;
-}
-
 uint32_t PageTableWalker::get_occupancy(uint8_t queue_type, uint64_t address)
 {
-	if (queue_type == 0)
+    if (queue_type == 0)
         return std::count_if(MSHR.begin(), MSHR.end(), is_valid<PACKET>());
     else if (queue_type == 1)
         return RQ.occupancy();
-    else if (queue_type == 2)
-        return WQ.occupancy();
-    else if (queue_type == 3)
-	return PQ.occupancy();
     return 0;
 }
-        
+
 uint32_t PageTableWalker::get_size(uint8_t queue_type, uint64_t address)
 {
-	if (queue_type == 0)
+    if (queue_type == 0)
         return MSHR_SIZE;
     else if (queue_type == 1)
         return RQ.size();
-    else if (queue_type == 2)
-        return WQ.size();
-    else if (queue_type == 3)
-	return PQ.size();
     return 0;
 }
 
-uint32_t PagingStructureCache::get_set(uint64_t address)
+void PagingStructureCache::fill_cache(uint64_t next_level_paddr, uint64_t vaddr)
 {
-    return (uint32_t) (address & ((1 << lg2(NUM_SET)) - 1)); 
+    auto set_idx    = (vaddr >> vmem.shamt(level+1)) & bitmask(lg2(NUM_SET));
+    auto set_begin  = std::next(std::begin(block), set_idx*NUM_WAY);
+    auto set_end    = std::next(set_begin, NUM_WAY);
+    auto fill_block = std::max_element(set_begin, set_end, lru_comparator<block_t, block_t>());
+
+    *fill_block = {true, vaddr, next_level_paddr, fill_block->lru};
+    std::for_each(set_begin, set_end, lru_updater<block_t>(fill_block));
 }
 
-void PagingStructureCache::fill_cache(uint64_t next_level_base_addr, PACKET *packet)
+std::optional<uint64_t> PagingStructureCache::check_hit(uint64_t address)
 {
-	uint64_t address = get_index(packet->full_v_addr);
-	
-    auto set_begin = std::next(std::begin(block), get_set(address)*NUM_WAY);
+    auto set_idx   = (address >> vmem.shamt(level+1)) & bitmask(lg2(NUM_SET));
+    auto set_begin = std::next(std::begin(block), set_idx*NUM_WAY);
     auto set_end   = std::next(set_begin, NUM_WAY);
-    auto fill_block = std::max_element(set_begin, set_end, lru_comparator<BLOCK, BLOCK>());
+    auto hit_block = std::find_if(set_begin, set_end, eq_addr<block_t>{address, vmem.shamt(level+1)});
 
-    fill_block->valid = true;
-    fill_block->prefetch = (packet->type == PREFETCH);
-    fill_block->dirty = false;
-    fill_block->address = address;
-    fill_block->full_addr = packet->full_addr;
-    fill_block->v_address = packet->v_address;
-    fill_block->full_v_addr = packet->full_v_addr;
-    fill_block->data = next_level_base_addr;
-    fill_block->ip = packet->ip;
-    fill_block->cpu = packet->cpu;
-    fill_block->instr_id = packet->instr_id;
+    if (hit_block != set_end)
+        return splice_bits(hit_block->data, vmem.get_offset(address, level) * PTE_BYTES, LOG2_PAGE_SIZE);
 
-    std::for_each(set_begin, set_end, lru_updater<BLOCK>(fill_block));
+    return {};
 }
 
-uint64_t PagingStructureCache::get_index(uint64_t address)
-{
-
-	address = address & ( (1L<<57) -1); //Extract Last 57 bits
-
-	int shift = 12;
-
-	switch(cache_type)
-	{
-		case IS_PSCL5: shift+= 9+9+9+9;
-					   break;
-		case IS_PSCL4: shift+= 9+9+9;
-					   break;
-		case IS_PSCL3: shift+= 9+9;
-					   break;
-		case IS_PSCL2: shift+= 9; //Most siginificant 36 bits will be used to index PSCL2 
-					   break;
-	}
-
-	return (address >> shift); 
-}
-
-uint64_t PagingStructureCache::check_hit(uint64_t address)
-{
-	address = get_index(address);
-
-	uint32_t set = get_set(address);
-
-    if (NUM_SET < set) {
-        cerr << "[" << NAME << "_ERROR] " << __func__ << " invalid set index: " << set << " NUM_SET: " << NUM_SET;
-        assert(0);
-    }
-
-    for (uint32_t way=0; way < NUM_WAY; way++) {
-        if (block[set * NUM_WAY + way].valid && (block[set * NUM_WAY + way].address == address)) {
-	    	return block[set * NUM_WAY + way].data;
-        }
-    }
-
-    return UINT64_MAX;
-}
-    

--- a/src/ptw.cc
+++ b/src/ptw.cc
@@ -77,7 +77,7 @@ void PageTableWalker::handle_fill()
             auto [addr, fault] = vmem.va_to_pa(cpu, fill_mshr->full_v_addr);
             if (warmup_complete[cpu] && fault)
             {
-                fill_mshr->event_cycle = current_cycle + MINOR_FAULT_PENALTY;
+                fill_mshr->event_cycle = current_cycle + vmem.minor_fault_penalty;
                 MSHR.sort(ord_event_cycle<PACKET>{});
             }
             else
@@ -100,7 +100,7 @@ void PageTableWalker::handle_fill()
             auto [addr, fault] = vmem.get_pte_pa(cpu, fill_mshr->full_v_addr, fill_mshr->translation_level);
             if (warmup_complete[cpu] && fault)
             {
-                fill_mshr->event_cycle = current_cycle + MINOR_FAULT_PENALTY;
+                fill_mshr->event_cycle = current_cycle + vmem.minor_fault_penalty;
                 MSHR.sort(ord_event_cycle<PACKET>{});
             }
             else

--- a/src/vmem.cc
+++ b/src/vmem.cc
@@ -9,8 +9,8 @@
 #include "champsim.h"
 #include "util.h"
 
-VirtualMemory::VirtualMemory(uint64_t capacity, uint64_t pg_size, uint32_t page_table_levels, uint64_t random_seed)
-    : pt_levels(page_table_levels), page_size(pg_size), ppage_free_list((capacity-VMEM_RESERVE_CAPACITY)/PAGE_SIZE, PAGE_SIZE)
+VirtualMemory::VirtualMemory(uint64_t capacity, uint64_t pg_size, uint32_t page_table_levels, uint64_t random_seed, uint64_t minor_fault_penalty)
+    : minor_fault_penalty(minor_fault_penalty), pt_levels(page_table_levels), page_size(pg_size), ppage_free_list((capacity-VMEM_RESERVE_CAPACITY)/PAGE_SIZE, PAGE_SIZE)
 {
     assert(capacity % PAGE_SIZE == 0);
     assert(pg_size == (1ul << lg2(pg_size)) && pg_size > 1024);

--- a/src/vmem.cc
+++ b/src/vmem.cc
@@ -1,134 +1,68 @@
 #include "vmem.h"
+
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+#include <numeric>
+#include <random>
+
 #include "champsim.h"
 #include "util.h"
 
-VirtualMemory::VirtualMemory(uint32_t number_of_cpus, uint64_t capacity, uint64_t pg_size, uint32_t page_table_levels, uint64_t random_seed)
+VirtualMemory::VirtualMemory(uint64_t capacity, uint64_t pg_size, uint32_t page_table_levels, uint64_t random_seed)
+    : pt_levels(page_table_levels), page_size(pg_size), ppage_free_list((capacity-VMEM_RESERVE_CAPACITY)/PAGE_SIZE, PAGE_SIZE)
 {
-    num_cpus = number_of_cpus;
-    pt_levels = page_table_levels;
+    assert(capacity % PAGE_SIZE == 0);
+    assert(pg_size == (1ul << lg2(pg_size)) && pg_size > 1024);
 
-    // calculate number of physical pages
-    page_size = pg_size;
-    if(capacity%page_size != 0)
-    {
-        std::cout << "VirtualMemory initialization error: memory capacity must be a multiple of page size!" << std::endl;
-        exit(0);
-    }
-    num_ppages = capacity/page_size;
-    std::cout << std::endl << "VirtualMemory physical capacity: " << capacity << " num_ppages: " << num_ppages << std::endl;
-
-    if (pg_size != (1<<lg2(pg_size)) || pg_size < 1024)
-    {
-        std::cout<< "VirtualMemory initialization error: page size must be a power of 2, and at least 1024!" << std::endl;
-        exit(0);
-    }
-    std::cout << "VirtualMemory page size: " << page_size << " log2_page_size: " << lg2(page_size) << std::endl;
-
-    // initialize random number generator
-    rand_state = random_seed+VMEM_RAND_FACTOR;
-    if(rand_state == 0)
-    {
-        rand_state = VMEM_RAND_FACTOR<<1;
-    }
-
-    std::cout << "VirtualMemory initalizing ppage free list ... ";
-    ppage_free_list.resize(num_ppages);
     // populate the free list
-    for(uint64_t i=0; i<num_ppages; i++)
-    {
-        ppage_free_list[i] = i;
-    }
-    std::cout << "done" << std::endl << "VirtualMemory shuffling ppage free list ... ";
-    // remove the reserve space from the free list
-    uint64_t num_reserve_ppages = VMEM_RESERVE_CAPACITY < pg_size ? 1 : VMEM_RESERVE_CAPACITY/pg_size;
-
-    for(int i=0; i<num_reserve_ppages; i++)
-    {
-        ppage_free_list.pop_front();
-    }
+    ppage_free_list.front() = VMEM_RESERVE_CAPACITY;
+    std::partial_sum(std::cbegin(ppage_free_list), std::cend(ppage_free_list), std::begin(ppage_free_list));
 
     // then shuffle it
-    uint64_t num_swap_ppages = num_ppages-num_reserve_ppages;
-    for(uint64_t i=0; i<num_swap_ppages; i++)
-    {
-        // i is the swap source, swap target is random
-        uint64_t swap_target = (vmem_rand()%(num_swap_ppages));
+    std::shuffle(std::begin(ppage_free_list), std::end(ppage_free_list), std::mt19937_64{random_seed});
 
-        uint64_t swap_temp = ppage_free_list[i];
-        ppage_free_list[i] = ppage_free_list[swap_target];
-        ppage_free_list[swap_target] = swap_temp;
-    }
-    std::cout << "done" << std::endl << std::endl;
-
-    // initialize V to P page map tables
-    vpage_to_ppage_map = new std::map<uint64_t, uint64_t>[num_cpus];
-
-    // initialize per-process page tables
-    page_table = new std::map<uint64_t, uint64_t>*[num_cpus];
-    for(uint32_t i=0; i<num_cpus; i++)
-    {
-        page_table[i] = new std::map<uint64_t, uint64_t>[pt_levels];
-    }
+    next_pte_page = ppage_free_list.front();
+    ppage_free_list.pop_front();
 }
 
-uint64_t VirtualMemory::get_next_free_ppage()
+uint64_t VirtualMemory::shamt(uint32_t level) const
 {
-  if(ppage_free_list.empty())
+    return LOG2_PAGE_SIZE + lg2(page_size/PTE_BYTES)*(level);
+}
+
+uint64_t VirtualMemory::get_offset(uint64_t vaddr, uint32_t level) const
+{
+    return (vaddr >> shamt(level)) & bitmask(lg2(page_size/PTE_BYTES));
+}
+
+std::pair<uint64_t, bool> VirtualMemory::va_to_pa(uint32_t cpu_num, uint64_t vaddr)
+{
+    auto [ppage, fault] = vpage_to_ppage_map.insert({{cpu_num, vaddr >> LOG2_PAGE_SIZE}, ppage_free_list.front()});
+
+    // this vpage doesn't yet have a ppage mapping
+    if (fault)
+        ppage_free_list.pop_front();
+
+    return {splice_bits(ppage->second, vaddr, LOG2_PAGE_SIZE), fault};
+}
+
+std::pair<uint64_t, bool> VirtualMemory::get_pte_pa(uint32_t cpu_num, uint64_t vaddr, uint32_t level)
+{
+    std::tuple key{cpu_num, vaddr >> shamt(level+1), level};
+    auto [ppage, fault] = page_table.insert({key, next_pte_page});
+
+    // this PTE doesn't yet have a mapping
+    if (fault)
     {
-      // ran out of physical pages to allocate, so throw error and exit
-      std::cout << "VirtualMemory error: ran out of physical pages to allocate!  Try a larger memory size." << std::endl;
-      exit(0);
+        next_pte_page += page_size;
+        if (next_pte_page % PAGE_SIZE)
+        {
+            next_pte_page = ppage_free_list.front();
+            ppage_free_list.pop_front();
+        }
     }
-  
-  uint64_t free_ppage = ppage_free_list[0];
-  ppage_free_list.pop_front();
-  return free_ppage;
+
+    return {splice_bits(ppage->second, get_offset(vaddr, level) * PTE_BYTES, lg2(page_size)), fault};
 }
 
-uint32_t VirtualMemory::get_paget_table_level_count()
-{
-  return pt_levels;
-}
-
-uint64_t VirtualMemory::va_to_pa(uint32_t cpu_num, uint64_t vaddr)
-{
-  uint64_t vpage = vaddr>>lg2(page_size);
-  uint64_t voffset = vaddr & bitmask(lg2(page_size));
-
-  if(vpage_to_ppage_map[cpu_num].find(vpage) == vpage_to_ppage_map[cpu_num].end())
-    {
-      // this vpage doesn't yet have a ppage mapping
-      vpage_to_ppage_map[cpu_num][vpage] = get_next_free_ppage();
-    }
-  
-  return (((vpage_to_ppage_map[cpu_num][vpage])<<lg2(page_size))+voffset);
-}
-
-uint64_t VirtualMemory::get_pte_pa(uint32_t cpu_num, uint64_t vaddr, uint32_t level)
-{
-  uint64_t vpage = vaddr>>lg2(page_size);
-  uint64_t pte_offset = vpage & bitmask(9);
-  
-  uint32_t shift_bits = 9 + (9*(pt_levels-1-level));
-  uint64_t pt_lookup_tag = vpage>>shift_bits;
-
-  if(page_table[cpu_num][level].find(pt_lookup_tag) == page_table[cpu_num][level].end())
-    {
-      // this PTE doesn't yet have a mapping
-      page_table[cpu_num][level][pt_lookup_tag] = get_next_free_ppage();
-    }
-  
-  return (((page_table[cpu_num][level][pt_lookup_tag])<<lg2(page_size))+(pte_offset*8));
-}
-
-uint64_t VirtualMemory::vmem_rand()
-{
-  rand_state += VMEM_RAND_FACTOR;
-
-  rand_state ^= (rand_state<<13);
-  rand_state ^= (rand_state>>7);
-  rand_state ^= (rand_state<<11);
-  rand_state ^= (rand_state>>1);
-  
-  return rand_state;
-}


### PR DESCRIPTION
This patch modifies the page table walker and the virtual memory. The primary intent is to remove the assumption that pages are 2^12 bytes in size and that there are 512 PTE entries per PTE page. Now, these two classes work more closely together.

This probably addresses #131 and #162. I'm curious if it does fix them.

There is a change in performance that results from this. It seems to come from a bug that I fixed where the PTW appeared to make one more step down the walk than it was supposed to.