### PR TITLE
Updates to bimodal branch predictor

### DIFF
--- a/branch/bimodal/bimodal.cc
+++ b/branch/bimodal/bimodal.cc
@@ -1,32 +1,37 @@
 #include "ooo_cpu.h"
 
-#define BIMODAL_TABLE_SIZE 16384
-#define BIMODAL_PRIME 16381
-#define MAX_COUNTER 3
-int bimodal_table[NUM_CPUS][BIMODAL_TABLE_SIZE];
+constexpr std::size_t BIMODAL_TABLE_SIZE = 16384;
+constexpr std::size_t BIMODAL_PRIME = 16381;
+constexpr std::size_t COUNTER_BITS = 2;
+
+std::map<O3_CPU*, std::array<int, BIMODAL_TABLE_SIZE>> bimodal_table;
 
 void O3_CPU::initialize_branch_predictor()
 {
-    cout << "CPU " << cpu << " Bimodal branch predictor" << endl;
-
-    for(int i = 0; i < BIMODAL_TABLE_SIZE; i++)
-        bimodal_table[cpu][i] = 0;
+    std::cout << "CPU " << cpu << " Bimodal branch predictor" << std::endl;
+    bimodal_table[this] = {};
 }
 
 uint8_t O3_CPU::predict_branch(uint64_t ip, uint64_t predicted_target, uint8_t always_taken, uint8_t branch_type)
 {
     uint32_t hash = ip % BIMODAL_PRIME;
-    uint8_t prediction = (bimodal_table[cpu][hash] >= ((MAX_COUNTER + 1)/2)) ? 1 : 0;
 
-    return prediction;
+    return bimodal_table[this][hash] >= (1 << (COUNTER_BITS-1));
 }
 
 void O3_CPU::last_branch_result(uint64_t ip, uint64_t branch_target, uint8_t taken, uint8_t branch_type)
 {
     uint32_t hash = ip % BIMODAL_PRIME;
 
-    if (taken && (bimodal_table[cpu][hash] < MAX_COUNTER))
-        bimodal_table[cpu][hash]++;
-    else if ((taken == 0) && (bimodal_table[cpu][hash] > 0))
-        bimodal_table[cpu][hash]--;
+    if (taken)
+    {
+        if (bimodal_table[this][hash] < ((1<<COUNTER_BITS)-1))
+            bimodal_table[this][hash]++;
+    }
+    else
+    {
+       if (bimodal_table[this][hash] > 0)
+            bimodal_table[this][hash]--;
+    }
 }
+


### PR DESCRIPTION
This is a simple patch compared to my other ones. This is a simple facelift to the bimodal branch predictor. It removes preprocessor directives and uses a map of cores to tables, rather than an array, which will be more future-proof.