### PR TITLE
Fixed bug with "--traces" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ git clone https://github.com/ChampSim/ChampSim.git
 ChampSim takes a JSON configuration script. Examine `champsim_config.json` for a fully-specified example. All options described in this file are optional and will be replaced with defaults if not specified. The configuration scrip can also be run without input, in which case an empty file is assumed.
 ```
 $ ./config.sh <configuration file>
-$ make clean
 $ make
 ```
 
@@ -25,7 +24,7 @@ Professor Daniel Jimenez at Texas A&M University kindly provided traces for the 
 
 Execute the binary directly.
 ```
-$ bin/champsim -warmup_instructions 200000000 -simulation_instructions 500000000 -traces ~/path/to/traces/600.perlbench_s-210B.champsimtrace.xz
+$ bin/champsim --warmup_instructions 200000000 --simulation_instructions 500000000 ~/path/to/traces/600.perlbench_s-210B.champsimtrace.xz
 ```
 
 The number of warmup and simulation instructions given will be the number of instructions retired. Note that the statistics printed at the end of the simulation include only the simulation phase.
@@ -57,7 +56,7 @@ Note that the example prefetcher is an L2 prefetcher. You might design a prefetc
 $ ./config.sh <configuration file>
 $ make clean
 $ make
-$ bin/champsim -warmup_instructions 200000000 -simulation_instructions 500000000 -traces dpc3_traces/600.perlbench_s-210B.champsimtrace.xz
+$ bin/champsim --warmup_instructions 200000000 --simulation_instructions 500000000 600.perlbench_s-210B.champsimtrace.xz
 ```
 
 # How to create traces

--- a/branch/bimodal/bimodal.cc
+++ b/branch/bimodal/bimodal.cc
@@ -1,32 +1,37 @@
 #include "ooo_cpu.h"
 
-#define BIMODAL_TABLE_SIZE 16384
-#define BIMODAL_PRIME 16381
-#define MAX_COUNTER 3
-int bimodal_table[NUM_CPUS][BIMODAL_TABLE_SIZE];
+constexpr std::size_t BIMODAL_TABLE_SIZE = 16384;
+constexpr std::size_t BIMODAL_PRIME = 16381;
+constexpr std::size_t COUNTER_BITS = 2;
+
+std::map<O3_CPU*, std::array<int, BIMODAL_TABLE_SIZE>> bimodal_table;
 
 void O3_CPU::initialize_branch_predictor()
 {
-    cout << "CPU " << cpu << " Bimodal branch predictor" << endl;
-
-    for(int i = 0; i < BIMODAL_TABLE_SIZE; i++)
-        bimodal_table[cpu][i] = 0;
+    std::cout << "CPU " << cpu << " Bimodal branch predictor" << std::endl;
+    bimodal_table[this] = {};
 }
 
 uint8_t O3_CPU::predict_branch(uint64_t ip, uint64_t predicted_target, uint8_t always_taken, uint8_t branch_type)
 {
     uint32_t hash = ip % BIMODAL_PRIME;
-    uint8_t prediction = (bimodal_table[cpu][hash] >= ((MAX_COUNTER + 1)/2)) ? 1 : 0;
 
-    return prediction;
+    return bimodal_table[this][hash] >= (1 << (COUNTER_BITS-1));
 }
 
 void O3_CPU::last_branch_result(uint64_t ip, uint64_t branch_target, uint8_t taken, uint8_t branch_type)
 {
     uint32_t hash = ip % BIMODAL_PRIME;
 
-    if (taken && (bimodal_table[cpu][hash] < MAX_COUNTER))
-        bimodal_table[cpu][hash]++;
-    else if ((taken == 0) && (bimodal_table[cpu][hash] > 0))
-        bimodal_table[cpu][hash]--;
+    if (taken)
+    {
+        if (bimodal_table[this][hash] < ((1<<COUNTER_BITS)-1))
+            bimodal_table[this][hash]++;
+    }
+    else
+    {
+       if (bimodal_table[this][hash] > 0)
+            bimodal_table[this][hash]--;
+    }
 }
+

--- a/branch/perceptron/perceptron.cc
+++ b/branch/perceptron/perceptron.cc
@@ -34,280 +34,126 @@
  * a hardware budget of (24+1)*8*163 = 32600 bits, or about 4K bytes,
  * which is comparable to the hardware budget of the Alpha 21264 hybrid
  * branch predictor.
- *
- * There are three important functions defined in this file:
- * 
- * 1. void initialize_perceptron_predictor (void);
- * Initialize the perceptron predictor
- *
- * 2. perceptron_state *perceptron_dir_lookup (unsigned int);
- * Get a branch prediction, given a branch address.  This function returns a
- * pointer to a 'perceptron_state' struct, which contains the prediction, the
- * perceptron output, and other information necessary for using and updating
- * the predictor.  The first member of a 'perceptron_state' struct is a char
- * that is assigned 3 if the branch is predicted taken, 0 otherwise; this way,
- * a pointer to 'perceptron_state' can be cast to (char *) and passed around
- * SimpleScalar as though it were a pointer to a pattern history table entry.
- *
- * 3. void perceptron_update (perceptron_state *, int);
- * Update the branch predictor using the 'perceptron_state' pointer 
- * returned by perceptron_dir_lookup() and an int that is 1 if the branch
- * was taken, 0 otherwise.
  */
 
 #include "ooo_cpu.h"
 
-/* history length for the global history shift register */
+#include <algorithm>
+#include <array>
+#include <bitset>
+#include <deque>
 
-#define PERCEPTRON_HISTORY	24
+template <typename T, std::size_t HISTLEN, std::size_t BITS>
+class perceptron
+{
+    T bias = 0;
+    std::array<T, HISTLEN> weights = {};
 
-/* number of perceptrons */
+    public:
+    // maximum and minimum weight values
+    constexpr static T max_weight = (1 << (BITS-1)) - 1;
+    constexpr static T min_weight = -(max_weight + 1);
 
-#define NUM_PERCEPTRONS		163
+    T predict(std::bitset<HISTLEN> history)
+    {
+        auto output = bias;
 
-/* number of bits per weight */
+        // find the (rest of the) dot product of the history register and the perceptron weights.
+        for (std::size_t i = 0; i < std::size(history); i++)
+        {
+            if (history[i]) output += weights[i];
+            else            output -= weights[i];
+        }
 
-#define PERCEPTRON_BITS		8
+        return output;
+    }
 
-/* maximum and minimum weight values */
+    void update(bool result, std::bitset<HISTLEN> history)
+    {
+        // if the branch was taken, increment the bias weight, else decrement it, with saturating arithmetic
+        if (result) bias = std::min(bias+1, max_weight);
+        else        bias = std::max(bias-1, min_weight);
 
-#define MAX_WEIGHT		((1<<(PERCEPTRON_BITS-1))-1)
-#define MIN_WEIGHT		(-(MAX_WEIGHT+1))
+        // for each weight and corresponding bit in the history register...
+        auto upd_mask = result ? history : ~history; // if the i'th bit in the history positively correlates with this branch outcome,
+        for (std::size_t i = 0; i < std::size(upd_mask); i++)
+        {
+            // increment the corresponding weight, else decrement it, with saturating arithmetic
+            if (upd_mask[i]) weights[i] = std::min(weights[i]+1, max_weight);
+            else             weights[i] = std::max(weights[i]-1, min_weight);
+        }
+    }
+};
 
-/* threshold for training */
+constexpr std::size_t PERCEPTRON_HISTORY = 24; // history length for the global history shift register
+constexpr std::size_t PERCEPTRON_BITS = 8; // number of bits per weight
+constexpr std::size_t NUM_PERCEPTRONS = 163;
 
-#define THETA			((int) (1.93 * PERCEPTRON_HISTORY + 14))
+constexpr int THETA = 1.93 * PERCEPTRON_HISTORY + 14; // threshold for training
 
-/* size of buffer for keeping 'perceptron_state' for update */
-
-#define NUM_UPDATE_ENTRIES	100
-
-/* perceptron data structure */
-
-typedef struct {
-	int	
-		/* just a vector of integers */
-
-		weights[PERCEPTRON_HISTORY+1];
-} perceptron;
+constexpr std::size_t NUM_UPDATE_ENTRIES = 100; // size of buffer for keeping 'perceptron_state' for update
 
 /* 'perceptron_state' - stores the branch prediction and keeps information
  * such as output and history needed for updating the perceptron predictor
  */
-typedef struct {
-	char	
-		/* this char emulates a pattern history	table entry
-		 * with a value of 0 for "predict not taken" or 3 for 
-		 * "predict taken," so a perceptron_state pointer can 
-		 * be passed around SimpleScalar's branch prediction 
-		 * infrastructure without changing too much stuff.
-		 */
-		dummy_counter;
+struct perceptron_state
+{
+    uint64_t ip = 0;
+    bool prediction = false; // prediction: 1 for taken, 0 for not taken
+    int output = 0; // perceptron output
+    std::bitset<PERCEPTRON_HISTORY> history = 0; // value of the history register yielding this prediction
+};
 
-	int
-		/* prediction: 1 for taken, 0 for not taken */
-
-		prediction,
-
-		/* perceptron output */
-
-		output;
-
-	unsigned long long int 
-		/* value of the history register yielding this prediction */
-
-		history;
-
-	perceptron
-		/* pointer to the perceptron yielding this prediction */
-
-		*perc;
-} perceptron_state;
-
-perceptron 
-	/* table of perceptrons */
-
-	perceptrons[NUM_CPUS][NUM_PERCEPTRONS];
-
-perceptron_state 
-	/* state for updating perceptron predictor */
-
-	perceptron_state_buf[NUM_CPUS][NUM_UPDATE_ENTRIES];
-
-int 
-	/* index of the next "free" perceptron_state */
-
-	perceptron_state_buf_ctr[NUM_CPUS];
-
-unsigned long long int
-
-	/* speculative global history - updated by predictor */
-
-	spec_global_history[NUM_CPUS],
-
-	/* real global history - updated when the predictor is updated */
-
-	global_history[NUM_CPUS];
-
-perceptron_state *u[NUM_CPUS];
-
-/* initialize a single perceptron */
-void initialize_perceptron (perceptron *p) {
-    int	i;
-
-    for (i=0; i<=PERCEPTRON_HISTORY; i++) p->weights[i] = 0;
-}
+std::map<O3_CPU*, std::array<perceptron<int, PERCEPTRON_HISTORY, PERCEPTRON_BITS>, NUM_PERCEPTRONS>> perceptrons; // table of perceptrons
+std::map<O3_CPU*, std::deque<perceptron_state>> perceptron_state_buf; // state for updating perceptron predictor
+std::map<O3_CPU*, std::bitset<PERCEPTRON_HISTORY>> spec_global_history; // speculative global history - updated by predictor
+std::map<O3_CPU*, std::bitset<PERCEPTRON_HISTORY>> global_history; // real global history - updated when the predictor is updated
 
 void O3_CPU::initialize_branch_predictor()
 {
-    spec_global_history[cpu] = 0;
-    global_history[cpu] = 0;
-    perceptron_state_buf_ctr[cpu] = 0;
-    for (int i=0; i<NUM_PERCEPTRONS; i++)
-        initialize_perceptron (&perceptrons[cpu][i]);
 }
 
 uint8_t O3_CPU::predict_branch(uint64_t ip, uint64_t predicted_target, uint8_t always_taken, uint8_t branch_type)
 {
-    uint64_t address = ip;
+    // hash the address to get an index into the table of perceptrons
+    auto index = ip % NUM_PERCEPTRONS;
+    auto output = perceptrons[this][index].predict(spec_global_history[this]);
 
-    int	
-        index,
-        i,
-        output,
-        *w;
-    unsigned long long int 
-        mask;
-    perceptron 
-        *p;
+    bool prediction = (output >= 0);
 
-    /* get a pointer to the next "free" perceptron_state,
-     * bumping up the pointer (and possibly letting it wrap around) 
-     */
+    // record the various values needed to update the predictor
+    perceptron_state_buf[this].push_back({ ip, prediction, output, spec_global_history[this] });
+    if (std::size(perceptron_state_buf[this]) > NUM_UPDATE_ENTRIES)
+        perceptron_state_buf[this].pop_front();
 
-    u[cpu] = &perceptron_state_buf[cpu][perceptron_state_buf_ctr[cpu]++];
-    if (perceptron_state_buf_ctr[cpu] >= NUM_UPDATE_ENTRIES)
-        perceptron_state_buf_ctr[cpu] = 0;
-
-    /* hash the address to get an index into the table of perceptrons */
-
-    index = address % NUM_PERCEPTRONS;
-
-    /* get pointers to that perceptron and its weights */
-
-    p = &perceptrons[cpu][index];
-    w = &p->weights[0];
-
-    /* initialize the output to the bias weight, and bump the pointer
-     * to the weights
-     */
-
-    output = *w++;
-
-    /* find the (rest of the) dot product of the history register
-     * and the perceptron weights.  note that, instead of actually
-     * doing the expensive multiplies, we simply add a weight when the
-     * corresponding branch in the history register is taken, or
-     * subtract a weight when the branch is not taken.  this also lets
-     * us use binary instead of bipolar logic to represent the history
-     * register
-     */
-    for (mask=1,i=0; i<PERCEPTRON_HISTORY; i++,mask<<=1,w++) {
-        if (spec_global_history[cpu] & mask)
-            output += *w;
-        else
-            output += -*w;
-    }
-
-    /* record the various values needed to update the predictor */
-
-    u[cpu]->output = output;
-    u[cpu]->perc = p;
-    u[cpu]->history = spec_global_history[cpu];
-    u[cpu]->prediction = output >= 0;
-    u[cpu]->dummy_counter = u[cpu]->prediction ? 3 : 0;
-
-    /* update the speculative global history register */
-
-    spec_global_history[cpu] <<= 1;
-    spec_global_history[cpu] |= u[cpu]->prediction;
-    return u[cpu]->prediction;
+    // update the speculative global history register
+    spec_global_history[this] <<= 1;
+    spec_global_history[this].set(0, prediction);
+    return prediction;
 }
 
 void O3_CPU::last_branch_result(uint64_t ip, uint64_t branch_target, uint8_t taken, uint8_t branch_type)
 {
-    int	
-        i,
-        y, 
-        *w;
+    auto state = std::find_if(std::begin(perceptron_state_buf[this]), std::end(perceptron_state_buf[this]), [ip](auto x){ return x.ip == ip; });
+    if (state == std::end(perceptron_state_buf[this]))
+        return; // Skip update because state was lost
 
-    unsigned long long int
-        mask, 
-        history;
+    auto [_ip, prediction, output, history] = *state;
+    perceptron_state_buf[this].erase(state);
 
-    /* update the real global history shift register */
+    auto index = ip % NUM_PERCEPTRONS;
 
-    global_history[cpu] <<= 1;
-    global_history[cpu] |= taken;
+    // update the real global history shift register
+    global_history[this] <<= 1;
+    global_history[this].set(0, taken);
 
-    /* if this branch was mispredicted, restore the speculative
-     * history to the last known real history
-     */
+    // if this branch was mispredicted, restore the speculative history to the last known real history
+    if (prediction != taken)
+        spec_global_history[this] = global_history[this];
 
-    if (u[cpu]->prediction != taken) spec_global_history[cpu] = global_history[cpu];
-
-    /* if the output of the perceptron predictor is outside of
-     * the range [-THETA,THETA] *and* the prediction was correct,
-     * then we don't need to adjust the weights
-     */
-
-    if (u[cpu]->output > THETA)
-        y = 1;
-    else if (u[cpu]->output < -THETA)
-        y = 0;
-    else
-        y = 2;
-    if (y == 1 && taken) return;
-    if (y == 0 && !taken) return;
-
-    /* w is a pointer to the first weight (the bias weight) */
-
-    w = &u[cpu]->perc->weights[0];
-
-    /* if the branch was taken, increment the bias weight,
-     * else decrement it, with saturating arithmetic
-     */
-
-    if (taken)
-        (*w)++;
-    else
-        (*w)--;
-    if (*w > MAX_WEIGHT) *w = MAX_WEIGHT;
-    if (*w < MIN_WEIGHT) *w = MIN_WEIGHT;
-
-    /* now w points to the next weight */
-
-    w++;
-
-    /* get the history that led to this prediction */
-
-    history = u[cpu]->history;
-
-    /* for each weight and corresponding bit in the history register... */
-
-    for (mask=1,i=0; i<PERCEPTRON_HISTORY; i++,mask<<=1,w++) {
-
-        /* if the i'th bit in the history positively correlates
-         * with this branch outcome, increment the corresponding 
-         * weight, else decrement it, with saturating arithmetic
-         */
-
-        if (!!(history & mask) == taken) { // a common trick to conver to boolean => !!x is 1 iff x is not zero, in this case history is positively correlated with branch outcome
-            (*w)++;
-            if (*w > MAX_WEIGHT) *w = MAX_WEIGHT;
-        } else {
-            (*w)--;
-            if (*w < MIN_WEIGHT) *w = MIN_WEIGHT;
-        }
-    }
+    // if the output of the perceptron predictor is outside of the range [-THETA,THETA] *and* the prediction was correct,
+    // then we don't need to adjust the weights
+    if ((output <= THETA && output >= -THETA) || (prediction != taken))
+        perceptrons[this][index].update(taken, history);
 }
+

--- a/prefetcher/ip_stride/ip_stride.cc
+++ b/prefetcher/ip_stride/ip_stride.cc
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <array>
+#include <map>
 
 #include "cache.h"
 
@@ -15,11 +16,35 @@ struct tracker_entry
 
 constexpr std::size_t TRACKER_SETS = 256;
 constexpr std::size_t TRACKER_WAYS = 4;
-std::array<tracker_entry, TRACKER_SETS*TRACKER_WAYS> trackers;
+std::map<CACHE*, std::tuple<uint64_t, int64_t, int>> lookahead; // pf_address, stride, degree
+std::map<CACHE*, std::array<tracker_entry, TRACKER_SETS*TRACKER_WAYS>> trackers;
 
 void CACHE::l2c_prefetcher_initialize()
 {
     std::cout << this->NAME << " IP-based stride prefetcher" << std::endl;
+}
+
+void CACHE::prefetcher_cycle_operate()
+{
+    // If a lookahead is active
+    if (auto [pf_address, stride, degree] = lookahead[this]; pf_address != 0)
+    {
+        // If the next step would exceed the degree or run off the page, stop
+        if (degree < PREFETCH_DEGREE && (virtual_prefetch || ((pf_address + (stride << LOG2_BLOCK_SIZE)) >> LOG2_PAGE_SIZE) == (pf_address >> LOG2_PAGE_SIZE)))
+        {
+            // calculate prefetch address
+            pf_address += stride << LOG2_BLOCK_SIZE;
+
+            // check the MSHR occupancy to decide if we're going to prefetch to the L2 or LLC
+            prefetch_line(0, 0, pf_address, (get_occupancy(0,pf_address) < get_size(0,pf_address)/2) ? FILL_L2 : FILL_LLC, 0);
+        }
+        else
+        {
+            pf_address = 0;
+        }
+
+        lookahead[this] = {pf_address, stride, degree+1};
+    }
 }
 
 uint32_t CACHE::prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in)
@@ -28,7 +53,7 @@ uint32_t CACHE::prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cac
     int64_t stride = 0;
 
     // get boundaries of tracking set
-    auto set_begin = std::next(std::begin(trackers), ip % TRACKER_SETS);
+    auto set_begin = std::next(std::begin(trackers[this]), ip % TRACKER_SETS);
     auto set_end   = std::next(set_begin, TRACKER_WAYS);
 
     // find the current ip within the set
@@ -41,23 +66,10 @@ uint32_t CACHE::prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cac
         // no need to check for overflow since these values are downshifted
         stride = (int64_t)cl_addr - (int64_t)found->last_cl_addr;
 
-        // don't do anything if we somehow saw the same address twice in a row
+        // Initialize prefetch state unless we somehow saw the same address twice in a row
         // or if this is the first time we've seen this stride
         if (stride != 0 && stride == found->last_stride)
-        {
-            for (auto i = 0; i<PREFETCH_DEGREE; i++)
-            {
-                // calculate prefetch address
-                uint64_t pf_address = (cl_addr + (stride*(i+1))) << LOG2_BLOCK_SIZE;
-
-                // stop prefetching if we have iterated off the virtual page
-                if (!virtual_prefetch && (pf_address >> LOG2_PAGE_SIZE) != (addr >> LOG2_PAGE_SIZE))
-                    break;
-
-                // check the MSHR occupancy to decide if we're going to prefetch to the L2 or LLC
-                prefetch_line(ip, addr, pf_address, (get_occupancy(0,pf_address) < get_size(0,pf_address)/2) ? FILL_L2 : FILL_LLC, 0);
-            }
-        }
+            lookahead[this] = {cl_addr << LOG2_BLOCK_SIZE, stride, 0};
     }
     else
     {
@@ -74,11 +86,7 @@ uint32_t CACHE::prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cac
 
 uint32_t CACHE::prefetcher_cache_fill(uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
 {
-  return metadata_in;
-}
-
-void CACHE::prefetcher_cycle_operate()
-{
+    return metadata_in;
 }
 
 void CACHE::prefetcher_final_stats()

--- a/prefetcher/ip_stride/ip_stride.cc
+++ b/prefetcher/ip_stride/ip_stride.cc
@@ -8,42 +8,48 @@ constexpr int PREFETCH_DEGREE = 3;
 
 struct tracker_entry
 {
-    uint64_t ip           = 0; // the IP we're tracking
-    uint64_t last_cl_addr = 0; // the last address accessed by this IP
-    int64_t last_stride   = 0; // the stride between the last two addresses accessed by this IP
-    uint64_t lru          = 0; // use LRU to evict old IP trackers
+    uint64_t ip              = 0; // the IP we're tracking
+    uint64_t last_cl_addr    = 0; // the last address accessed by this IP
+    int64_t  last_stride     = 0; // the stride between the last two addresses accessed by this IP
+    uint64_t last_used_cycle = 0; // use LRU to evict old IP trackers
+};
+
+struct lookahead_entry
+{
+    uint64_t address = 0;
+    int64_t  stride  = 0;
+    int      degree  = 0;
 };
 
 constexpr std::size_t TRACKER_SETS = 256;
 constexpr std::size_t TRACKER_WAYS = 4;
-std::map<CACHE*, std::tuple<uint64_t, int64_t, int>> lookahead; // pf_address, stride, degree
+std::map<CACHE*, lookahead_entry> lookahead;
 std::map<CACHE*, std::array<tracker_entry, TRACKER_SETS*TRACKER_WAYS>> trackers;
 
-void CACHE::l2c_prefetcher_initialize()
+void CACHE::prefetcher_initialize()
 {
-    std::cout << this->NAME << " IP-based stride prefetcher" << std::endl;
+    std::cout << NAME << " IP-based stride prefetcher" << std::endl;
 }
 
 void CACHE::prefetcher_cycle_operate()
 {
     // If a lookahead is active
-    if (auto [pf_address, stride, degree] = lookahead[this]; pf_address != 0)
+    if (auto [old_pf_address, stride, degree] = lookahead[this]; old_pf_address != 0)
     {
-        // If the next step would exceed the degree or run off the page, stop
-        if (degree < PREFETCH_DEGREE && (virtual_prefetch || ((pf_address + (stride << LOG2_BLOCK_SIZE)) >> LOG2_PAGE_SIZE) == (pf_address >> LOG2_PAGE_SIZE)))
-        {
-            // calculate prefetch address
-            pf_address += stride << LOG2_BLOCK_SIZE;
+        auto pf_address = old_pf_address + (stride << LOG2_BLOCK_SIZE);
 
-            // check the MSHR occupancy to decide if we're going to prefetch to the L2 or LLC
-            prefetch_line(0, 0, pf_address, (get_occupancy(0,pf_address) < get_size(0,pf_address)/2) ? FILL_L2 : FILL_LLC, 0);
+        // If the next step would exceed the degree or run off the page, stop
+        if (degree < PREFETCH_DEGREE && (virtual_prefetch || (pf_address >> LOG2_PAGE_SIZE) == (old_pf_address >> LOG2_PAGE_SIZE)))
+        {
+            // check the MSHR occupancy to decide if we're going to prefetch to this level or not
+            bool success = prefetch_line(0, 0, pf_address, (get_occupancy(0,pf_address) < get_size(0,pf_address)/2), 0);
+            if (success)
+                lookahead[this] = {pf_address, stride, degree+1};
         }
         else
         {
-            pf_address = 0;
+            lookahead[this] = {};
         }
-
-        lookahead[this] = {pf_address, stride, degree+1};
     }
 }
 
@@ -69,17 +75,16 @@ uint32_t CACHE::prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cac
         // Initialize prefetch state unless we somehow saw the same address twice in a row
         // or if this is the first time we've seen this stride
         if (stride != 0 && stride == found->last_stride)
-            lookahead[this] = {cl_addr << LOG2_BLOCK_SIZE, stride, 0};
+            lookahead[this] = {cl_addr, stride, 0};
     }
     else
     {
         // replace by LRU
-        found = std::max_element(set_begin, set_end, [](tracker_entry x, tracker_entry y){ return x.lru < y.lru; });
+        found = std::min_element(set_begin, set_end, [](tracker_entry x, tracker_entry y){ return x.last_used_cycle < y.last_used_cycle; });
     }
 
     // update tracking set
-    std::for_each(set_begin, set_end, [](tracker_entry &x){ x.lru++; });
-    *found = {ip, cl_addr, stride, 0};
+    *found = {ip, cl_addr, stride, current_cycle};
 
     return metadata_in;
 }


### PR DESCRIPTION
This patch fixes a few minor bugs with the CLI:

- `--traces` would terminate getopt, but not fill traces list.
- `-w` and `-i` would not capture argument.
- Removed unused `-s` and `-b`.