### PR TITLE
Remove lint trigger for pull requests.

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -11,7 +11,9 @@ on:
       - '.github/workflows/*.yml'
       # re-include current file to not be excluded
       - '!.github/workflows/buildcheck.yml'
+      
   pull_request:
+    branches:
       - master
       - develop
     paths-ignore:

--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -1,0 +1,46 @@
+name: Build Check
+
+on:
+  push:
+    branches: 
+      - master
+      - develop
+    paths-ignore:
+      - '.gitignore'
+      - '*.md'
+      - '.github/workflows/*.yml'
+      # re-include current file to not be excluded
+      - '!.github/workflows/buildcheck.yml'
+  pull_request:
+      - master
+      - develop
+    paths-ignore:
+      - '.gitignore'
+      - '*.md'
+      - '.github/workflows/*.yml'
+      # re-include current file to not be excluded
+      - '!.github/workflows/buildcheck.yml'
+      
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2.3.4
+
+    - name: Configure
+      run: ./config.sh
+      
+    - name: Make
+      run: make
+      
+    # TODO run an actual set of checks
+    - name: Run tests
+      run: ./bin/champsim -w50000000 -i50000000 -- https://hpca23.cse.tamu.edu/champsim-traces/speccpu/400.perlbench-41B.champsimtrace.xz > result.txt
+
+    # We upload the generated files under github actions assets
+    - name: Upload Results
+      uses: actions/upload-artifact@v2
+      with:
+        name: champsim-results
+        path: result.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,11 @@
 name: lint
   
 on:
-  # Triggers the workflow on push or pull request events for master and develop
+  # Triggers the workflow on push events for master and develop
   push:
-    branches: [ master,develop ]
-  pull_request:
-    branches: [ master,develop ]
+    branches:
+      - master
+      - develop
 
 jobs:
   build: 
@@ -20,7 +20,6 @@ jobs:
           inplace: True
       - uses: EndBug/add-and-commit@v4
         with:
-          author_name: Auto-Formatter
-          author_email: format@example.com
           message: 'Formatted with clang-format'
+          default_author: github_actions
           add: 'src inc prefetcher branch replacement btb'


### PR DESCRIPTION
The `add-and-commit` action that we have been using to automatically format commands doesn't work when the remote branch is a fork. To accommodate this, I've removed the triggering condition for pull requests. Instead, it will run when the pull request is merged.