### PR TITLE
Allow pipelined ITLB and L1I cache

### DIFF
--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -300,7 +300,7 @@ void O3_CPU::translate_fetch()
   uint64_t find_addr = itlb_req_begin->ip;
   auto itlb_req_end = std::find_if(itlb_req_begin, IFETCH_BUFFER.end(),
                                    [find_addr](const ooo_model_instr& x) { return (find_addr >> LOG2_PAGE_SIZE) != (x.ip >> LOG2_PAGE_SIZE); });
-  if (itlb_req_end != IFETCH_BUFFER.end() || itlb_req_begin == IFETCH_BUFFER.begin()) {
+  if (itlb_req_begin != itlb_req_end) {
     do_translate_fetch(itlb_req_begin, itlb_req_end);
   }
 }
@@ -353,8 +353,7 @@ void O3_CPU::fetch_instruction()
   uint64_t find_addr = l1i_req_begin->instruction_pa;
   auto l1i_req_end = std::find_if(l1i_req_begin, IFETCH_BUFFER.end(),
                                   [find_addr](const ooo_model_instr& x) { return (find_addr >> LOG2_BLOCK_SIZE) != (x.instruction_pa >> LOG2_BLOCK_SIZE); });
-  if (l1i_req_end != IFETCH_BUFFER.end() || l1i_req_begin == IFETCH_BUFFER.begin()) {
-
+  if (l1i_req_begin != l1i_req_end) {
     do_fetch_instruction(l1i_req_begin, l1i_req_end);
   }
 }


### PR DESCRIPTION
This pull request is related to issue #211.

Right now there are unnecessary stalls in the fetch stage when a cache line is requested and other instructions (e.g., to the same address) are enqueued in the fetch queue. These later do not initiate cache line look up until the previous instructions move to decode. In summary it seems that cache pipelining (issuing one request per cycle) is not allowed.

As a consequence this pull request improves performance.