### PR TITLE
Resolve conditional branches early and re-evaluate them at decode

### DIFF
--- a/inc/instruction.h
+++ b/inc/instruction.h
@@ -73,7 +73,8 @@ struct ooo_model_instr {
   bool is_branch = 0;
   bool is_memory = 0;
   bool branch_taken = 0;
-  bool branch_mispredicted = 0;
+  bool branch_prediction = 0;
+  bool branch_mispredicted = 0; // A branch can be mispredicted even if the direction prediction is correct when the predicted target is not correct
 
   uint8_t asid[2] = {std::numeric_limits<uint8_t>::max(), std::numeric_limits<uint8_t>::max()};
 


### PR DESCRIPTION
Right now all conditional branches are resolved at execution. However, at decode they obtain the target address and they should correct their previous prediction if the new information would change it.

For example, assume that the branch (direction) predictor says taken, but the BTB does not find a target. The prediction would be not taken. However the branch is taken. When computing the target address at decode, the misprediction can be resolved.

But it could also happen that the branch is actually not taken. In that case, the initial prediction would have been correct, but on decode, the prediction should be changed to incorrect (the direction predictor is the one it should be trusted in this case).

After the change, a hashed_perceptron predictor should offer better IPC. A bimodal, may not get always better, though.

But I think this is how conditional branches should be modeled.
