### PR TITLE
Removed LRU's first-class status

### DIFF
--- a/inc/cache.h
+++ b/inc/cache.h
@@ -19,6 +19,21 @@ extern std::array<O3_CPU*, NUM_CPUS> ooo_cpu;
 
 class CACHE : public champsim::operable, public MemoryRequestConsumer, public MemoryRequestProducer
 {
+  class BLOCK
+  {
+    public:
+      bool valid = false;
+      bool prefetch = false;
+      bool dirty = false;
+
+      uint64_t address = 0;
+      uint64_t v_address = 0;
+      uint64_t data = 0;
+      uint64_t ip = 0;
+      uint64_t cpu = 0;
+      uint64_t instr_id = 0;
+  };
+
 public:
   uint32_t cpu;
   const std::string NAME;

--- a/inc/memory_class.h
+++ b/inc/memory_class.h
@@ -13,18 +13,6 @@
 #define TRANSLATION 4
 #define NUM_TYPES 5
 
-// CACHE BLOCK
-class BLOCK
-{
-public:
-  bool valid = false, prefetch = false, dirty = false;
-
-  uint64_t address = 0, v_address = 0, tag = 0, data = 0, ip = 0, cpu = 0, instr_id = 0;
-
-  // replacement state
-  uint32_t lru = std::numeric_limits<uint32_t>::max() >> 1;
-};
-
 class MemoryRequestConsumer
 {
 public:

--- a/replacement/lru/lru.cc
+++ b/replacement/lru/lru.cc
@@ -1,33 +1,30 @@
 #include <algorithm>
-#include <iterator>
+#include <map>
+#include <vector>
 
 #include "cache.h"
-#include "util.h"
 
-void CACHE::initialize_replacement() {}
+std::map<CACHE*, std::vector<uint64_t>> last_used_cycles;
 
-// find replacement victim
-uint32_t CACHE::find_victim(uint32_t cpu, uint64_t instr_id, uint32_t set, const BLOCK* current_set, uint64_t ip, uint64_t full_addr, uint32_t type)
+void CACHE::initialize_replacement()
 {
-  // baseline LRU
-  return std::distance(current_set, std::max_element(current_set, std::next(current_set, NUM_WAY), lru_comparator<BLOCK, BLOCK>()));
+  last_used_cycles[this] = std::vector<uint64_t>(NUM_SET*NUM_WAY);
 }
 
-// called on every cache hit and cache fill
-void CACHE::update_replacement_state(uint32_t cpu, uint32_t set, uint32_t way, uint64_t full_addr, uint64_t ip, uint64_t victim_addr, uint32_t type,
-                                     uint8_t hit)
+uint32_t CACHE::find_victim(uint32_t cpu, uint64_t instr_id, uint32_t set, const BLOCK* current_set, uint64_t ip, uint64_t full_addr, uint32_t type)
 {
-  if (hit && type == WRITEBACK)
-    return;
+  auto begin = std::next(std::begin(last_used_cycles[this]), set*NUM_WAY);
+  auto end   = std::next(begin, NUM_WAY);
 
-  auto begin = std::next(block.begin(), set * NUM_WAY);
-  auto end = std::next(begin, NUM_WAY);
-  uint32_t hit_lru = std::next(begin, way)->lru;
-  std::for_each(begin, end, [hit_lru](BLOCK& x) {
-    if (x.lru <= hit_lru)
-      x.lru++;
-  });
-  std::next(begin, way)->lru = 0; // promote to the MRU position
+  // Find the way whose last use cycle is most distant
+  return std::distance(begin, std::min_element(begin, end));
+}
+
+void CACHE::update_replacement_state(uint32_t cpu, uint32_t set, uint32_t way, uint64_t full_addr, uint64_t ip, uint64_t victim_addr, uint32_t type, uint8_t hit)
+{
+  // Mark the way as being used on the current cycle
+  if (!hit || type != WRITEBACK) // Skip this for writeback hits
+    last_used_cycles[this][set*NUM_WAY + way] = current_cycle;
 }
 
 void CACHE::replacement_final_stats() {}


### PR DESCRIPTION
LRU is the only replacement policy with first-class status, where its metadata was stored in the blocks themselves. This moves the metadata into a separate LRU structure, which should be more informative to new users.