### PR TITLE
Move packet collsion detection into cache operation

### DIFF
--- a/inc/block.h
+++ b/inc/block.h
@@ -16,6 +16,7 @@ class PACKET
 {
 public:
   bool scheduled = false;
+  bool forward_checked = false;
 
   uint8_t asid[2] = {std::numeric_limits<uint8_t>::max(), std::numeric_limits<uint8_t>::max()}, type = 0, fill_level = 0, pf_origin_level = 0;
 

--- a/inc/cache.h
+++ b/inc/cache.h
@@ -57,6 +57,7 @@ public:
   void operate() override;
   void operate_writes();
   void operate_reads();
+  void check_collision();
 
   uint32_t get_occupancy(uint8_t queue_type, uint64_t address) override;
   uint32_t get_size(uint8_t queue_type, uint64_t address) override;

--- a/inc/cache.h
+++ b/inc/cache.h
@@ -37,12 +37,8 @@ public:
   uint64_t pf_requested = 0, pf_issued = 0, pf_useful = 0, pf_useless = 0, pf_fill = 0;
 
   // queues
-  champsim::delay_queue<PACKET> RQ{RQ_SIZE, HIT_LATENCY}, // read queue
-      PQ{PQ_SIZE, HIT_LATENCY},                           // prefetch queue
-      VAPQ{PQ_SIZE, VA_PREFETCH_TRANSLATION_LATENCY},     // virtual address prefetch queue
-      WQ{WQ_SIZE, HIT_LATENCY};                           // write queue
-
-  std::list<PACKET> MSHR; // MSHR
+  std::deque<PACKET> RQ, PQ, VAPQ, WQ;
+  std::list<PACKET> MSHR;
 
   uint64_t sim_access[NUM_CPUS][NUM_TYPES] = {}, sim_hit[NUM_CPUS][NUM_TYPES] = {}, sim_miss[NUM_CPUS][NUM_TYPES] = {}, roi_access[NUM_CPUS][NUM_TYPES] = {},
            roi_hit[NUM_CPUS][NUM_TYPES] = {}, roi_miss[NUM_CPUS][NUM_TYPES] = {};

--- a/inc/cache.h
+++ b/inc/cache.h
@@ -49,9 +49,9 @@ public:
   uint64_t total_miss_latency = 0;
 
   // functions
-  int add_rq(PACKET* packet) override;
-  int add_wq(PACKET* packet) override;
-  int add_pq(PACKET* packet) override;
+  bool add_rq(PACKET* packet) override;
+  bool add_wq(PACKET* packet) override;
+  bool add_pq(PACKET* packet) override;
 
   void return_data(PACKET* packet) override;
   void operate() override;

--- a/inc/dram_controller.h
+++ b/inc/dram_controller.h
@@ -46,6 +46,8 @@ struct DRAM_CHANNEL {
   bool write_mode = false;
 
   unsigned WQ_ROW_BUFFER_HIT = 0, WQ_ROW_BUFFER_MISS = 0, RQ_ROW_BUFFER_HIT = 0, RQ_ROW_BUFFER_MISS = 0, WQ_FULL = 0;
+
+  void check_collision();
 };
 
 class MEMORY_CONTROLLER : public champsim::operable, public MemoryRequestConsumer

--- a/inc/dram_controller.h
+++ b/inc/dram_controller.h
@@ -64,9 +64,9 @@ public:
 
   MEMORY_CONTROLLER(double freq_scale) : champsim::operable(freq_scale), MemoryRequestConsumer(std::numeric_limits<unsigned>::max()) {}
 
-  int add_rq(PACKET* packet) override;
-  int add_wq(PACKET* packet) override;
-  int add_pq(PACKET* packet) override;
+  bool add_rq(PACKET* packet) override;
+  bool add_wq(PACKET* packet) override;
+  bool add_pq(PACKET* packet) override;
 
   void operate() override;
 

--- a/inc/memory_class.h
+++ b/inc/memory_class.h
@@ -28,20 +28,10 @@ public:
 class MemoryRequestConsumer
 {
 public:
-  /*
-   * add_*q() return values:
-   *
-   * -2 : queue full
-   * -1 : packet value forwarded, returned
-   * 0  : packet merged
-   * >0 : new queue occupancy
-   *
-   */
-
   const unsigned fill_level;
-  virtual int add_rq(PACKET* packet) = 0;
-  virtual int add_wq(PACKET* packet) = 0;
-  virtual int add_pq(PACKET* packet) = 0;
+  virtual bool add_rq(PACKET* packet) = 0;
+  virtual bool add_wq(PACKET* packet) = 0;
+  virtual bool add_pq(PACKET* packet) = 0;
   virtual uint32_t get_occupancy(uint8_t queue_type, uint64_t address) = 0;
   virtual uint32_t get_size(uint8_t queue_type, uint64_t address) = 0;
 

--- a/inc/ooo_cpu.h
+++ b/inc/ooo_cpu.h
@@ -22,8 +22,8 @@ class CacheBus : public MemoryRequestProducer
 public:
   champsim::circular_buffer<PACKET> PROCESSED;
   CacheBus(uint32_t cpu, std::size_t q_size, MemoryRequestConsumer* ll) : MemoryRequestProducer(ll), cpu(cpu), PROCESSED(q_size) {}
-  int issue_read(PACKET packet);
-  int issue_write(PACKET packet);
+  bool issue_read(PACKET packet);
+  bool issue_write(PACKET packet);
   void return_data(PACKET* packet);
 };
 
@@ -113,9 +113,9 @@ public:
 
   void initialize_core();
   void execute_store(std::vector<LSQ_ENTRY>::iterator sq_it);
-  int execute_load(std::vector<LSQ_ENTRY>::iterator lq_it);
-  int do_translate_store(std::vector<LSQ_ENTRY>::iterator sq_it);
-  int do_translate_load(std::vector<LSQ_ENTRY>::iterator sq_it);
+  bool execute_load(std::vector<LSQ_ENTRY>::iterator lq_it);
+  bool do_translate_store(std::vector<LSQ_ENTRY>::iterator sq_it);
+  bool do_translate_load(std::vector<LSQ_ENTRY>::iterator sq_it);
   void complete_inflight_instruction();
   void handle_memory_return();
   void retire_rob();

--- a/inc/ptw.h
+++ b/inc/ptw.h
@@ -53,9 +53,9 @@ public:
                   uint32_t v9, uint32_t v10, uint32_t v11, uint32_t v12, uint32_t v13, unsigned latency, MemoryRequestConsumer* ll);
 
   // functions
-  int add_rq(PACKET* packet) override;
-  int add_wq(PACKET* packet) override { assert(0); }
-  int add_pq(PACKET* packet) override { assert(0); }
+  bool add_rq(PACKET* packet) override;
+  bool add_wq(PACKET* packet) override { assert(0); }
+  bool add_pq(PACKET* packet) override { assert(0); }
 
   void return_data(PACKET* packet) override;
   void operate() override;

--- a/src/dram_controller.cc
+++ b/src/dram_controller.cc
@@ -174,7 +174,7 @@ void DRAM_CHANNEL::check_collision()
   }
 }
 
-int MEMORY_CONTROLLER::add_rq(PACKET* packet)
+bool MEMORY_CONTROLLER::add_rq(PACKET* packet)
 {
   auto& channel = channels[dram_get_channel(packet->address)];
 
@@ -184,13 +184,13 @@ int MEMORY_CONTROLLER::add_rq(PACKET* packet)
     packet->event_cycle = current_cycle;
     *rq_it = *packet;
 
-    return get_occupancy(1, packet->address);
+    return true;
   }
 
-  return -2;
+  return false;
 }
 
-int MEMORY_CONTROLLER::add_wq(PACKET* packet)
+bool MEMORY_CONTROLLER::add_wq(PACKET* packet)
 {
   auto& channel = channels[dram_get_channel(packet->address)];
 
@@ -200,14 +200,14 @@ int MEMORY_CONTROLLER::add_wq(PACKET* packet)
     packet->event_cycle = current_cycle;
     *wq_it = *packet;
 
-    return get_occupancy(2, packet->address);
+    return true;
   }
 
   channel.WQ_FULL++;
-  return -2;
+  return false;
 }
 
-int MEMORY_CONTROLLER::add_pq(PACKET* packet) { return add_rq(packet); }
+bool MEMORY_CONTROLLER::add_pq(PACKET* packet) { return add_rq(packet); }
 
 /*
  * | row address | rank index | column address | bank index | channel | block

--- a/src/dram_controller.cc
+++ b/src/dram_controller.cc
@@ -17,6 +17,9 @@ struct next_schedule : public invalid_is_maximal<PACKET, min_event_cycle<PACKET>
 void MEMORY_CONTROLLER::operate()
 {
   for (auto& channel : channels) {
+    // Check for forwarding
+    channel.check_collision();
+
     // Finish request
     if (channel.active_request != std::end(channel.bank_request) && channel.active_request->event_cycle <= current_cycle) {
       for (auto ret : channel.active_request->pkt->to_return)
@@ -114,6 +117,49 @@ void MEMORY_CONTROLLER::operate()
   }
 }
 
+void DRAM_CHANNEL::check_collision()
+{
+  for (auto wq_it = std::find_if(std::begin(WQ), std::end(WQ), std::not_fn(&PACKET::forward_checked)); wq_it != std::end(WQ);) {
+    eq_addr<PACKET> checker{wq_it->address, LOG2_BLOCK_SIZE};
+    if (auto found = std::find_if(std::begin(WQ), wq_it, checker); found != wq_it) { // Forward check
+      *wq_it = {};
+    } else if (auto found = std::find_if(std::next(wq_it), std::end(WQ), checker); found != std::end(WQ)) { // Backward check
+      *wq_it = {};
+    } else {
+      wq_it->forward_checked = true;
+      ++wq_it;
+    }
+  }
+
+  for (auto rq_it = std::find_if(std::begin(RQ), std::end(RQ), std::not_fn(&PACKET::forward_checked)); rq_it != std::end(RQ);) {
+    eq_addr<PACKET> checker{rq_it->address, LOG2_BLOCK_SIZE};
+    if (auto wq_it = std::find_if(std::begin(WQ), std::end(WQ), checker); wq_it != std::end(WQ)) {
+      rq_it->data = wq_it->data;
+      for (auto ret : rq_it->to_return)
+        ret->return_data(&(*rq_it));
+
+      *rq_it = {};
+    } else if (auto found = std::find_if(std::begin(RQ), rq_it, checker); found != rq_it) {
+      packet_dep_merge(found->lq_index_depend_on_me, rq_it->lq_index_depend_on_me);
+      packet_dep_merge(found->sq_index_depend_on_me, rq_it->sq_index_depend_on_me);
+      packet_dep_merge(found->instr_depend_on_me, rq_it->instr_depend_on_me);
+      packet_dep_merge(found->to_return, rq_it->to_return);
+
+      *rq_it = {};
+    } else if (auto found = std::find_if(std::next(rq_it), std::end(RQ), checker); found != std::end(RQ)) {
+      packet_dep_merge(found->lq_index_depend_on_me, rq_it->lq_index_depend_on_me);
+      packet_dep_merge(found->sq_index_depend_on_me, rq_it->sq_index_depend_on_me);
+      packet_dep_merge(found->instr_depend_on_me, rq_it->instr_depend_on_me);
+      packet_dep_merge(found->to_return, rq_it->to_return);
+
+      *rq_it = {};
+    } else {
+      rq_it->forward_checked = true;
+      ++rq_it;
+    }
+  }
+}
+
 int MEMORY_CONTROLLER::add_rq(PACKET* packet)
 {
   if (all_warmup_complete < NUM_CPUS) {
@@ -125,37 +171,16 @@ int MEMORY_CONTROLLER::add_rq(PACKET* packet)
 
   auto& channel = channels[dram_get_channel(packet->address)];
 
-  // Check for forwarding
-  auto wq_it = std::find_if(std::begin(channel.WQ), std::end(channel.WQ), eq_addr<PACKET>(packet->address, LOG2_BLOCK_SIZE));
-  if (wq_it != std::end(channel.WQ)) {
-    packet->data = wq_it->data;
-    for (auto ret : packet->to_return)
-      ret->return_data(packet);
-
-    return -1; // merged index
-  }
-
-  // Check for duplicates
-  auto rq_it = std::find_if(std::begin(channel.RQ), std::end(channel.RQ), eq_addr<PACKET>(packet->address, LOG2_BLOCK_SIZE));
-  if (rq_it != std::end(channel.RQ)) {
-    packet_dep_merge(rq_it->lq_index_depend_on_me, packet->lq_index_depend_on_me);
-    packet_dep_merge(rq_it->sq_index_depend_on_me, packet->sq_index_depend_on_me);
-    packet_dep_merge(rq_it->instr_depend_on_me, packet->instr_depend_on_me);
-    packet_dep_merge(rq_it->to_return, packet->to_return);
-
-    return std::distance(std::begin(channel.RQ), rq_it); // merged index
-  }
-
   // Find empty slot
-  rq_it = std::find_if_not(std::begin(channel.RQ), std::end(channel.RQ), is_valid<PACKET>());
-  if (rq_it == std::end(channel.RQ)) {
-    return 0;
+  if (auto rq_it = std::find_if_not(std::begin(channel.RQ), std::end(channel.RQ), is_valid<PACKET>()); rq_it != std::end(channel.RQ)) {
+    packet->forward_checked = false;
+    packet->event_cycle = current_cycle;
+    *rq_it = *packet;
+
+    return get_occupancy(1, packet->address);
   }
 
-  *rq_it = *packet;
-  rq_it->event_cycle = current_cycle;
-
-  return get_occupancy(1, packet->address);
+  return 0;
 }
 
 int MEMORY_CONTROLLER::add_wq(PACKET* packet)
@@ -165,22 +190,17 @@ int MEMORY_CONTROLLER::add_wq(PACKET* packet)
 
   auto& channel = channels[dram_get_channel(packet->address)];
 
-  // Check for duplicates
-  auto wq_it = std::find_if(std::begin(channel.WQ), std::end(channel.WQ), eq_addr<PACKET>(packet->address, LOG2_BLOCK_SIZE));
-  if (wq_it != std::end(channel.WQ))
-    return 0;
-
   // search for the empty index
-  wq_it = std::find_if_not(std::begin(channel.WQ), std::end(channel.WQ), is_valid<PACKET>());
-  if (wq_it == std::end(channel.WQ)) {
-    channel.WQ_FULL++;
-    return -2;
+  if (auto wq_it = std::find_if_not(std::begin(channel.WQ), std::end(channel.WQ), is_valid<PACKET>()); wq_it != std::end(channel.WQ)) {
+    packet->forward_checked = false;
+    packet->event_cycle = current_cycle;
+    *wq_it = *packet;
+
+    return get_occupancy(2, packet->address);
   }
 
-  *wq_it = *packet;
-  wq_it->event_cycle = current_cycle;
-
-  return get_occupancy(2, packet->address);
+  channel.WQ_FULL++;
+  return -2;
 }
 
 int MEMORY_CONTROLLER::add_pq(PACKET* packet) { return add_rq(packet); }

--- a/src/ptw.cc
+++ b/src/ptw.cc
@@ -160,7 +160,7 @@ void PageTableWalker::operate()
   RQ.operate();
 }
 
-int PageTableWalker::add_rq(PACKET* packet)
+bool PageTableWalker::add_rq(PACKET* packet)
 {
   assert(packet->address != 0);
 
@@ -170,13 +170,13 @@ int PageTableWalker::add_rq(PACKET* packet)
 
   // check occupancy
   if (RQ.full()) {
-    return -2; // cannot handle this request
+    return false; // cannot handle this request
   }
 
   // if there is no duplicate, add it to RQ
   RQ.push_back(*packet);
 
-  return RQ.occupancy();
+  return true;
 }
 
 void PageTableWalker::return_data(PACKET* packet)


### PR DESCRIPTION
This patch pulls the collision detection of `PACKET`s in `MemoryRequestConsumers` into the operation step. Now, packets which are added are not immediately scanned for their collisions, and so can never be immediately (before the `add_*q()` function returns) returned. All packets, provided the underlying allocation succeeds, will spend at least some time in the queue.

This has some advantages. We can now avoid an antipattern in `CACHE` ([here](https://github.com/ChampSim/ChampSim/compare/develop...ngober:virtual_prefetch?expand=1#diff-f12a80a9b06758711decb7a6dadca0e5d80e28206c03953ca5e64551130254f0R297)), where we check the size of the underlying consumer's queue, allocate an MSHR if there is space in the underlying cache, and only then sends the forwarding request. Now, the underlying consumer does not need to advertise its queue capacities. Instead, it returns a boolean concerning whether or not any allocation actually occurred.

This arose out of a larger work that I'm working on, concerning translation in caches, but the change I'm making started getting systemic, so I'm sending it in multiple parts.