### PR TITLE
Pass PACKETs by const reference to memory request producers and consumers

### DIFF
--- a/inc/block.h
+++ b/inc/block.h
@@ -37,7 +37,7 @@ struct is_valid<PACKET> {
 };
 
 template <typename LIST>
-void packet_dep_merge(LIST& dest, LIST& src)
+void packet_dep_merge(LIST& dest, const LIST& src)
 {
   dest.reserve(std::size(dest) + std::size(src));
   auto middle = std::end(dest);

--- a/inc/cache.h
+++ b/inc/cache.h
@@ -53,9 +53,9 @@ public:
   uint64_t total_miss_latency = 0;
 
   // functions
-  int add_rq(PACKET packet) override;
-  int add_wq(PACKET packet) override;
-  int add_pq(PACKET packet) override;
+  int add_rq(const PACKET &packet) override;
+  int add_wq(const PACKET &packet) override;
+  int add_pq(const PACKET &packet) override;
 
   void return_data(const PACKET &packet) override;
   void operate() override;

--- a/inc/cache.h
+++ b/inc/cache.h
@@ -53,11 +53,11 @@ public:
   uint64_t total_miss_latency = 0;
 
   // functions
-  int add_rq(PACKET* packet) override;
-  int add_wq(PACKET* packet) override;
-  int add_pq(PACKET* packet) override;
+  int add_rq(PACKET packet) override;
+  int add_wq(PACKET packet) override;
+  int add_pq(PACKET packet) override;
 
-  void return_data(PACKET* packet) override;
+  void return_data(PACKET packet) override;
   void operate() override;
   void operate_writes();
   void operate_reads();

--- a/inc/cache.h
+++ b/inc/cache.h
@@ -57,7 +57,7 @@ public:
   int add_wq(PACKET packet) override;
   int add_pq(PACKET packet) override;
 
-  void return_data(PACKET packet) override;
+  void return_data(const PACKET &packet) override;
   void operate() override;
   void operate_writes();
   void operate_reads();

--- a/inc/dram_controller.h
+++ b/inc/dram_controller.h
@@ -62,9 +62,9 @@ public:
 
   MEMORY_CONTROLLER(double freq_scale) : champsim::operable(freq_scale), MemoryRequestConsumer(std::numeric_limits<unsigned>::max()) {}
 
-  int add_rq(PACKET* packet) override;
-  int add_wq(PACKET* packet) override;
-  int add_pq(PACKET* packet) override;
+  int add_rq(PACKET packet) override;
+  int add_wq(PACKET packet) override;
+  int add_pq(PACKET packet) override;
 
   void operate() override;
 

--- a/inc/dram_controller.h
+++ b/inc/dram_controller.h
@@ -62,9 +62,9 @@ public:
 
   MEMORY_CONTROLLER(double freq_scale) : champsim::operable(freq_scale), MemoryRequestConsumer(std::numeric_limits<unsigned>::max()) {}
 
-  int add_rq(PACKET packet) override;
-  int add_wq(PACKET packet) override;
-  int add_pq(PACKET packet) override;
+  int add_rq(const PACKET &packet) override;
+  int add_wq(const PACKET &packet) override;
+  int add_pq(const PACKET &packet) override;
 
   void operate() override;
 

--- a/inc/memory_class.h
+++ b/inc/memory_class.h
@@ -52,7 +52,7 @@ class MemoryRequestProducer
 {
 public:
   MemoryRequestConsumer* lower_level;
-  virtual void return_data(PACKET packet) = 0;
+  virtual void return_data(const PACKET &packet) = 0;
 
 protected:
   MemoryRequestProducer() {}

--- a/inc/memory_class.h
+++ b/inc/memory_class.h
@@ -39,9 +39,9 @@ public:
    */
 
   const unsigned fill_level;
-  virtual int add_rq(PACKET* packet) = 0;
-  virtual int add_wq(PACKET* packet) = 0;
-  virtual int add_pq(PACKET* packet) = 0;
+  virtual int add_rq(PACKET packet) = 0;
+  virtual int add_wq(PACKET packet) = 0;
+  virtual int add_pq(PACKET packet) = 0;
   virtual uint32_t get_occupancy(uint8_t queue_type, uint64_t address) = 0;
   virtual uint32_t get_size(uint8_t queue_type, uint64_t address) = 0;
 
@@ -52,7 +52,7 @@ class MemoryRequestProducer
 {
 public:
   MemoryRequestConsumer* lower_level;
-  virtual void return_data(PACKET* packet) = 0;
+  virtual void return_data(PACKET packet) = 0;
 
 protected:
   MemoryRequestProducer() {}

--- a/inc/memory_class.h
+++ b/inc/memory_class.h
@@ -39,9 +39,9 @@ public:
    */
 
   const unsigned fill_level;
-  virtual int add_rq(PACKET packet) = 0;
-  virtual int add_wq(PACKET packet) = 0;
-  virtual int add_pq(PACKET packet) = 0;
+  virtual int add_rq(const PACKET &packet) = 0;
+  virtual int add_wq(const PACKET &packet) = 0;
+  virtual int add_pq(const PACKET &packet) = 0;
   virtual uint32_t get_occupancy(uint8_t queue_type, uint64_t address) = 0;
   virtual uint32_t get_size(uint8_t queue_type, uint64_t address) = 0;
 

--- a/inc/ooo_cpu.h
+++ b/inc/ooo_cpu.h
@@ -24,7 +24,7 @@ public:
   CacheBus(uint32_t cpu, std::size_t q_size, MemoryRequestConsumer* ll) : MemoryRequestProducer(ll), cpu(cpu), PROCESSED(q_size) {}
   int issue_read(PACKET packet);
   int issue_write(PACKET packet);
-  void return_data(PACKET* packet);
+  void return_data(PACKET packet);
 };
 
 // cpu

--- a/inc/ooo_cpu.h
+++ b/inc/ooo_cpu.h
@@ -24,7 +24,7 @@ public:
   CacheBus(uint32_t cpu, std::size_t q_size, MemoryRequestConsumer* ll) : MemoryRequestProducer(ll), cpu(cpu), PROCESSED(q_size) {}
   int issue_read(PACKET packet);
   int issue_write(PACKET packet);
-  void return_data(PACKET packet);
+  void return_data(const PACKET &packet);
 };
 
 // cpu

--- a/inc/ptw.h
+++ b/inc/ptw.h
@@ -53,11 +53,11 @@ public:
                   uint32_t v9, uint32_t v10, uint32_t v11, uint32_t v12, uint32_t v13, unsigned latency, MemoryRequestConsumer* ll);
 
   // functions
-  int add_rq(PACKET* packet) override;
-  int add_wq(PACKET* packet) override { assert(0); }
-  int add_pq(PACKET* packet) override { assert(0); }
+  int add_rq(PACKET packet) override;
+  int add_wq(PACKET packet) override { assert(0); }
+  int add_pq(PACKET packet) override { assert(0); }
 
-  void return_data(PACKET* packet) override;
+  void return_data(PACKET packet) override;
   void operate() override;
 
   void handle_read();

--- a/inc/ptw.h
+++ b/inc/ptw.h
@@ -53,9 +53,9 @@ public:
                   uint32_t v9, uint32_t v10, uint32_t v11, uint32_t v12, uint32_t v13, unsigned latency, MemoryRequestConsumer* ll);
 
   // functions
-  int add_rq(PACKET packet) override;
-  int add_wq(PACKET packet) override { assert(0); }
-  int add_pq(PACKET packet) override { assert(0); }
+  int add_rq(const PACKET &packet) override;
+  int add_wq(const PACKET &packet) override { assert(0); }
+  int add_pq(const PACKET &packet) override { assert(0); }
 
   void return_data(const PACKET &packet) override;
   void operate() override;

--- a/inc/ptw.h
+++ b/inc/ptw.h
@@ -57,7 +57,7 @@ public:
   int add_wq(PACKET packet) override { assert(0); }
   int add_pq(PACKET packet) override { assert(0); }
 
-  void return_data(PACKET packet) override;
+  void return_data(const PACKET &packet) override;
   void operate() override;
 
   void handle_read();

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -636,7 +636,7 @@ int CACHE::add_pq(PACKET packet)
   return PQ.occupancy();
 }
 
-void CACHE::return_data(PACKET packet)
+void CACHE::return_data(const PACKET &packet)
 {
   // check MSHR information
   auto mshr_entry = std::find_if(MSHR.begin(), MSHR.end(), eq_addr<PACKET>(packet.address, OFFSET_BITS));

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -407,7 +407,7 @@ int CACHE::invalidate_entry(uint64_t inval_addr)
   return way;
 }
 
-int CACHE::add_rq(PACKET packet)
+int CACHE::add_rq(const PACKET &packet)
 {
   assert(packet.address != 0);
   RQ_ACCESS++;
@@ -425,9 +425,10 @@ int CACHE::add_rq(PACKET packet)
 
     DP(if (warmup_complete[packet.cpu]) std::cout << " MERGED_WQ" << std::endl;)
 
-    packet.data = found_wq->data;
-    for (auto ret : packet.to_return)
-      ret->return_data(packet);
+    PACKET copy{packet};
+    copy.data = found_wq->data;
+    for (auto ret : copy.to_return)
+      ret->return_data(copy);
 
     WQ_FORWARD++;
     return -1;
@@ -470,7 +471,7 @@ int CACHE::add_rq(PACKET packet)
   return RQ.occupancy();
 }
 
-int CACHE::add_wq(PACKET packet)
+int CACHE::add_wq(const PACKET &packet)
 {
   WQ_ACCESS++;
 
@@ -577,7 +578,7 @@ void CACHE::va_translate_prefetches()
   }
 }
 
-int CACHE::add_pq(PACKET packet)
+int CACHE::add_pq(const PACKET &packet)
 {
   assert(packet.address != 0);
   PQ_ACCESS++;
@@ -595,9 +596,10 @@ int CACHE::add_pq(PACKET packet)
 
     DP(if (warmup_complete[packet.cpu]) std::cout << " MERGED_WQ" << std::endl;)
 
-    packet.data = found_wq->data;
-    for (auto ret : packet.to_return)
-      ret->return_data(packet);
+    PACKET copy{packet};
+    copy.data = found_wq->data;
+    for (auto ret : copy.to_return)
+      ret->return_data(copy);
 
     WQ_FORWARD++;
     return -1;

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -42,7 +42,7 @@ void CACHE::handle_fill()
       fill_mshr->data = block[set * NUM_WAY + way].data;
 
       for (auto ret : fill_mshr->to_return)
-        ret->return_data(&(*fill_mshr));
+        ret->return_data(*fill_mshr);
     }
 
     MSHR.erase(fill_mshr);
@@ -192,7 +192,7 @@ void CACHE::readlike_hit(std::size_t set, std::size_t way, PACKET& handle_pkt)
   sim_access[handle_pkt.cpu][handle_pkt.type]++;
 
   for (auto ret : handle_pkt.to_return)
-    ret->return_data(&handle_pkt);
+    ret->return_data(handle_pkt);
 
   // update prefetch stats and reset prefetch bit
   if (hit_block.prefetch) {
@@ -262,9 +262,9 @@ bool CACHE::readlike_miss(PACKET& handle_pkt)
       handle_pkt.to_return.clear();
 
     if (!is_read)
-      lower_level->add_pq(&handle_pkt);
+      lower_level->add_pq(handle_pkt);
     else
-      lower_level->add_rq(&handle_pkt);
+      lower_level->add_rq(handle_pkt);
   }
 
   // update prefetcher on load instructions and prefetches from upper levels
@@ -310,7 +310,7 @@ bool CACHE::filllike_miss(std::size_t set, std::size_t way, PACKET& handle_pkt)
       writeback_packet.ip = 0;
       writeback_packet.type = WRITEBACK;
 
-      auto result = lower_level->add_wq(&writeback_packet);
+      auto result = lower_level->add_wq(writeback_packet);
       if (result == -2)
         return false;
     }
@@ -407,26 +407,26 @@ int CACHE::invalidate_entry(uint64_t inval_addr)
   return way;
 }
 
-int CACHE::add_rq(PACKET* packet)
+int CACHE::add_rq(PACKET packet)
 {
-  assert(packet->address != 0);
+  assert(packet.address != 0);
   RQ_ACCESS++;
 
-  DP(if (warmup_complete[packet->cpu]) {
-    std::cout << "[" << NAME << "_RQ] " << __func__ << " instr_id: " << packet->instr_id << " address: " << std::hex << (packet->address >> OFFSET_BITS);
-    std::cout << " full_addr: " << packet->address << " v_address: " << packet->v_address << std::dec << " type: " << +packet->type
+  DP(if (warmup_complete[packet.cpu]) {
+    std::cout << "[" << NAME << "_RQ] " << __func__ << " instr_id: " << packet.instr_id << " address: " << std::hex << (packet.address >> OFFSET_BITS);
+    std::cout << " full_addr: " << packet.address << " v_address: " << packet.v_address << std::dec << " type: " << +packet.type
               << " occupancy: " << RQ.occupancy();
   })
 
   // check for the latest writebacks in the write queue
-  champsim::delay_queue<PACKET>::iterator found_wq = std::find_if(WQ.begin(), WQ.end(), eq_addr<PACKET>(packet->address, match_offset_bits ? 0 : OFFSET_BITS));
+  champsim::delay_queue<PACKET>::iterator found_wq = std::find_if(WQ.begin(), WQ.end(), eq_addr<PACKET>(packet.address, match_offset_bits ? 0 : OFFSET_BITS));
 
   if (found_wq != WQ.end()) {
 
-    DP(if (warmup_complete[packet->cpu]) std::cout << " MERGED_WQ" << std::endl;)
+    DP(if (warmup_complete[packet.cpu]) std::cout << " MERGED_WQ" << std::endl;)
 
-    packet->data = found_wq->data;
-    for (auto ret : packet->to_return)
+    packet.data = found_wq->data;
+    for (auto ret : packet.to_return)
       ret->return_data(packet);
 
     WQ_FORWARD++;
@@ -434,15 +434,15 @@ int CACHE::add_rq(PACKET* packet)
   }
 
   // check for duplicates in the read queue
-  auto found_rq = std::find_if(RQ.begin(), RQ.end(), eq_addr<PACKET>(packet->address, OFFSET_BITS));
+  auto found_rq = std::find_if(RQ.begin(), RQ.end(), eq_addr<PACKET>(packet.address, OFFSET_BITS));
   if (found_rq != RQ.end()) {
 
-    DP(if (warmup_complete[packet->cpu]) std::cout << " MERGED_RQ" << std::endl;)
+    DP(if (warmup_complete[packet.cpu]) std::cout << " MERGED_RQ" << std::endl;)
 
-    packet_dep_merge(found_rq->lq_index_depend_on_me, packet->lq_index_depend_on_me);
-    packet_dep_merge(found_rq->sq_index_depend_on_me, packet->sq_index_depend_on_me);
-    packet_dep_merge(found_rq->instr_depend_on_me, packet->instr_depend_on_me);
-    packet_dep_merge(found_rq->to_return, packet->to_return);
+    packet_dep_merge(found_rq->lq_index_depend_on_me, packet.lq_index_depend_on_me);
+    packet_dep_merge(found_rq->sq_index_depend_on_me, packet.sq_index_depend_on_me);
+    packet_dep_merge(found_rq->instr_depend_on_me, packet.instr_depend_on_me);
+    packet_dep_merge(found_rq->to_return, packet.to_return);
 
     RQ_MERGED++;
 
@@ -453,39 +453,39 @@ int CACHE::add_rq(PACKET* packet)
   if (RQ.full()) {
     RQ_FULL++;
 
-    DP(if (warmup_complete[packet->cpu]) std::cout << " FULL" << std::endl;)
+    DP(if (warmup_complete[packet.cpu]) std::cout << " FULL" << std::endl;)
 
     return -2; // cannot handle this request
   }
 
   // if there is no duplicate, add it to RQ
   if (warmup_complete[cpu])
-    RQ.push_back(*packet);
+    RQ.push_back(packet);
   else
-    RQ.push_back_ready(*packet);
+    RQ.push_back_ready(packet);
 
-  DP(if (warmup_complete[packet->cpu]) std::cout << " ADDED" << std::endl;)
+  DP(if (warmup_complete[packet.cpu]) std::cout << " ADDED" << std::endl;)
 
   RQ_TO_CACHE++;
   return RQ.occupancy();
 }
 
-int CACHE::add_wq(PACKET* packet)
+int CACHE::add_wq(PACKET packet)
 {
   WQ_ACCESS++;
 
-  DP(if (warmup_complete[packet->cpu]) {
-    std::cout << "[" << NAME << "_WQ] " << __func__ << " instr_id: " << packet->instr_id << " address: " << std::hex << (packet->address >> OFFSET_BITS);
-    std::cout << " full_addr: " << packet->address << " v_address: " << packet->v_address << std::dec << " type: " << +packet->type
+  DP(if (warmup_complete[packet.cpu]) {
+    std::cout << "[" << NAME << "_WQ] " << __func__ << " instr_id: " << packet.instr_id << " address: " << std::hex << (packet.address >> OFFSET_BITS);
+    std::cout << " full_addr: " << packet.address << " v_address: " << packet.v_address << std::dec << " type: " << +packet.type
               << " occupancy: " << RQ.occupancy();
   })
 
   // check for duplicates in the write queue
-  champsim::delay_queue<PACKET>::iterator found_wq = std::find_if(WQ.begin(), WQ.end(), eq_addr<PACKET>(packet->address, match_offset_bits ? 0 : OFFSET_BITS));
+  champsim::delay_queue<PACKET>::iterator found_wq = std::find_if(WQ.begin(), WQ.end(), eq_addr<PACKET>(packet.address, match_offset_bits ? 0 : OFFSET_BITS));
 
   if (found_wq != WQ.end()) {
 
-    DP(if (warmup_complete[packet->cpu]) std::cout << " MERGED" << std::endl;)
+    DP(if (warmup_complete[packet.cpu]) std::cout << " MERGED" << std::endl;)
 
     WQ_MERGED++;
     return 0; // merged index
@@ -493,7 +493,7 @@ int CACHE::add_wq(PACKET* packet)
 
   // Check for room in the queue
   if (WQ.full()) {
-    DP(if (warmup_complete[packet->cpu]) std::cout << " FULL" << std::endl;)
+    DP(if (warmup_complete[packet.cpu]) std::cout << " FULL" << std::endl;)
 
     ++WQ_FULL;
     return -2;
@@ -501,11 +501,11 @@ int CACHE::add_wq(PACKET* packet)
 
   // if there is no duplicate, add it to the write queue
   if (warmup_complete[cpu])
-    WQ.push_back(*packet);
+    WQ.push_back(packet);
   else
-    WQ.push_back_ready(*packet);
+    WQ.push_back_ready(packet);
 
-  DP(if (warmup_complete[packet->cpu]) std::cout << " ADDED" << std::endl;)
+  DP(if (warmup_complete[packet.cpu]) std::cout << " ADDED" << std::endl;)
 
   WQ_TO_CACHE++;
   WQ_ACCESS++;
@@ -532,7 +532,7 @@ int CACHE::prefetch_line(uint64_t pf_addr, bool fill_this_level, uint32_t prefet
       return 1;
     }
   } else {
-    int result = add_pq(&pf_packet);
+    int result = add_pq(pf_packet);
     if (result != -2) {
       if (result > 0)
         pf_issued++;
@@ -566,7 +566,7 @@ void CACHE::va_translate_prefetches()
     VAPQ.front().address = vmem.va_to_pa(cpu, VAPQ.front().v_address).first;
 
     // move the translated prefetch over to the regular PQ
-    int result = add_pq(&VAPQ.front());
+    int result = add_pq(VAPQ.front());
 
     // remove the prefetch from the VAPQ
     if (result != -2)
@@ -577,26 +577,26 @@ void CACHE::va_translate_prefetches()
   }
 }
 
-int CACHE::add_pq(PACKET* packet)
+int CACHE::add_pq(PACKET packet)
 {
-  assert(packet->address != 0);
+  assert(packet.address != 0);
   PQ_ACCESS++;
 
-  DP(if (warmup_complete[packet->cpu]) {
-    std::cout << "[" << NAME << "_WQ] " << __func__ << " instr_id: " << packet->instr_id << " address: " << std::hex << (packet->address >> OFFSET_BITS);
-    std::cout << " full_addr: " << packet->address << " v_address: " << packet->v_address << std::dec << " type: " << +packet->type
+  DP(if (warmup_complete[packet.cpu]) {
+    std::cout << "[" << NAME << "_WQ] " << __func__ << " instr_id: " << packet.instr_id << " address: " << std::hex << (packet.address >> OFFSET_BITS);
+    std::cout << " full_addr: " << packet.address << " v_address: " << packet.v_address << std::dec << " type: " << +packet.type
               << " occupancy: " << RQ.occupancy();
   })
 
   // check for the latest wirtebacks in the write queue
-  champsim::delay_queue<PACKET>::iterator found_wq = std::find_if(WQ.begin(), WQ.end(), eq_addr<PACKET>(packet->address, match_offset_bits ? 0 : OFFSET_BITS));
+  champsim::delay_queue<PACKET>::iterator found_wq = std::find_if(WQ.begin(), WQ.end(), eq_addr<PACKET>(packet.address, match_offset_bits ? 0 : OFFSET_BITS));
 
   if (found_wq != WQ.end()) {
 
-    DP(if (warmup_complete[packet->cpu]) std::cout << " MERGED_WQ" << std::endl;)
+    DP(if (warmup_complete[packet.cpu]) std::cout << " MERGED_WQ" << std::endl;)
 
-    packet->data = found_wq->data;
-    for (auto ret : packet->to_return)
+    packet.data = found_wq->data;
+    for (auto ret : packet.to_return)
       ret->return_data(packet);
 
     WQ_FORWARD++;
@@ -604,12 +604,12 @@ int CACHE::add_pq(PACKET* packet)
   }
 
   // check for duplicates in the PQ
-  auto found = std::find_if(PQ.begin(), PQ.end(), eq_addr<PACKET>(packet->address, OFFSET_BITS));
+  auto found = std::find_if(PQ.begin(), PQ.end(), eq_addr<PACKET>(packet.address, OFFSET_BITS));
   if (found != PQ.end()) {
-    DP(if (warmup_complete[packet->cpu]) std::cout << " MERGED_PQ" << std::endl;)
+    DP(if (warmup_complete[packet.cpu]) std::cout << " MERGED_PQ" << std::endl;)
 
-    found->fill_level = std::min(found->fill_level, packet->fill_level);
-    packet_dep_merge(found->to_return, packet->to_return);
+    found->fill_level = std::min(found->fill_level, packet.fill_level);
+    packet_dep_merge(found->to_return, packet.to_return);
 
     PQ_MERGED++;
     return 0;
@@ -618,7 +618,7 @@ int CACHE::add_pq(PACKET* packet)
   // check occupancy
   if (PQ.full()) {
 
-    DP(if (warmup_complete[packet->cpu]) std::cout << " FULL" << std::endl;)
+    DP(if (warmup_complete[packet.cpu]) std::cout << " FULL" << std::endl;)
 
     PQ_FULL++;
     return -2; // cannot handle this request
@@ -626,38 +626,38 @@ int CACHE::add_pq(PACKET* packet)
 
   // if there is no duplicate, add it to PQ
   if (warmup_complete[cpu])
-    PQ.push_back(*packet);
+    PQ.push_back(packet);
   else
-    PQ.push_back_ready(*packet);
+    PQ.push_back_ready(packet);
 
-  DP(if (warmup_complete[packet->cpu]) std::cout << " ADDED" << std::endl;)
+  DP(if (warmup_complete[packet.cpu]) std::cout << " ADDED" << std::endl;)
 
   PQ_TO_CACHE++;
   return PQ.occupancy();
 }
 
-void CACHE::return_data(PACKET* packet)
+void CACHE::return_data(PACKET packet)
 {
   // check MSHR information
-  auto mshr_entry = std::find_if(MSHR.begin(), MSHR.end(), eq_addr<PACKET>(packet->address, OFFSET_BITS));
+  auto mshr_entry = std::find_if(MSHR.begin(), MSHR.end(), eq_addr<PACKET>(packet.address, OFFSET_BITS));
   auto first_unreturned = std::find_if(MSHR.begin(), MSHR.end(), [](auto x) { return x.event_cycle == std::numeric_limits<uint64_t>::max(); });
 
   // sanity check
   if (mshr_entry == MSHR.end()) {
-    std::cerr << "[" << NAME << "_MSHR] " << __func__ << " instr_id: " << packet->instr_id << " cannot find a matching entry!";
-    std::cerr << " address: " << std::hex << packet->address;
-    std::cerr << " v_address: " << packet->v_address;
-    std::cerr << " address: " << (packet->address >> OFFSET_BITS) << std::dec;
-    std::cerr << " event: " << packet->event_cycle << " current: " << current_cycle << std::endl;
+    std::cerr << "[" << NAME << "_MSHR] " << __func__ << " instr_id: " << packet.instr_id << " cannot find a matching entry!";
+    std::cerr << " address: " << std::hex << packet.address;
+    std::cerr << " v_address: " << packet.v_address;
+    std::cerr << " address: " << (packet.address >> OFFSET_BITS) << std::dec;
+    std::cerr << " event: " << packet.event_cycle << " current: " << current_cycle << std::endl;
     assert(0);
   }
 
   // MSHR holds the most updated information about this request
-  mshr_entry->data = packet->data;
-  mshr_entry->pf_metadata = packet->pf_metadata;
+  mshr_entry->data = packet.data;
+  mshr_entry->pf_metadata = packet.pf_metadata;
   mshr_entry->event_cycle = current_cycle + (warmup_complete[cpu] ? FILL_LATENCY : 0);
 
-  DP(if (warmup_complete[packet->cpu]) {
+  DP(if (warmup_complete[packet.cpu]) {
     std::cout << "[" << NAME << "_MSHR] " << __func__ << " instr_id: " << mshr_entry->instr_id;
     std::cout << " address: " << std::hex << (mshr_entry->address >> OFFSET_BITS) << " full_addr: " << mshr_entry->address;
     std::cout << " data: " << mshr_entry->data << std::dec;

--- a/src/dram_controller.cc
+++ b/src/dram_controller.cc
@@ -114,7 +114,7 @@ void MEMORY_CONTROLLER::operate()
   }
 }
 
-int MEMORY_CONTROLLER::add_rq(PACKET packet)
+int MEMORY_CONTROLLER::add_rq(const PACKET &packet)
 {
   if (all_warmup_complete < NUM_CPUS) {
     for (auto ret : packet.to_return)
@@ -128,9 +128,10 @@ int MEMORY_CONTROLLER::add_rq(PACKET packet)
   // Check for forwarding
   auto wq_it = std::find_if(std::begin(channel.WQ), std::end(channel.WQ), eq_addr<PACKET>(packet.address, LOG2_BLOCK_SIZE));
   if (wq_it != std::end(channel.WQ)) {
-    packet.data = wq_it->data;
-    for (auto ret : packet.to_return)
-      ret->return_data(packet);
+    PACKET copy{packet};
+    copy.data = wq_it->data;
+    for (auto ret : copy.to_return)
+      ret->return_data(copy);
 
     return -1; // merged index
   }
@@ -158,7 +159,7 @@ int MEMORY_CONTROLLER::add_rq(PACKET packet)
   return get_occupancy(1, packet.address);
 }
 
-int MEMORY_CONTROLLER::add_wq(PACKET packet)
+int MEMORY_CONTROLLER::add_wq(const PACKET &packet)
 {
   if (all_warmup_complete < NUM_CPUS)
     return -1; // Fast-forward
@@ -183,7 +184,7 @@ int MEMORY_CONTROLLER::add_wq(PACKET packet)
   return get_occupancy(2, packet.address);
 }
 
-int MEMORY_CONTROLLER::add_pq(PACKET packet) { return add_rq(packet); }
+int MEMORY_CONTROLLER::add_pq(const PACKET &packet) { return add_rq(packet); }
 
 /*
  * | row address | rank index | column address | bank index | channel | block

--- a/src/dram_controller.cc
+++ b/src/dram_controller.cc
@@ -20,7 +20,7 @@ void MEMORY_CONTROLLER::operate()
     // Finish request
     if (channel.active_request != std::end(channel.bank_request) && channel.active_request->event_cycle <= current_cycle) {
       for (auto ret : channel.active_request->pkt->to_return)
-        ret->return_data(&(*channel.active_request->pkt));
+        ret->return_data(*channel.active_request->pkt);
 
       channel.active_request->valid = false;
 
@@ -114,34 +114,34 @@ void MEMORY_CONTROLLER::operate()
   }
 }
 
-int MEMORY_CONTROLLER::add_rq(PACKET* packet)
+int MEMORY_CONTROLLER::add_rq(PACKET packet)
 {
   if (all_warmup_complete < NUM_CPUS) {
-    for (auto ret : packet->to_return)
+    for (auto ret : packet.to_return)
       ret->return_data(packet);
 
     return -1; // Fast-forward
   }
 
-  auto& channel = channels[dram_get_channel(packet->address)];
+  auto& channel = channels[dram_get_channel(packet.address)];
 
   // Check for forwarding
-  auto wq_it = std::find_if(std::begin(channel.WQ), std::end(channel.WQ), eq_addr<PACKET>(packet->address, LOG2_BLOCK_SIZE));
+  auto wq_it = std::find_if(std::begin(channel.WQ), std::end(channel.WQ), eq_addr<PACKET>(packet.address, LOG2_BLOCK_SIZE));
   if (wq_it != std::end(channel.WQ)) {
-    packet->data = wq_it->data;
-    for (auto ret : packet->to_return)
+    packet.data = wq_it->data;
+    for (auto ret : packet.to_return)
       ret->return_data(packet);
 
     return -1; // merged index
   }
 
   // Check for duplicates
-  auto rq_it = std::find_if(std::begin(channel.RQ), std::end(channel.RQ), eq_addr<PACKET>(packet->address, LOG2_BLOCK_SIZE));
+  auto rq_it = std::find_if(std::begin(channel.RQ), std::end(channel.RQ), eq_addr<PACKET>(packet.address, LOG2_BLOCK_SIZE));
   if (rq_it != std::end(channel.RQ)) {
-    packet_dep_merge(rq_it->lq_index_depend_on_me, packet->lq_index_depend_on_me);
-    packet_dep_merge(rq_it->sq_index_depend_on_me, packet->sq_index_depend_on_me);
-    packet_dep_merge(rq_it->instr_depend_on_me, packet->instr_depend_on_me);
-    packet_dep_merge(rq_it->to_return, packet->to_return);
+    packet_dep_merge(rq_it->lq_index_depend_on_me, packet.lq_index_depend_on_me);
+    packet_dep_merge(rq_it->sq_index_depend_on_me, packet.sq_index_depend_on_me);
+    packet_dep_merge(rq_it->instr_depend_on_me, packet.instr_depend_on_me);
+    packet_dep_merge(rq_it->to_return, packet.to_return);
 
     return std::distance(std::begin(channel.RQ), rq_it); // merged index
   }
@@ -152,21 +152,21 @@ int MEMORY_CONTROLLER::add_rq(PACKET* packet)
     return 0;
   }
 
-  *rq_it = *packet;
+  *rq_it = packet;
   rq_it->event_cycle = current_cycle;
 
-  return get_occupancy(1, packet->address);
+  return get_occupancy(1, packet.address);
 }
 
-int MEMORY_CONTROLLER::add_wq(PACKET* packet)
+int MEMORY_CONTROLLER::add_wq(PACKET packet)
 {
   if (all_warmup_complete < NUM_CPUS)
     return -1; // Fast-forward
 
-  auto& channel = channels[dram_get_channel(packet->address)];
+  auto& channel = channels[dram_get_channel(packet.address)];
 
   // Check for duplicates
-  auto wq_it = std::find_if(std::begin(channel.WQ), std::end(channel.WQ), eq_addr<PACKET>(packet->address, LOG2_BLOCK_SIZE));
+  auto wq_it = std::find_if(std::begin(channel.WQ), std::end(channel.WQ), eq_addr<PACKET>(packet.address, LOG2_BLOCK_SIZE));
   if (wq_it != std::end(channel.WQ))
     return 0;
 
@@ -177,13 +177,13 @@ int MEMORY_CONTROLLER::add_wq(PACKET* packet)
     return -2;
   }
 
-  *wq_it = *packet;
+  *wq_it = packet;
   wq_it->event_cycle = current_cycle;
 
-  return get_occupancy(2, packet->address);
+  return get_occupancy(2, packet.address);
 }
 
-int MEMORY_CONTROLLER::add_pq(PACKET* packet) { return add_rq(packet); }
+int MEMORY_CONTROLLER::add_pq(PACKET packet) { return add_rq(packet); }
 
 /*
  * | row address | rank index | column address | bank index | channel | block

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -902,7 +902,7 @@ void O3_CPU::retire_rob()
     throw champsim::deadlock{cpu};
 }
 
-void CacheBus::return_data(PACKET packet)
+void CacheBus::return_data(const PACKET &packet)
 {
   if (packet.type != PREFETCH) {
     PROCESSED.push_back(packet);

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -902,10 +902,10 @@ void O3_CPU::retire_rob()
     throw champsim::deadlock{cpu};
 }
 
-void CacheBus::return_data(PACKET* packet)
+void CacheBus::return_data(PACKET packet)
 {
-  if (packet->type != PREFETCH) {
-    PROCESSED.push_back(*packet);
+  if (packet.type != PREFETCH) {
+    PROCESSED.push_back(packet);
   }
 }
 
@@ -966,7 +966,7 @@ int CacheBus::issue_read(PACKET data_packet)
   data_packet.cpu = cpu;
   data_packet.to_return = {this};
 
-  return lower_level->add_rq(&data_packet);
+  return lower_level->add_rq(data_packet);
 }
 
 int CacheBus::issue_write(PACKET data_packet)
@@ -974,5 +974,5 @@ int CacheBus::issue_write(PACKET data_packet)
   data_packet.fill_level = lower_level->fill_level;
   data_packet.cpu = cpu;
 
-  return lower_level->add_wq(&data_packet);
+  return lower_level->add_wq(data_packet);
 }

--- a/src/ptw.cc
+++ b/src/ptw.cc
@@ -160,7 +160,7 @@ void PageTableWalker::operate()
   RQ.operate();
 }
 
-int PageTableWalker::add_rq(PACKET packet)
+int PageTableWalker::add_rq(const PACKET &packet)
 {
   assert(packet.address != 0);
 

--- a/src/ptw.cc
+++ b/src/ptw.cc
@@ -26,7 +26,7 @@ void PageTableWalker::handle_read()
   while (reads_this_cycle > 0 && RQ.has_ready() && std::size(MSHR) != MSHR_SIZE) {
     PACKET& handle_pkt = RQ.front();
 
-    DP(if (warmup_complete[packet->cpu]) {
+    DP(if (warmup_complete[handle_pkt.cpu]) {
       std::cout << "[" << NAME << "] " << __func__ << " instr_id: " << handle_pkt.instr_id;
       std::cout << " address: " << std::hex << (handle_pkt.address >> LOG2_PAGE_SIZE) << " full_addr: " << handle_pkt.address;
       std::cout << " full_v_addr: " << handle_pkt.v_address;
@@ -54,7 +54,7 @@ void PageTableWalker::handle_read()
     packet.translation_level = packet.init_translation_level;
     packet.to_return = {this};
 
-    int rq_index = lower_level->add_rq(&packet);
+    int rq_index = lower_level->add_rq(packet);
     if (rq_index == -2)
       return;
 
@@ -99,7 +99,7 @@ void PageTableWalker::handle_fill()
         });
 
         for (auto ret : fill_mshr->to_return)
-          ret->return_data(&(*fill_mshr));
+          ret->return_data(*fill_mshr);
 
         if (warmup_complete[cpu])
           total_miss_latency += current_cycle - fill_mshr->cycle_enqueued;
@@ -138,7 +138,7 @@ void PageTableWalker::handle_fill()
         packet.to_return = {this};
         packet.translation_level = fill_mshr->translation_level - 1;
 
-        int rq_index = lower_level->add_rq(&packet);
+        int rq_index = lower_level->add_rq(packet);
         if (rq_index != -2) {
           fill_mshr->event_cycle = std::numeric_limits<uint64_t>::max();
           fill_mshr->address = packet.address;
@@ -160,12 +160,12 @@ void PageTableWalker::operate()
   RQ.operate();
 }
 
-int PageTableWalker::add_rq(PACKET* packet)
+int PageTableWalker::add_rq(PACKET packet)
 {
-  assert(packet->address != 0);
+  assert(packet.address != 0);
 
   // check for duplicates in the read queue
-  auto found_rq = std::find_if(RQ.begin(), RQ.end(), eq_addr<PACKET>(packet->address, LOG2_PAGE_SIZE));
+  auto found_rq = std::find_if(RQ.begin(), RQ.end(), eq_addr<PACKET>(packet.address, LOG2_PAGE_SIZE));
   assert(found_rq == RQ.end()); // Duplicate request should not be sent.
 
   // check occupancy
@@ -174,15 +174,15 @@ int PageTableWalker::add_rq(PACKET* packet)
   }
 
   // if there is no duplicate, add it to RQ
-  RQ.push_back(*packet);
+  RQ.push_back(packet);
 
   return RQ.occupancy();
 }
 
-void PageTableWalker::return_data(PACKET* packet)
+void PageTableWalker::return_data(PACKET packet)
 {
   for (auto& mshr_entry : MSHR) {
-    if (eq_addr<PACKET>{packet->address, LOG2_BLOCK_SIZE}(mshr_entry)) {
+    if (eq_addr<PACKET>{packet.address, LOG2_BLOCK_SIZE}(mshr_entry)) {
       mshr_entry.event_cycle = current_cycle;
 
       DP(if (warmup_complete[cpu]) {

--- a/src/ptw.cc
+++ b/src/ptw.cc
@@ -179,7 +179,7 @@ int PageTableWalker::add_rq(PACKET packet)
   return RQ.occupancy();
 }
 
-void PageTableWalker::return_data(PACKET packet)
+void PageTableWalker::return_data(const PACKET &packet)
 {
   for (auto& mshr_entry : MSHR) {
     if (eq_addr<PACKET>{packet.address, LOG2_BLOCK_SIZE}(mshr_entry)) {


### PR DESCRIPTION
This patch passes `PACKET` objects by const reference to the producers and consumers. The previous way of passing them, by pointer, implies some strange things about ownership and modification. Passing by const reference makes the interface clearly designate that the queue allocation and the returning actions will not modify the passed packet.