### PR TITLE
Removed some preprocessor compile controls

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -30,36 +30,6 @@ vmem_fmtstr = 'VirtualMemory vmem({attrs[size]}, 1 << 12, {attrs[num_levels]}, 1
 
 module_make_fmtstr = '{1}/%.o: CFLAGS += -I{1}\n{1}/%.o: CXXFLAGS += -I{1}\n{1}/%.o: CXXFLAGS += {2}\nobj/{0}: $(patsubst %.cc,%.o,$(wildcard {1}/*.cc)) $(patsubst %.c,%.o,$(wildcard {1}/*.c))\n\t@mkdir -p $(dir $@)\n\tar -rcs $@ $^\n\n'
 
-define_fmtstr = '#define {{names[{name}]}} {{config[{name}]}}ul\n'
-define_nonint_fmtstr = '#define {{names[{name}]}} {{config[{name}]}}\n'
-define_log_fmtstr = '#define LOG2_{{names[{name}]}} lg2({{names[{name}]}})\n'
-
-###
-# Begin named constants
-###
-
-const_names = {
-    'block_size': 'BLOCK_SIZE',
-    'page_size': 'PAGE_SIZE',
-    'heartbeat_frequency': 'STAT_PRINTING_PERIOD',
-    'num_cores': 'NUM_CPUS',
-    'physical_memory': {
-        'io_freq': 'DRAM_IO_FREQ',
-        'channels': 'DRAM_CHANNELS',
-        'ranks': 'DRAM_RANKS',
-        'banks': 'DRAM_BANKS',
-        'rows': 'DRAM_ROWS',
-        'columns': 'DRAM_COLUMNS',
-        'channel_width': 'DRAM_CHANNEL_WIDTH',
-        'wq_size': 'DRAM_WQ_SIZE',
-        'rq_size': 'DRAM_RQ_SIZE',
-        'tRP': 'tRP_DRAM_NANOSECONDS',
-        'tRCD': 'tRCD_DRAM_NANOSECONDS',
-        'tCAS': 'tCAS_DRAM_NANOSECONDS',
-        'turn_around_time': 'DBUS_TURN_AROUND_NANOSECONDS'
-    }
-}
-
 ###
 # Begin default core model definition
 ###
@@ -579,20 +549,28 @@ with open(constants_header_name, 'wt') as wfp:
     wfp.write('#ifndef CHAMPSIM_CONSTANTS_H\n')
     wfp.write('#define CHAMPSIM_CONSTANTS_H\n')
     wfp.write('#include "util.h"\n')
-    wfp.write(define_fmtstr.format(name='block_size').format(names=const_names, config=config_file))
-    wfp.write(define_log_fmtstr.format(name='block_size').format(names=const_names, config=config_file))
-    wfp.write(define_fmtstr.format(name='page_size').format(names=const_names, config=config_file))
-    wfp.write(define_log_fmtstr.format(name='page_size').format(names=const_names, config=config_file))
-    wfp.write(define_fmtstr.format(name='heartbeat_frequency').format(names=const_names, config=config_file))
-    wfp.write(define_fmtstr.format(name='num_cores').format(names=const_names, config=config_file))
-    wfp.write('#define NUM_CACHES ' + str(len(caches)) + 'u\n')
-    wfp.write('#define NUM_OPERABLES ' + str(len(cores) + len(memory_system) + 1) + 'u\n')
+    wfp.write('constexpr unsigned BLOCK_SIZE = {block_size};\n'.format(**config_file))
+    wfp.write('constexpr unsigned PAGE_SIZE = {page_size};\n'.format(**config_file))
+    wfp.write('constexpr uint64_t STAT_PRINTING_PERIOD = {heartbeat_frequency};\n'.format(**config_file))
+    wfp.write('constexpr std::size_t NUM_CPUS = {num_cores};\n'.format(**config_file))
+    wfp.write('constexpr std::size_t NUM_CACHES = ' + str(len(caches)) + ';\n')
+    wfp.write('constexpr std::size_t NUM_OPERABLES = 2*NUM_CPUS + NUM_CACHES + 1;\n')
+    wfp.write('constexpr auto LOG2_BLOCK_SIZE = lg2(BLOCK_SIZE);\n')
+    wfp.write('constexpr auto LOG2_PAGE_SIZE = lg2(PAGE_SIZE);\n')
 
-    for k in const_names['physical_memory']:
-        if k in ['tRP', 'tRCD', 'tCAS', 'turn_around_time']:
-            wfp.write(define_nonint_fmtstr.format(name=k).format(names=const_names['physical_memory'], config=config_file['physical_memory']))
-        else:
-            wfp.write(define_fmtstr.format(name=k).format(names=const_names['physical_memory'], config=config_file['physical_memory']))
+    wfp.write('constexpr uint64_t DRAM_IO_FREQ = {io_freq};\n'.format(**config_file['physical_memory']))
+    wfp.write('constexpr std::size_t DRAM_CHANNELS = {channels};\n'.format(**config_file['physical_memory']))
+    wfp.write('constexpr std::size_t DRAM_RANKS = {ranks};\n'.format(**config_file['physical_memory']))
+    wfp.write('constexpr std::size_t DRAM_BANKS = {banks};\n'.format(**config_file['physical_memory']))
+    wfp.write('constexpr std::size_t DRAM_ROWS = {rows};\n'.format(**config_file['physical_memory']))
+    wfp.write('constexpr std::size_t DRAM_COLUMNS = {columns};\n'.format(**config_file['physical_memory']))
+    wfp.write('constexpr std::size_t DRAM_CHANNEL_WIDTH = {channel_width};\n'.format(**config_file['physical_memory']))
+    wfp.write('constexpr std::size_t DRAM_WQ_SIZE = {wq_size};\n'.format(**config_file['physical_memory']))
+    wfp.write('constexpr std::size_t DRAM_RQ_SIZE = {rq_size};\n'.format(**config_file['physical_memory']))
+    wfp.write('constexpr double tRP_DRAM_NANOSECONDS = {tRP};\n'.format(**config_file['physical_memory']))
+    wfp.write('constexpr double tRCD_DRAM_NANOSECONDS = {tRCD};\n'.format(**config_file['physical_memory']))
+    wfp.write('constexpr double tCAS_DRAM_NANOSECONDS = {tCAS};\n'.format(**config_file['physical_memory']))
+    wfp.write('constexpr double DBUS_TURN_AROUND_NANOSECONDS = {turn_around_time};\n'.format(**config_file['physical_memory']))
 
     wfp.write('#endif\n')
 

--- a/inc/block.h
+++ b/inc/block.h
@@ -4,7 +4,6 @@
 #include <algorithm>
 #include <vector>
 
-#include "champsim_constants.h"
 #include "circular_buffer.hpp"
 #include "instruction.h"
 
@@ -21,7 +20,7 @@ public:
   uint8_t asid[2] = {std::numeric_limits<uint8_t>::max(), std::numeric_limits<uint8_t>::max()}, type = 0, fill_level = 0, pf_origin_level = 0;
 
   uint32_t pf_metadata = 0;
-  uint32_t cpu = NUM_CPUS;
+  uint32_t cpu = std::numeric_limits<uint32_t>::max();
 
   uint64_t address = 0, v_address = 0, data = 0, instr_id = 0, ip = 0, event_cycle = std::numeric_limits<uint64_t>::max(), cycle_enqueued = 0;
 

--- a/inc/cache.h
+++ b/inc/cache.h
@@ -1,21 +1,25 @@
 #ifndef CACHE_H
 #define CACHE_H
 
+#include <deque>
 #include <functional>
 #include <list>
 #include <string>
 #include <vector>
 
-#include "champsim.h"
+#include "champsim_constants.h"
 #include "delay_queue.hpp"
 #include "memory_class.h"
-#include "ooo_cpu.h"
 #include "operable.h"
+
+#define FILL_L1 1
+#define FILL_L2 2
+#define FILL_LLC 4
+#define FILL_DRC 8
+#define FILL_DRAM 16
 
 // virtual address space prefetching
 #define VA_PREFETCH_TRANSLATION_LATENCY 2
-
-extern std::array<O3_CPU*, NUM_CPUS> ooo_cpu;
 
 class CACHE : public champsim::operable, public MemoryRequestConsumer, public MemoryRequestProducer
 {

--- a/inc/cache.h
+++ b/inc/cache.h
@@ -12,17 +12,19 @@
 #include "memory_class.h"
 #include "operable.h"
 
-#define FILL_L1 1
-#define FILL_L2 2
-#define FILL_LLC 4
-#define FILL_DRC 8
-#define FILL_DRAM 16
-
 // virtual address space prefetching
 #define VA_PREFETCH_TRANSLATION_LATENCY 2
 
 class CACHE : public champsim::operable, public MemoryRequestConsumer, public MemoryRequestProducer
 {
+  enum FILL_LEVEL {
+    FILL_L1 = 1,
+    FILL_L2 = 2,
+    FILL_LLC = 4,
+    FILL_DRC = 8,
+    FILL_DRAM = 16
+  };
+
   class BLOCK
   {
   public:

--- a/inc/cache.h
+++ b/inc/cache.h
@@ -13,7 +13,7 @@
 #include "operable.h"
 
 // virtual address space prefetching
-#define VA_PREFETCH_TRANSLATION_LATENCY 2
+constexpr uint64_t VA_PREFETCH_TRANSLATION_LATENCY = 2;
 
 class CACHE : public champsim::operable, public MemoryRequestConsumer, public MemoryRequestProducer
 {

--- a/inc/champsim.h
+++ b/inc/champsim.h
@@ -1,12 +1,7 @@
 #ifndef CHAMPSIM_H
 #define CHAMPSIM_H
 
-#include <array>
-#include <cstdint>
 #include <exception>
-#include <iostream>
-
-#include "champsim_constants.h"
 
 #define INFLIGHT 1
 #define COMPLETED 2
@@ -16,8 +11,6 @@
 #define FILL_LLC 4
 #define FILL_DRC 8
 #define FILL_DRAM 16
-
-extern uint8_t warmup_complete[NUM_CPUS];
 
 namespace champsim
 {

--- a/inc/champsim.h
+++ b/inc/champsim.h
@@ -8,12 +8,6 @@
 
 #include "champsim_constants.h"
 
-// USEFUL MACROS
-#define SANITY_CHECK
-#define LLC_BYPASS
-#define DRC_BYPASS
-#define NO_CRC2_COMPILE
-
 #define INFLIGHT 1
 #define COMPLETED 2
 

--- a/inc/champsim.h
+++ b/inc/champsim.h
@@ -9,19 +9,11 @@
 #include "champsim_constants.h"
 
 // USEFUL MACROS
-//#define DEBUG_PRINT
 #define SANITY_CHECK
 #define LLC_BYPASS
 #define DRC_BYPASS
 #define NO_CRC2_COMPILE
 
-#ifdef DEBUG_PRINT
-#define DP(x) x
-#else
-#define DP(x)
-#endif
-
-// CACHE
 #define INFLIGHT 1
 #define COMPLETED 2
 
@@ -43,6 +35,12 @@ struct deadlock : public std::exception {
 struct deprecated_clock_cycle {
   uint64_t operator[](std::size_t cpu_idx);
 };
+
+#ifdef DEBUG_PRINT
+constexpr bool debug_print = true;
+#else
+constexpr bool debug_print = false;
+#endif
 } // namespace champsim
 
 extern champsim::deprecated_clock_cycle current_core_cycle;

--- a/inc/champsim.h
+++ b/inc/champsim.h
@@ -3,15 +3,6 @@
 
 #include <exception>
 
-#define INFLIGHT 1
-#define COMPLETED 2
-
-#define FILL_L1 1
-#define FILL_L2 2
-#define FILL_LLC 4
-#define FILL_DRC 8
-#define FILL_DRAM 16
-
 namespace champsim
 {
 struct deadlock : public std::exception {

--- a/inc/dram_controller.h
+++ b/inc/dram_controller.h
@@ -2,7 +2,6 @@
 #define DRAM_H
 
 #include <array>
-#include <cmath>
 #include <limits>
 
 #include "champsim_constants.h"

--- a/inc/ooo_cpu.h
+++ b/inc/ooo_cpu.h
@@ -15,8 +15,10 @@
 #include "memory_class.h"
 #include "operable.h"
 
-#define INFLIGHT 1
-#define COMPLETED 2
+enum STATUS {
+  INFLIGHT = 1,
+  COMPLETED = 2
+};
 
 class CacheBus : public MemoryRequestProducer
 {

--- a/inc/ooo_cpu.h
+++ b/inc/ooo_cpu.h
@@ -9,11 +9,14 @@
 #include <vector>
 
 #include "block.h"
-#include "champsim.h"
+#include "champsim_constants.h"
 #include "delay_queue.hpp"
 #include "instruction.h"
 #include "memory_class.h"
 #include "operable.h"
+
+#define INFLIGHT 1
+#define COMPLETED 2
 
 class CacheBus : public MemoryRequestProducer
 {

--- a/prefetcher/spp_dev/spp_dev.cc
+++ b/prefetcher/spp_dev/spp_dev.cc
@@ -25,9 +25,10 @@ uint32_t CACHE::prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cac
   confidence_q[0] = 100;
   GHR.global_accuracy = GHR.pf_issued ? ((100 * GHR.pf_useful) / GHR.pf_issued) : 0;
 
-  SPP_DP(std::cout << std::endl
-                   << "[ChampSim] " << __func__ << " addr: " << std::hex << addr << " cache_line: " << (addr >> LOG2_BLOCK_SIZE);
-         std::cout << " page: " << page << " page_offset: " << std::dec << page_offset << std::endl;);
+  if constexpr (SPP_DEBUG_PRINT) {
+    std::cout << std::endl << "[ChampSim] " << __func__ << " addr: " << std::hex << addr << " cache_line: " << (addr >> LOG2_BLOCK_SIZE);
+    std::cout << " page: " << page << " page_offset: " << std::dec << page_offset << std::endl;
+  }
 
   // Stage 1: Read and update a sig stored in ST
   // last_sig and delta are used to update (sig, delta) correlation in PT
@@ -46,9 +47,7 @@ uint32_t CACHE::prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cac
   uint32_t lookahead_conf = 100, pf_q_head = 0, pf_q_tail = 0;
   uint8_t do_lookahead = 0;
 
-#ifdef LOOKAHEAD_ON
   do {
-#endif
     uint32_t lookahead_way = PT_WAY;
     PT.read_pattern(curr_sig, delta_q, confidence_q, lookahead_way, lookahead_conf, pf_q_tail, depth);
 
@@ -67,20 +66,24 @@ uint32_t CACHE::prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cac
                 GHR.pf_issued >>= 1;
                 GHR.pf_useful >>= 1;
               }
-              SPP_DP(std::cout << "[ChampSim] SPP L2 prefetch issued GHR.pf_issued: " << GHR.pf_issued << " GHR.pf_useful: " << GHR.pf_useful << std::endl;);
+              if constexpr (SPP_DEBUG_PRINT) {
+                std::cout << "[ChampSim] SPP L2 prefetch issued GHR.pf_issued: " << GHR.pf_issued << " GHR.pf_useful: " << GHR.pf_useful << std::endl;
+              }
             }
 
-            SPP_DP(std::cout << "[ChampSim] " << __func__ << " base_addr: " << std::hex << base_addr << " pf_addr: " << pf_addr;
-                   std::cout << " pf_cache_line: " << (pf_addr >> LOG2_BLOCK_SIZE);
-                   std::cout << " prefetch_delta: " << std::dec << delta_q[i] << " confidence: " << confidence_q[i];
-                   std::cout << " depth: " << i << " fill_level: " << ((confidence_q[i] >= FILL_THRESHOLD) ? FILL_L2 : FILL_LLC) << std::endl;);
+            if constexpr (SPP_DEBUG_PRINT) {
+              std::cout << "[ChampSim] " << __func__ << " base_addr: " << std::hex << base_addr << " pf_addr: " << pf_addr;
+              std::cout << " pf_cache_line: " << (pf_addr >> LOG2_BLOCK_SIZE);
+              std::cout << " prefetch_delta: " << std::dec << delta_q[i] << " confidence: " << confidence_q[i];
+              std::cout << " depth: " << i << " fill_level: " << ((confidence_q[i] >= FILL_THRESHOLD) ? FILL_L2 : FILL_LLC) << std::endl;
+            }
           }
         } else { // Prefetch request is crossing the physical page boundary
-#ifdef GHR_ON
-          // Store this prefetch request in GHR to bootstrap SPP learning when
-          // we see a ST miss (i.e., accessing a new page)
-          GHR.update_entry(curr_sig, confidence_q[i], (pf_addr >> LOG2_BLOCK_SIZE) & 0x3F, delta_q[i]);
-#endif
+          if constexpr (GHR_ON) {
+            // Store this prefetch request in GHR to bootstrap SPP learning when
+            // we see a ST miss (i.e., accessing a new page)
+            GHR.update_entry(curr_sig, confidence_q[i], (pf_addr >> LOG2_BLOCK_SIZE) & 0x3F, delta_q[i]);
+          }
         }
 
         do_lookahead = 1;
@@ -102,22 +105,23 @@ uint32_t CACHE::prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cac
       curr_sig = ((curr_sig << SIG_SHIFT) ^ sig_delta) & SIG_MASK;
     }
 
-    SPP_DP(std::cout << "Looping curr_sig: " << std::hex << curr_sig << " base_addr: " << base_addr << std::dec;
-           std::cout << " pf_q_head: " << pf_q_head << " pf_q_tail: " << pf_q_tail << " depth: " << depth << std::endl;);
-
-#ifdef LOOKAHEAD_ON
-  } while (do_lookahead);
-#endif
+    if constexpr (SPP_DEBUG_PRINT) {
+      std::cout << "Looping curr_sig: " << std::hex << curr_sig << " base_addr: " << base_addr << std::dec;
+      std::cout << " pf_q_head: " << pf_q_head << " pf_q_tail: " << pf_q_tail << " depth: " << depth << std::endl;
+    }
+  } while (LOOKAHEAD_ON && do_lookahead);
 
   return metadata_in;
 }
 
 uint32_t CACHE::prefetcher_cache_fill(uint64_t addr, uint32_t set, uint32_t match, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
 {
-#ifdef FILTER_ON
-  SPP_DP(std::cout << std::endl;);
-  FILTER.check(evicted_addr, L2C_EVICT);
-#endif
+  if constexpr (FILTER_ON) {
+    if constexpr (SPP_DEBUG_PRINT) {
+      std::cout << std::endl;
+    }
+    FILTER.check(evicted_addr, L2C_EVICT);
+  }
 
   return metadata_in;
 }
@@ -149,7 +153,9 @@ void SIGNATURE_TABLE::read_and_update_sig(uint64_t page, uint32_t page_offset, u
   uint8_t ST_hit = 0;
   int sig_delta = 0;
 
-  SPP_DP(std::cout << "[ST] " << __func__ << " page: " << std::hex << page << " partial_page: " << partial_page << std::dec << std::endl;);
+  if constexpr (SPP_DEBUG_PRINT) {
+    std::cout << "[ST] " << __func__ << " page: " << std::hex << page << " partial_page: " << partial_page << std::dec << std::endl;
+  }
 
   // Case 2: Invalid
   if (match == ST_WAY) {
@@ -166,10 +172,12 @@ void SIGNATURE_TABLE::read_and_update_sig(uint64_t page, uint32_t page_offset, u
           curr_sig = sig[set][match];
           last_offset[set][match] = page_offset;
 
-          SPP_DP(std::cout << "[ST] " << __func__ << " hit set: " << set << " way: " << match;
-                 std::cout << " valid: " << valid[set][match] << " tag: " << std::hex << tag[set][match];
-                 std::cout << " last_sig: " << last_sig << " curr_sig: " << curr_sig;
-                 std::cout << " delta: " << std::dec << delta << " last_offset: " << page_offset << std::endl;);
+          if constexpr (SPP_DEBUG_PRINT) {
+            std::cout << "[ST] " << __func__ << " hit set: " << set << " way: " << match;
+            std::cout << " valid: " << valid[set][match] << " tag: " << std::hex << tag[set][match];
+            std::cout << " last_sig: " << last_sig << " curr_sig: " << curr_sig;
+            std::cout << " delta: " << std::dec << delta << " last_offset: " << page_offset << std::endl;
+          }
         } else
           last_sig = 0; // Hitting the same cache line, delta is zero
 
@@ -189,67 +197,69 @@ void SIGNATURE_TABLE::read_and_update_sig(uint64_t page, uint32_t page_offset, u
         curr_sig = sig[set][match];
         last_offset[set][match] = page_offset;
 
-        SPP_DP(std::cout << "[ST] " << __func__ << " invalid set: " << set << " way: " << match;
-               std::cout << " valid: " << valid[set][match] << " tag: " << std::hex << partial_page;
-               std::cout << " sig: " << sig[set][match] << " last_offset: " << std::dec << page_offset << std::endl;);
+        if constexpr (SPP_DEBUG_PRINT) {
+          std::cout << "[ST] " << __func__ << " invalid set: " << set << " way: " << match;
+          std::cout << " valid: " << valid[set][match] << " tag: " << std::hex << partial_page;
+          std::cout << " sig: " << sig[set][match] << " last_offset: " << std::dec << page_offset << std::endl;
+        }
 
         break;
       }
     }
   }
 
-#ifdef SPP_SANITY_CHECK
-  // Assertion
-  if (match == ST_WAY) {
-    for (match = 0; match < ST_WAY; match++) {
-      if (lru[set][match] == ST_WAY - 1) { // Find replacement victim
-        tag[set][match] = partial_page;
-        sig[set][match] = 0;
-        curr_sig = sig[set][match];
-        last_offset[set][match] = page_offset;
-
-        SPP_DP(std::cout << "[ST] " << __func__ << " miss set: " << set << " way: " << match;
-               std::cout << " valid: " << valid[set][match] << " victim tag: " << std::hex << tag[set][match] << " new tag: " << partial_page;
-               std::cout << " sig: " << sig[set][match] << " last_offset: " << std::dec << page_offset << std::endl;);
-
-        break;
-      }
-    }
-
-#ifdef SPP_SANITY_CHECK
+  if constexpr (SPP_SANITY_CHECK) {
     // Assertion
     if (match == ST_WAY) {
-      std::cout << "[ST] Cannot find a replacement victim!" << std::endl;
-      assert(0);
+      for (match = 0; match < ST_WAY; match++) {
+        if (lru[set][match] == ST_WAY - 1) { // Find replacement victim
+          tag[set][match] = partial_page;
+          sig[set][match] = 0;
+          curr_sig = sig[set][match];
+          last_offset[set][match] = page_offset;
+
+          if constexpr (SPP_DEBUG_PRINT) {
+            std::cout << "[ST] " << __func__ << " miss set: " << set << " way: " << match;
+            std::cout << " valid: " << valid[set][match] << " victim tag: " << std::hex << tag[set][match] << " new tag: " << partial_page;
+            std::cout << " sig: " << sig[set][match] << " last_offset: " << std::dec << page_offset << std::endl;
+          }
+
+          break;
+        }
+      }
+
+      // Assertion
+      if (match == ST_WAY) {
+        std::cout << "[ST] Cannot find a replacement victim!" << std::endl;
+        assert(0);
+      }
     }
-#endif
   }
-#endif
 }
 
-#ifdef GHR_ON
-if (ST_hit == 0) {
-  uint32_t GHR_found = GHR.check_entry(page_offset);
-  if (GHR_found < MAX_GHR_ENTRY) {
-    sig_delta = (GHR.delta[GHR_found] < 0) ? (((-1) * GHR.delta[GHR_found]) + (1 << (SIG_DELTA_BIT - 1))) : GHR.delta[GHR_found];
-    sig[set][match] = ((GHR.sig[GHR_found] << SIG_SHIFT) ^ sig_delta) & SIG_MASK;
-    curr_sig = sig[set][match];
+if constexpr (GHR_ON) {
+  if (ST_hit == 0) {
+    uint32_t GHR_found = GHR.check_entry(page_offset);
+    if (GHR_found < MAX_GHR_ENTRY) {
+      sig_delta = (GHR.delta[GHR_found] < 0) ? (((-1) * GHR.delta[GHR_found]) + (1 << (SIG_DELTA_BIT - 1))) : GHR.delta[GHR_found];
+      sig[set][match] = ((GHR.sig[GHR_found] << SIG_SHIFT) ^ sig_delta) & SIG_MASK;
+      curr_sig = sig[set][match];
+    }
   }
 }
-#endif
 
 // Update LRU
 for (uint32_t way = 0; way < ST_WAY; way++) {
   if (lru[set][way] < lru[set][match]) {
     lru[set][way]++;
 
-#ifdef SPP_SANITY_CHECK
-    // Assertion
-    if (lru[set][way] >= ST_WAY) {
-      std::cout << "[ST] LRU value is wrong! set: " << set << " way: " << way << " lru: " << lru[set][way] << std::endl;
-      assert(0);
+    if constexpr (SPP_SANITY_CHECK) {
+      // Assertion
+      if (lru[set][way] >= ST_WAY) {
+        std::cout << "[ST] LRU value is wrong! set: " << set << " way: " << way << " lru: " << lru[set][way] << std::endl;
+        assert(0);
+      }
     }
-#endif
   }
 }
 }
@@ -272,47 +282,48 @@ void PATTERN_TABLE::update_pattern(uint32_t last_sig, int curr_delta)
         c_sig[set] >>= 1;
       }
 
-      SPP_DP(std::cout << "[PT] " << __func__ << " hit sig: " << std::hex << last_sig << std::dec << " set: " << set << " way: " << match;
-             std::cout << " delta: " << delta[set][match] << " c_delta: " << c_delta[set][match] << " c_sig: " << c_sig[set] << std::endl;);
+      if constexpr (SPP_DEBUG_PRINT) {
+        std::cout << "[PT] " << __func__ << " hit sig: " << std::hex << last_sig << std::dec << " set: " << set << " way: " << match;
+        std::cout << " delta: " << delta[set][match] << " c_delta: " << c_delta[set][match] << " c_sig: " << c_sig[set] << std::endl;
+      }
 
       break;
     }
   }
-}
 
-// Case 2: Miss
-if (match == PT_WAY) {
-  uint32_t victim_way = PT_WAY, min_counter = C_SIG_MAX;
+  // Case 2: Miss
+  if (match == PT_WAY) {
+    uint32_t victim_way = PT_WAY, min_counter = C_SIG_MAX;
 
-  for (match = 0; match < PT_WAY; match++) {
-    if (c_delta[set][match] < min_counter) { // Select an entry with the minimum c_delta
-      victim_way = match;
-      min_counter = c_delta[set][match];
+    for (match = 0; match < PT_WAY; match++) {
+      if (c_delta[set][match] < min_counter) { // Select an entry with the minimum c_delta
+        victim_way = match;
+        min_counter = c_delta[set][match];
+      }
+    }
+
+    delta[set][victim_way] = curr_delta;
+    c_delta[set][victim_way] = 0;
+    c_sig[set]++;
+    if (c_sig[set] > C_SIG_MAX) {
+      for (uint32_t way = 0; way < PT_WAY; way++)
+        c_delta[set][way] >>= 1;
+      c_sig[set] >>= 1;
+    }
+
+    if constexpr (SPP_DEBUG_PRINT) {
+      std::cout << "[PT] " << __func__ << " miss sig: " << std::hex << last_sig << std::dec << " set: " << set << " way: " << victim_way;
+      std::cout << " delta: " << delta[set][victim_way] << " c_delta: " << c_delta[set][victim_way] << " c_sig: " << c_sig[set] << std::endl;
+    }
+
+    if constexpr (SPP_SANITY_CHECK) {
+      // Assertion
+      if (victim_way == PT_WAY) {
+        std::cout << "[PT] Cannot find a replacement victim!" << std::endl;
+        assert(0);
+      }
     }
   }
-
-  delta[set][victim_way] = curr_delta;
-  c_delta[set][victim_way] = 0;
-  c_sig[set]++;
-  if (c_sig[set] > C_SIG_MAX) {
-    for (uint32_t way = 0; way < PT_WAY; way++)
-      c_delta[set][way] >>= 1;
-    c_sig[set] >>= 1;
-  }
-
-  SPP_DP(std::cout << "[PT] " << __func__ << " miss sig: " << std::hex << last_sig << std::dec << " set: " << set << " way: " << victim_way;
-         std::cout << " delta: " << delta[set][victim_way] << " c_delta: " << c_delta[set][victim_way] << " c_sig: " << c_sig[set] << std::endl;);
-
-#ifdef SPP_SANITY_CHECK
-  // Assertion
-  if (victim_way == PT_WAY) {
-    std::cout << "[PT] Cannot find a replacement victim!" << std::endl;
-    assert(0);
-  }
-#endif
-}
-#endif
-}
 }
 
 void PATTERN_TABLE::read_pattern(uint32_t curr_sig, int* delta_q, uint32_t* confidence_q, uint32_t& lookahead_way, uint32_t& lookahead_conf,
@@ -337,33 +348,41 @@ void PATTERN_TABLE::read_pattern(uint32_t curr_sig, int* delta_q, uint32_t* conf
         }
         pf_q_tail++;
 
-        SPP_DP(std::cout << "[PT] " << __func__ << " HIGH CONF: " << pf_conf << " sig: " << std::hex << curr_sig << std::dec << " set: " << set
-                         << " way: " << way;
-               std::cout << " delta: " << delta[set][way] << " c_delta: " << c_delta[set][way] << " c_sig: " << c_sig[set];
-               std::cout << " conf: " << local_conf << " depth: " << depth << std::endl;);
+        if constexpr (SPP_DEBUG_PRINT) {
+          std::cout << "[PT] " << __func__ << " HIGH CONF: " << pf_conf << " sig: " << std::hex << curr_sig << std::dec << " set: " << set << " way: " << way;
+          std::cout << " delta: " << delta[set][way] << " c_delta: " << c_delta[set][way] << " c_sig: " << c_sig[set];
+          std::cout << " conf: " << local_conf << " depth: " << depth << std::endl;
+        }
       } else {
-        SPP_DP(std::cout << "[PT] " << __func__ << "  LOW CONF: " << pf_conf << " sig: " << std::hex << curr_sig << std::dec << " set: " << set
-                         << " way: " << way;
-               std::cout << " delta: " << delta[set][way] << " c_delta: " << c_delta[set][way] << " c_sig: " << c_sig[set];
-               std::cout << " conf: " << local_conf << " depth: " << depth << std::endl;);
+        if constexpr (SPP_DEBUG_PRINT) {
+          std::cout << "[PT] " << __func__ << "  LOW CONF: " << pf_conf << " sig: " << std::hex << curr_sig << std::dec << " set: " << set << " way: " << way;
+          std::cout << " delta: " << delta[set][way] << " c_delta: " << c_delta[set][way] << " c_sig: " << c_sig[set];
+          std::cout << " conf: " << local_conf << " depth: " << depth << std::endl;
+        }
       }
     }
     pf_q_tail++;
 
-    SPP_DP(cout << "[PT] " << __func__ << " HIGH CONF: " << pf_conf << " sig: " << hex << curr_sig << dec << " set: " << set << " way: " << way;
-           cout << " delta: " << delta[set][way] << " c_delta: " << c_delta[set][way] << " c_sig: " << c_sig[set];
-           cout << " conf: " << local_conf << " depth: " << depth << endl;);
+    if constexpr (SPP_DEBUG_PRINT) {
+      std::cout << "[PT] " << __func__ << " HIGH CONF: " << pf_conf << " sig: " << std::hex << curr_sig << std::dec << " set: " << set << " way: " << way;
+      std::cout << " delta: " << delta[set][way] << " c_delta: " << c_delta[set][way] << " c_sig: " << c_sig[set];
+      std::cout << " conf: " << local_conf << " depth: " << depth << std::endl;
+    }
   } else {
-    SPP_DP(cout << "[PT] " << __func__ << "  LOW CONF: " << pf_conf << " sig: " << hex << curr_sig << dec << " set: " << set << " way: " << way;
-           cout << " delta: " << delta[set][way] << " c_delta: " << c_delta[set][way] << " c_sig: " << c_sig[set];
-           cout << " conf: " << local_conf << " depth: " << depth << endl;);
+    if constexpr (SPP_DEBUG_PRINT) {
+      std::cout << "[PT] " << __func__ << "  LOW CONF: " << pf_conf << " sig: " << std::hex << curr_sig << std::dec << " set: " << set << " way: " << way;
+      std::cout << " delta: " << delta[set][way] << " c_delta: " << c_delta[set][way] << " c_sig: " << c_sig[set];
+      std::cout << " conf: " << local_conf << " depth: " << depth << std::endl;
+    }
   }
 }
 lookahead_conf = max_conf;
 if (lookahead_conf >= PF_THRESHOLD)
   depth++;
 
-SPP_DP(std::cout << "global_accuracy: " << GHR.global_accuracy << " lookahead_conf: " << lookahead_conf << std::endl;);
+if constexpr (SPP_DEBUG_PRINT) {
+  std::cout << "global_accuracy: " << GHR.global_accuracy << " lookahead_conf: " << lookahead_conf << std::endl;
+}
 }
 else confidence_q[pf_q_tail] = 0;
 }
@@ -373,15 +392,18 @@ bool PREFETCH_FILTER::check(uint64_t check_addr, FILTER_REQUEST filter_request)
   uint64_t cache_line = check_addr >> LOG2_BLOCK_SIZE, hash = get_hash(cache_line), quotient = (hash >> REMAINDER_BIT) & ((1 << QUOTIENT_BIT) - 1),
            remainder = hash % (1 << REMAINDER_BIT);
 
-  SPP_DP(std::cout << "[FILTER] check_addr: " << std::hex << check_addr << " check_cache_line: " << (check_addr >> LOG2_BLOCK_SIZE);
-         std::cout << " hash: " << hash << std::dec << " quotient: " << quotient << " remainder: " << remainder << std::endl;);
+  if constexpr (SPP_DEBUG_PRINT) {
+    std::cout << "[FILTER] check_addr: " << std::hex << check_addr << " check_cache_line: " << (check_addr >> LOG2_BLOCK_SIZE);
+    std::cout << " hash: " << hash << std::dec << " quotient: " << quotient << " remainder: " << remainder << std::endl;
+  }
 
   switch (filter_request) {
   case SPP_L2C_PREFETCH:
     if ((valid[quotient] || useful[quotient]) && remainder_tag[quotient] == remainder) {
-      SPP_DP(std::cout << "[FILTER] " << __func__ << " line is already in the filter check_addr: " << std::hex << check_addr << " cache_line: " << cache_line
-                       << std::dec;
-             std::cout << " quotient: " << quotient << " valid: " << valid[quotient] << " useful: " << useful[quotient] << std::endl;);
+      if constexpr (SPP_DEBUG_PRINT) {
+        std::cout << "[FILTER] " << __func__ << " line is already in the filter check_addr: " << std::hex << check_addr << " cache_line: " << cache_line << std::dec;
+        std::cout << " quotient: " << quotient << " valid: " << valid[quotient] << " useful: " << useful[quotient] << std::endl;
+      }
 
       return false; // False return indicates "Do not prefetch"
     } else {
@@ -389,17 +411,19 @@ bool PREFETCH_FILTER::check(uint64_t check_addr, FILTER_REQUEST filter_request)
       useful[quotient] = 0; // Reset useful bit
       remainder_tag[quotient] = remainder;
 
-      SPP_DP(std::cout << "[FILTER] " << __func__ << " set valid for check_addr: " << std::hex << check_addr << " cache_line: " << cache_line << std::dec;
-             std::cout << " quotient: " << quotient << " remainder_tag: " << remainder_tag[quotient] << " valid: " << valid[quotient]
-                       << " useful: " << useful[quotient] << std::endl;);
+      if constexpr (SPP_DEBUG_PRINT) {
+        std::cout << "[FILTER] " << __func__ << " set valid for check_addr: " << std::hex << check_addr << " cache_line: " << cache_line << std::dec;
+        std::cout << " quotient: " << quotient << " remainder_tag: " << remainder_tag[quotient] << " valid: " << valid[quotient] << " useful: " << useful[quotient] << std::endl;
+      }
     }
     break;
 
   case SPP_LLC_PREFETCH:
     if ((valid[quotient] || useful[quotient]) && remainder_tag[quotient] == remainder) {
-      SPP_DP(std::cout << "[FILTER] " << __func__ << " line is already in the filter check_addr: " << std::hex << check_addr << " cache_line: " << cache_line
-                       << std::dec;
-             std::cout << " quotient: " << quotient << " valid: " << valid[quotient] << " useful: " << useful[quotient] << std::endl;);
+      if constexpr (SPP_DEBUG_PRINT) {
+        std::cout << "[FILTER] " << __func__ << " line is already in the filter check_addr: " << std::hex << check_addr << " cache_line: " << cache_line << std::dec;
+        std::cout << " quotient: " << quotient << " valid: " << valid[quotient] << " useful: " << useful[quotient] << std::endl;
+      }
 
       return false; // False return indicates "Do not prefetch"
     } else {
@@ -412,8 +436,10 @@ bool PREFETCH_FILTER::check(uint64_t check_addr, FILTER_REQUEST filter_request)
       // valid[quotient] = 1;
       // useful[quotient] = 0;
 
-      SPP_DP(std::cout << "[FILTER] " << __func__ << " don't set valid for check_addr: " << std::hex << check_addr << " cache_line: " << cache_line << std::dec;
-             std::cout << " quotient: " << quotient << " valid: " << valid[quotient] << " useful: " << useful[quotient] << std::endl;);
+      if constexpr (SPP_DEBUG_PRINT) {
+        std::cout << "[FILTER] " << __func__ << " don't set valid for check_addr: " << std::hex << check_addr << " cache_line: " << cache_line << std::dec;
+        std::cout << " quotient: " << quotient << " valid: " << valid[quotient] << " useful: " << useful[quotient] << std::endl;
+      }
     }
     break;
 
@@ -423,9 +449,11 @@ bool PREFETCH_FILTER::check(uint64_t check_addr, FILTER_REQUEST filter_request)
       if (valid[quotient])
         GHR.pf_useful++; // This cache line was prefetched by SPP and actually used in the program
 
-      SPP_DP(std::cout << "[FILTER] " << __func__ << " set useful for check_addr: " << std::hex << check_addr << " cache_line: " << cache_line << std::dec;
-             std::cout << " quotient: " << quotient << " valid: " << valid[quotient] << " useful: " << useful[quotient];
-             std::cout << " GHR.pf_issued: " << GHR.pf_issued << " GHR.pf_useful: " << GHR.pf_useful << std::endl;);
+      if constexpr (SPP_DEBUG_PRINT) {
+        std::cout << "[FILTER] " << __func__ << " set useful for check_addr: " << std::hex << check_addr << " cache_line: " << cache_line << std::dec;
+        std::cout << " quotient: " << quotient << " valid: " << valid[quotient] << " useful: " << useful[quotient];
+        std::cout << " GHR.pf_issued: " << GHR.pf_issued << " GHR.pf_useful: " << GHR.pf_useful << std::endl;
+      }
     }
     break;
 
@@ -449,8 +477,10 @@ bool PREFETCH_FILTER::check(uint64_t check_addr, FILTER_REQUEST filter_request)
 
 case SPP_LLC_PREFETCH:
   if ((valid[quotient] || useful[quotient]) && remainder_tag[quotient] == remainder) {
-    SPP_DP(cout << "[FILTER] " << __func__ << " line is already in the filter check_addr: " << hex << check_addr << " cache_line: " << cache_line << dec;
-           cout << " quotient: " << quotient << " valid: " << valid[quotient] << " useful: " << useful[quotient] << endl;);
+    if constexpr (SPP_DEBUG_PRINT) {
+      std::cout << "[FILTER] " << __func__ << " line is already in the filter check_addr: " << std::hex << check_addr << " cache_line: " << cache_line << std::dec;
+      std::cout << " quotient: " << quotient << " valid: " << valid[quotient] << " useful: " << useful[quotient] << std::endl;
+    }
 
     return false; // False return indicates "Do not prefetch"
   } else {
@@ -465,8 +495,10 @@ case SPP_LLC_PREFETCH:
     // valid[quotient] = 1;
     // useful[quotient] = 0;
 
-    SPP_DP(cout << "[FILTER] " << __func__ << " don't set valid for check_addr: " << hex << check_addr << " cache_line: " << cache_line << dec;
-           cout << " quotient: " << quotient << " valid: " << valid[quotient] << " useful: " << useful[quotient] << endl;);
+    if constexpr (SPP_DEBUG_PRINT) {
+      std::cout << "[FILTER] " << __func__ << " don't set valid for check_addr: " << std::hex << check_addr << " cache_line: " << cache_line << std::dec;
+      std::cout << " quotient: " << quotient << " valid: " << valid[quotient] << " useful: " << useful[quotient] << std::endl;
+    }
   }
   break;
 
@@ -477,9 +509,11 @@ case L2C_DEMAND:
       GHR.pf_useful++; // This cache line was prefetched by SPP and actually
                        // used in the program
 
-    SPP_DP(cout << "[FILTER] " << __func__ << " set useful for check_addr: " << hex << check_addr << " cache_line: " << cache_line << dec;
-           cout << " quotient: " << quotient << " valid: " << valid[quotient] << " useful: " << useful[quotient];
-           cout << " GHR.pf_issued: " << GHR.pf_issued << " GHR.pf_useful: " << GHR.pf_useful << endl;);
+    if constexpr (SPP_DEBUG_PRINT) {
+      std::cout << "[FILTER] " << __func__ << " set useful for check_addr: " << std::hex << check_addr << " cache_line: " << cache_line << std::dec;
+      std::cout << " quotient: " << quotient << " valid: " << valid[quotient] << " useful: " << useful[quotient];
+      std::cout << " GHR.pf_issued: " << GHR.pf_issued << " GHR.pf_useful: " << GHR.pf_useful << std::endl;
+    }
   }
   break;
 
@@ -510,8 +544,10 @@ void GLOBAL_REGISTER::update_entry(uint32_t pf_sig, uint32_t pf_confidence, uint
   // Instead of matching (last_offset + delta), GHR simply stores and matches the pf_offset
   uint32_t min_conf = 100, victim_way = MAX_GHR_ENTRY;
 
-  SPP_DP(std::cout << "[GHR] Crossing the page boundary pf_sig: " << std::hex << pf_sig << std::dec;
-         std::cout << " confidence: " << pf_confidence << " pf_offset: " << pf_offset << " pf_delta: " << pf_delta << std::endl;);
+  if constexpr (SPP_DEBUG_PRINT) {
+    std::cout << "[GHR] Crossing the page boundary pf_sig: " << std::hex << pf_sig << std::dec;
+    std::cout << " confidence: " << pf_confidence << " pf_offset: " << pf_offset << " pf_delta: " << pf_delta << std::endl;
+  }
 
   for (uint32_t i = 0; i < MAX_GHR_ENTRY; i++) {
     // if (sig[i] == pf_sig) { // TODO: Which one is better and consistent?
@@ -523,7 +559,9 @@ void GLOBAL_REGISTER::update_entry(uint32_t pf_sig, uint32_t pf_confidence, uint
       // offset[i] = pf_offset;
       delta[i] = pf_delta;
 
-      SPP_DP(std::cout << "[GHR] Found a matching index: " << i << std::endl;);
+      if constexpr (SPP_DEBUG_PRINT) {
+        std::cout << "[GHR] Found a matching index: " << i << std::endl;
+      }
 
       return;
     }
@@ -542,8 +580,10 @@ void GLOBAL_REGISTER::update_entry(uint32_t pf_sig, uint32_t pf_confidence, uint
     assert(0);
   }
 
-  SPP_DP(std::cout << "[GHR] Replace index: " << victim_way << " pf_sig: " << std::hex << sig[victim_way] << std::dec;
-         std::cout << " confidence: " << confidence[victim_way] << " pf_offset: " << offset[victim_way] << " pf_delta: " << delta[victim_way] << std::endl;);
+  if constexpr (SPP_DEBUG_PRINT) {
+    std::cout << "[GHR] Replace index: " << victim_way << " pf_sig: " << std::hex << sig[victim_way] << std::dec;
+    std::cout << " confidence: " << confidence[victim_way] << " pf_offset: " << offset[victim_way] << " pf_delta: " << delta[victim_way] << std::endl;
+  }
 
   valid[victim_way] = 1;
   sig[victim_way] = pf_sig;

--- a/prefetcher/spp_dev/spp_dev.h
+++ b/prefetcher/spp_dev/spp_dev.h
@@ -1,49 +1,46 @@
 #ifndef SPP_H
 #define SPP_H
 
-// SPP functional knobs
-#define LOOKAHEAD_ON
-#define FILTER_ON
-#define GHR_ON
-#define SPP_SANITY_CHECK
+#include <cstdint>
+#include <iostream>
 
-//#define SPP_DEBUG_PRINT
-#ifdef SPP_DEBUG_PRINT
-#define SPP_DP(x) x
-#else
-#define SPP_DP(x)
-#endif
+// SPP functional knobs
+constexpr bool LOOKAHEAD_ON = true;
+constexpr bool FILTER_ON = true;
+constexpr bool GHR_ON = true;
+constexpr bool SPP_SANITY_CHECK = true;
+constexpr bool SPP_DEBUG_PRINT = false;
 
 // Signature table parameters
-#define ST_SET 1
-#define ST_WAY 256
-#define ST_TAG_BIT 16
-#define ST_TAG_MASK ((1 << ST_TAG_BIT) - 1)
-#define SIG_SHIFT 3
-#define SIG_BIT 12
-#define SIG_MASK ((1 << SIG_BIT) - 1)
-#define SIG_DELTA_BIT 7
+constexpr std::size_t ST_SET = 1;
+constexpr std::size_t ST_WAY = 256;
+constexpr unsigned ST_TAG_BIT = 16;
+constexpr uint32_t ST_TAG_MASK = ((1 << ST_TAG_BIT) - 1);
+constexpr unsigned SIG_SHIFT = 3;
+constexpr unsigned SIG_BIT = 12;
+constexpr uint32_t SIG_MASK = ((1 << SIG_BIT) - 1);
+constexpr unsigned SIG_DELTA_BIT = 7;
 
 // Pattern table parameters
-#define PT_SET 512
-#define PT_WAY 4
-#define C_SIG_BIT 4
-#define C_DELTA_BIT 4
-#define C_SIG_MAX ((1 << C_SIG_BIT) - 1)
-#define C_DELTA_MAX ((1 << C_DELTA_BIT) - 1)
+constexpr std::size_t PT_SET = 512;
+constexpr std::size_t PT_WAY = 4;
+constexpr unsigned C_SIG_BIT = 4;
+constexpr unsigned C_DELTA_BIT = 4;
+constexpr uint32_t C_SIG_MAX = ((1 << C_SIG_BIT) - 1);
+constexpr uint32_t C_DELTA_MAX = ((1 << C_DELTA_BIT) - 1);
 
 // Prefetch filter parameters
-#define QUOTIENT_BIT 10
-#define REMAINDER_BIT 6
-#define HASH_BIT (QUOTIENT_BIT + REMAINDER_BIT + 1)
-#define FILTER_SET (1 << QUOTIENT_BIT)
-#define FILL_THRESHOLD 90
-#define PF_THRESHOLD 25
+constexpr unsigned QUOTIENT_BIT = 10;
+constexpr unsigned REMAINDER_BIT = 6;
+constexpr unsigned HASH_BIT = (QUOTIENT_BIT + REMAINDER_BIT + 1);
+constexpr std::size_t FILTER_SET = (1 << QUOTIENT_BIT);
+constexpr uint32_t FILL_THRESHOLD = 90;
+constexpr uint32_t PF_THRESHOLD = 25;
 
 // Global register parameters
-#define GLOBAL_COUNTER_BIT 10
-#define GLOBAL_COUNTER_MAX ((1 << GLOBAL_COUNTER_BIT) - 1)
-#define MAX_GHR_ENTRY 8
+constexpr unsigned GLOBAL_COUNTER_BIT = 10;
+constexpr uint32_t GLOBAL_COUNTER_MAX = ((1 << GLOBAL_COUNTER_BIT) - 1);
+constexpr std::size_t MAX_GHR_ENTRY = 8;
 
 enum FILTER_REQUEST { SPP_L2C_PREFETCH, SPP_LLC_PREFETCH, L2C_DEMAND, L2C_EVICT }; // Request type for prefetch filter
 uint64_t get_hash(uint64_t key);
@@ -56,11 +53,11 @@ public:
 
   SIGNATURE_TABLE()
   {
-    cout << "Initialize SIGNATURE TABLE" << endl;
-    cout << "ST_SET: " << ST_SET << endl;
-    cout << "ST_WAY: " << ST_WAY << endl;
-    cout << "ST_TAG_BIT: " << ST_TAG_BIT << endl;
-    cout << "ST_TAG_MASK: " << hex << ST_TAG_MASK << dec << endl;
+    std::cout << "Initialize SIGNATURE TABLE" << std::endl;
+    std::cout << "ST_SET: " << ST_SET << std::endl;
+    std::cout << "ST_WAY: " << ST_WAY << std::endl;
+    std::cout << "ST_TAG_BIT: " << ST_TAG_BIT << std::endl;
+    std::cout << "ST_TAG_MASK: " << std::hex << ST_TAG_MASK << std::dec << std::endl;
 
     for (uint32_t set = 0; set < ST_SET; set++)
       for (uint32_t way = 0; way < ST_WAY; way++) {
@@ -83,12 +80,12 @@ public:
 
   PATTERN_TABLE()
   {
-    cout << endl << "Initialize PATTERN TABLE" << endl;
-    cout << "PT_SET: " << PT_SET << endl;
-    cout << "PT_WAY: " << PT_WAY << endl;
-    cout << "SIG_DELTA_BIT: " << SIG_DELTA_BIT << endl;
-    cout << "C_SIG_BIT: " << C_SIG_BIT << endl;
-    cout << "C_DELTA_BIT: " << C_DELTA_BIT << endl;
+    std::cout << std::endl << "Initialize PATTERN TABLE" << std::endl;
+    std::cout << "PT_SET: " << PT_SET << std::endl;
+    std::cout << "PT_WAY: " << PT_WAY << std::endl;
+    std::cout << "SIG_DELTA_BIT: " << SIG_DELTA_BIT << std::endl;
+    std::cout << "C_SIG_BIT: " << C_SIG_BIT << std::endl;
+    std::cout << "C_DELTA_BIT: " << C_DELTA_BIT << std::endl;
 
     for (uint32_t set = 0; set < PT_SET; set++) {
       for (uint32_t way = 0; way < PT_WAY; way++) {
@@ -112,8 +109,8 @@ public:
 
   PREFETCH_FILTER()
   {
-    cout << endl << "Initialize PREFETCH FILTER" << endl;
-    cout << "FILTER_SET: " << FILTER_SET << endl;
+    std::cout << std::endl << "Initialize PREFETCH FILTER" << std::endl;
+    std::cout << "FILTER_SET: " << FILTER_SET << std::endl;
 
     for (uint32_t set = 0; set < FILTER_SET; set++) {
       remainder_tag[set] = 0;

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -8,10 +8,6 @@
 #include "util.h"
 #include "vmem.h"
 
-#ifndef SANITY_CHECK
-#define NDEBUG
-#endif
-
 extern VirtualMemory vmem;
 extern uint8_t warmup_complete[NUM_CPUS];
 
@@ -336,9 +332,6 @@ bool CACHE::filllike_miss(std::size_t set, std::size_t way, PACKET& handle_pkt)
   }
 
   bool bypass = (way == NUM_WAY);
-#ifndef LLC_BYPASS
-  assert(!bypass);
-#endif
   assert(handle_pkt.type != WRITEBACK || !bypass);
 
   BLOCK& fill_block = block[set * NUM_WAY + way];

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -206,14 +206,16 @@ void CACHE::check_collision()
 
 void CACHE::readlike_hit(std::size_t set, std::size_t way, PACKET& handle_pkt)
 {
-  DP(if (warmup_complete[handle_pkt.cpu]) {
-    std::cout << "[" << NAME << "] " << __func__ << " hit";
-    std::cout << " instr_id: " << handle_pkt.instr_id << " address: " << std::hex << (handle_pkt.address >> OFFSET_BITS);
-    std::cout << " full_addr: " << handle_pkt.address;
-    std::cout << " full_v_addr: " << handle_pkt.v_address << std::dec;
-    std::cout << " type: " << +handle_pkt.type;
-    std::cout << " cycle: " << current_cycle << std::endl;
-  });
+  if constexpr (champsim::debug_print) {
+    if (warmup_complete[handle_pkt.cpu]) {
+      std::cout << "[" << NAME << "] " << __func__ << " hit";
+      std::cout << " instr_id: " << handle_pkt.instr_id << " address: " << std::hex << (handle_pkt.address >> OFFSET_BITS);
+      std::cout << " full_addr: " << handle_pkt.address;
+      std::cout << " full_v_addr: " << handle_pkt.v_address << std::dec;
+      std::cout << " type: " << +handle_pkt.type;
+      std::cout << " cycle: " << current_cycle << std::endl;
+    }
+  }
 
   BLOCK& hit_block = block[set * NUM_WAY + way];
 
@@ -245,14 +247,16 @@ void CACHE::readlike_hit(std::size_t set, std::size_t way, PACKET& handle_pkt)
 
 bool CACHE::readlike_miss(PACKET& handle_pkt)
 {
-  DP(if (warmup_complete[handle_pkt.cpu]) {
-    std::cout << "[" << NAME << "] " << __func__ << " miss";
-    std::cout << " instr_id: " << handle_pkt.instr_id << " address: " << std::hex << (handle_pkt.address >> OFFSET_BITS);
-    std::cout << " full_addr: " << handle_pkt.address;
-    std::cout << " full_v_addr: " << handle_pkt.v_address << std::dec;
-    std::cout << " type: " << +handle_pkt.type;
-    std::cout << " cycle: " << current_cycle << std::endl;
-  });
+  if constexpr (champsim::debug_print) {
+    if (warmup_complete[handle_pkt.cpu]) {
+      std::cout << "[" << NAME << "] " << __func__ << " miss";
+      std::cout << " instr_id: " << handle_pkt.instr_id << " address: " << std::hex << (handle_pkt.address >> OFFSET_BITS);
+      std::cout << " full_addr: " << handle_pkt.address;
+      std::cout << " full_v_addr: " << handle_pkt.v_address << std::dec;
+      std::cout << " type: " << +handle_pkt.type;
+      std::cout << " cycle: " << current_cycle << std::endl;
+    }
+  }
 
   // check mshr
   auto mshr_entry = std::find_if(MSHR.begin(), MSHR.end(), eq_addr<PACKET>(handle_pkt.address, OFFSET_BITS));
@@ -320,14 +324,16 @@ bool CACHE::readlike_miss(PACKET& handle_pkt)
 
 bool CACHE::filllike_miss(std::size_t set, std::size_t way, PACKET& handle_pkt)
 {
-  DP(if (warmup_complete[handle_pkt.cpu]) {
-    std::cout << "[" << NAME << "] " << __func__ << " miss";
-    std::cout << " instr_id: " << handle_pkt.instr_id << " address: " << std::hex << (handle_pkt.address >> OFFSET_BITS);
-    std::cout << " full_addr: " << handle_pkt.address;
-    std::cout << " full_v_addr: " << handle_pkt.v_address << std::dec;
-    std::cout << " type: " << +handle_pkt.type;
-    std::cout << " cycle: " << current_cycle << std::endl;
-  });
+  if constexpr (champsim::debug_print) {
+    if (warmup_complete[handle_pkt.cpu]) {
+      std::cout << "[" << NAME << "] " << __func__ << " miss";
+      std::cout << " instr_id: " << handle_pkt.instr_id << " address: " << std::hex << (handle_pkt.address >> OFFSET_BITS);
+      std::cout << " full_addr: " << handle_pkt.address;
+      std::cout << " full_v_addr: " << handle_pkt.v_address << std::dec;
+      std::cout << " type: " << +handle_pkt.type;
+      std::cout << " cycle: " << current_cycle << std::endl;
+    }
+  }
 
   bool bypass = (way == NUM_WAY);
 #ifndef LLC_BYPASS
@@ -448,16 +454,21 @@ bool CACHE::add_rq(const PACKET& packet)
   assert(packet.address != 0);
   RQ_ACCESS++;
 
-  DP(if (warmup_complete[packet.cpu]) {
-    std::cout << "[" << NAME << "_RQ] " << __func__ << " instr_id: " << packet.instr_id << " address: " << std::hex << (packet.address >> OFFSET_BITS);
-    std::cout << " full_addr: " << packet.address << " v_address: " << packet.v_address << std::dec << " type: " << +packet.type << " occupancy: " << RQ.size();
-  })
+  if constexpr (champsim::debug_print) {
+    if (warmup_complete[packet.cpu]) {
+      std::cout << "[" << NAME << "_RQ] " << __func__ << " instr_id: " << packet.instr_id << " address: " << std::hex << (packet.address >> OFFSET_BITS);
+      std::cout << " full_addr: " << packet.address << " v_address: " << packet.v_address << std::dec << " type: " << +packet.type << " occupancy: " << RQ.size();
+    }
+  }
 
   // check occupancy
   if (std::size(RQ) >= RQ_SIZE) {
     RQ_FULL++;
 
-    DP(if (warmup_complete[packet.cpu]) std::cout << " FULL" << std::endl;)
+    if constexpr (champsim::debug_print) {
+      if (warmup_complete[packet.cpu])
+        std::cout << " FULL" << std::endl;
+    }
 
     return false; // cannot handle this request
   }
@@ -467,7 +478,10 @@ bool CACHE::add_rq(const PACKET& packet)
   RQ.back().forward_checked = false;
   RQ.back().event_cycle = current_cycle + (warmup_complete[packet.cpu] ? HIT_LATENCY : 0);
 
-  DP(if (warmup_complete[packet.cpu]) std::cout << " ADDED" << std::endl;)
+  if constexpr (champsim::debug_print) {
+    if (warmup_complete[packet.cpu])
+      std::cout << " ADDED" << std::endl;
+  }
 
   RQ_TO_CACHE++;
   return true;
@@ -477,14 +491,19 @@ bool CACHE::add_wq(const PACKET& packet)
 {
   WQ_ACCESS++;
 
-  DP(if (warmup_complete[packet.cpu]) {
-    std::cout << "[" << NAME << "_WQ] " << __func__ << " instr_id: " << packet.instr_id << " address: " << std::hex << (packet.address >> OFFSET_BITS);
-    std::cout << " full_addr: " << packet.address << " v_address: " << packet.v_address << std::dec << " type: " << +packet.type << " occupancy: " << WQ.size();
-  })
+  if constexpr (champsim::debug_print) {
+    if (warmup_complete[packet.cpu]) {
+      std::cout << "[" << NAME << "_WQ] " << __func__ << " instr_id: " << packet.instr_id << " address: " << std::hex << (packet.address >> OFFSET_BITS);
+      std::cout << " full_addr: " << packet.address << " v_address: " << packet.v_address << std::dec << " type: " << +packet.type << " occupancy: " << WQ.size();
+    }
+  }
 
   // Check for room in the queue
   if (std::size(WQ) >= WQ_SIZE) {
-    DP(if (warmup_complete[packet.cpu]) std::cout << " FULL" << std::endl;)
+    if constexpr (champsim::debug_print) {
+      if (warmup_complete[packet.cpu])
+        std::cout << " FULL" << std::endl;
+    }
 
     ++WQ_FULL;
     return false;
@@ -495,7 +514,10 @@ bool CACHE::add_wq(const PACKET& packet)
   WQ.back().forward_checked = false;
   WQ.back().event_cycle = current_cycle + (warmup_complete[packet.cpu] ? HIT_LATENCY : 0);
 
-  DP(if (warmup_complete[packet.cpu]) std::cout << " ADDED" << std::endl;)
+  if constexpr (champsim::debug_print) {
+    if (warmup_complete[packet.cpu])
+      std::cout << " ADDED" << std::endl;
+  }
 
   WQ_TO_CACHE++;
   WQ_ACCESS++;
@@ -568,15 +590,20 @@ bool CACHE::add_pq(const PACKET& packet)
   assert(packet.address != 0);
   PQ_ACCESS++;
 
-  DP(if (warmup_complete[packet.cpu]) {
-    std::cout << "[" << NAME << "_WQ] " << __func__ << " instr_id: " << packet.instr_id << " address: " << std::hex << (packet.address >> OFFSET_BITS);
-    std::cout << " full_addr: " << packet.address << " v_address: " << packet.v_address << std::dec << " type: " << +packet.type << " occupancy: " << PQ.size();
-  })
+  if constexpr (champsim::debug_print) {
+    if (warmup_complete[packet.cpu]) {
+      std::cout << "[" << NAME << "_WQ] " << __func__ << " instr_id: " << packet.instr_id << " address: " << std::hex << (packet.address >> OFFSET_BITS);
+      std::cout << " full_addr: " << packet.address << " v_address: " << packet.v_address << std::dec << " type: " << +packet.type << " occupancy: " << PQ.size();
+    }
+  }
 
   // check occupancy
   if (std::size(PQ) >= PQ_SIZE) {
 
-    DP(if (warmup_complete[packet.cpu]) std::cout << " FULL" << std::endl;)
+    if constexpr (champsim::debug_print) {
+      if (warmup_complete[packet.cpu])
+        std::cout << " FULL" << std::endl;
+    }
 
     PQ_FULL++;
     return false; // cannot handle this request
@@ -587,7 +614,10 @@ bool CACHE::add_pq(const PACKET& packet)
   PQ.back().forward_checked = false;
   PQ.back().event_cycle = current_cycle + (warmup_complete[packet.cpu] ? HIT_LATENCY : 0);
 
-  DP(if (warmup_complete[packet.cpu]) std::cout << " ADDED" << std::endl;)
+  if constexpr (champsim::debug_print) {
+    if (warmup_complete[packet.cpu])
+      std::cout << " ADDED" << std::endl;
+  }
 
   PQ_TO_CACHE++;
   return true;
@@ -614,13 +644,15 @@ void CACHE::return_data(const PACKET& packet)
   mshr_entry->pf_metadata = packet.pf_metadata;
   mshr_entry->event_cycle = current_cycle + (warmup_complete[cpu] ? FILL_LATENCY : 0);
 
-  DP(if (warmup_complete[packet.cpu]) {
-    std::cout << "[" << NAME << "_MSHR] " << __func__ << " instr_id: " << mshr_entry->instr_id;
-    std::cout << " address: " << std::hex << (mshr_entry->address >> OFFSET_BITS) << " full_addr: " << mshr_entry->address;
-    std::cout << " data: " << mshr_entry->data << std::dec;
-    std::cout << " index: " << std::distance(MSHR.begin(), mshr_entry) << " occupancy: " << get_occupancy(0, 0);
-    std::cout << " event: " << mshr_entry->event_cycle << " current: " << current_cycle << std::endl;
-  });
+  if constexpr (champsim::debug_print) {
+    if (warmup_complete[packet.cpu]) {
+      std::cout << "[" << NAME << "_MSHR] " << __func__ << " instr_id: " << mshr_entry->instr_id;
+      std::cout << " address: " << std::hex << (mshr_entry->address >> OFFSET_BITS) << " full_addr: " << mshr_entry->address;
+      std::cout << " data: " << mshr_entry->data << std::dec;
+      std::cout << " index: " << std::distance(MSHR.begin(), mshr_entry) << " occupancy: " << get_occupancy(0, 0);
+      std::cout << " event: " << mshr_entry->event_cycle << " current: " << current_cycle << std::endl;
+    }
+  }
 
   // Order this entry after previously-returned entries, but before non-returned
   // entries

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -203,14 +203,12 @@ void CACHE::check_collision()
 void CACHE::readlike_hit(std::size_t set, std::size_t way, PACKET& handle_pkt)
 {
   if constexpr (champsim::debug_print) {
-    if (warmup_complete[handle_pkt.cpu]) {
-      std::cout << "[" << NAME << "] " << __func__ << " hit";
-      std::cout << " instr_id: " << handle_pkt.instr_id << " address: " << std::hex << (handle_pkt.address >> OFFSET_BITS);
-      std::cout << " full_addr: " << handle_pkt.address;
-      std::cout << " full_v_addr: " << handle_pkt.v_address << std::dec;
-      std::cout << " type: " << +handle_pkt.type;
-      std::cout << " cycle: " << current_cycle << std::endl;
-    }
+    std::cout << "[" << NAME << "] " << __func__ << " hit";
+    std::cout << " instr_id: " << handle_pkt.instr_id << " address: " << std::hex << (handle_pkt.address >> OFFSET_BITS);
+    std::cout << " full_addr: " << handle_pkt.address;
+    std::cout << " full_v_addr: " << handle_pkt.v_address << std::dec;
+    std::cout << " type: " << +handle_pkt.type;
+    std::cout << " cycle: " << current_cycle << std::endl;
   }
 
   BLOCK& hit_block = block[set * NUM_WAY + way];
@@ -244,14 +242,12 @@ void CACHE::readlike_hit(std::size_t set, std::size_t way, PACKET& handle_pkt)
 bool CACHE::readlike_miss(PACKET& handle_pkt)
 {
   if constexpr (champsim::debug_print) {
-    if (warmup_complete[handle_pkt.cpu]) {
-      std::cout << "[" << NAME << "] " << __func__ << " miss";
-      std::cout << " instr_id: " << handle_pkt.instr_id << " address: " << std::hex << (handle_pkt.address >> OFFSET_BITS);
-      std::cout << " full_addr: " << handle_pkt.address;
-      std::cout << " full_v_addr: " << handle_pkt.v_address << std::dec;
-      std::cout << " type: " << +handle_pkt.type;
-      std::cout << " cycle: " << current_cycle << std::endl;
-    }
+    std::cout << "[" << NAME << "] " << __func__ << " miss";
+    std::cout << " instr_id: " << handle_pkt.instr_id << " address: " << std::hex << (handle_pkt.address >> OFFSET_BITS);
+    std::cout << " full_addr: " << handle_pkt.address;
+    std::cout << " full_v_addr: " << handle_pkt.v_address << std::dec;
+    std::cout << " type: " << +handle_pkt.type;
+    std::cout << " cycle: " << current_cycle << std::endl;
   }
 
   // check mshr
@@ -321,14 +317,12 @@ bool CACHE::readlike_miss(PACKET& handle_pkt)
 bool CACHE::filllike_miss(std::size_t set, std::size_t way, PACKET& handle_pkt)
 {
   if constexpr (champsim::debug_print) {
-    if (warmup_complete[handle_pkt.cpu]) {
-      std::cout << "[" << NAME << "] " << __func__ << " miss";
-      std::cout << " instr_id: " << handle_pkt.instr_id << " address: " << std::hex << (handle_pkt.address >> OFFSET_BITS);
-      std::cout << " full_addr: " << handle_pkt.address;
-      std::cout << " full_v_addr: " << handle_pkt.v_address << std::dec;
-      std::cout << " type: " << +handle_pkt.type;
-      std::cout << " cycle: " << current_cycle << std::endl;
-    }
+    std::cout << "[" << NAME << "] " << __func__ << " miss";
+    std::cout << " instr_id: " << handle_pkt.instr_id << " address: " << std::hex << (handle_pkt.address >> OFFSET_BITS);
+    std::cout << " full_addr: " << handle_pkt.address;
+    std::cout << " full_v_addr: " << handle_pkt.v_address << std::dec;
+    std::cout << " type: " << +handle_pkt.type;
+    std::cout << " cycle: " << current_cycle << std::endl;
   }
 
   bool bypass = (way == NUM_WAY);
@@ -448,10 +442,8 @@ bool CACHE::add_rq(const PACKET& packet)
   RQ_ACCESS++;
 
   if constexpr (champsim::debug_print) {
-    if (warmup_complete[packet.cpu]) {
-      std::cout << "[" << NAME << "_RQ] " << __func__ << " instr_id: " << packet.instr_id << " address: " << std::hex << (packet.address >> OFFSET_BITS);
-      std::cout << " full_addr: " << packet.address << " v_address: " << packet.v_address << std::dec << " type: " << +packet.type << " occupancy: " << RQ.size();
-    }
+    std::cout << "[" << NAME << "_RQ] " << __func__ << " instr_id: " << packet.instr_id << " address: " << std::hex << (packet.address >> OFFSET_BITS);
+    std::cout << " full_addr: " << packet.address << " v_address: " << packet.v_address << std::dec << " type: " << +packet.type << " occupancy: " << RQ.size();
   }
 
   // check occupancy
@@ -459,8 +451,7 @@ bool CACHE::add_rq(const PACKET& packet)
     RQ_FULL++;
 
     if constexpr (champsim::debug_print) {
-      if (warmup_complete[packet.cpu])
-        std::cout << " FULL" << std::endl;
+      std::cout << " FULL" << std::endl;
     }
 
     return false; // cannot handle this request
@@ -472,8 +463,7 @@ bool CACHE::add_rq(const PACKET& packet)
   RQ.back().event_cycle = current_cycle + (warmup_complete[packet.cpu] ? HIT_LATENCY : 0);
 
   if constexpr (champsim::debug_print) {
-    if (warmup_complete[packet.cpu])
-      std::cout << " ADDED" << std::endl;
+    std::cout << " ADDED" << std::endl;
   }
 
   RQ_TO_CACHE++;
@@ -485,17 +475,14 @@ bool CACHE::add_wq(const PACKET& packet)
   WQ_ACCESS++;
 
   if constexpr (champsim::debug_print) {
-    if (warmup_complete[packet.cpu]) {
-      std::cout << "[" << NAME << "_WQ] " << __func__ << " instr_id: " << packet.instr_id << " address: " << std::hex << (packet.address >> OFFSET_BITS);
-      std::cout << " full_addr: " << packet.address << " v_address: " << packet.v_address << std::dec << " type: " << +packet.type << " occupancy: " << WQ.size();
-    }
+    std::cout << "[" << NAME << "_WQ] " << __func__ << " instr_id: " << packet.instr_id << " address: " << std::hex << (packet.address >> OFFSET_BITS);
+    std::cout << " full_addr: " << packet.address << " v_address: " << packet.v_address << std::dec << " type: " << +packet.type << " occupancy: " << WQ.size();
   }
 
   // Check for room in the queue
   if (std::size(WQ) >= WQ_SIZE) {
     if constexpr (champsim::debug_print) {
-      if (warmup_complete[packet.cpu])
-        std::cout << " FULL" << std::endl;
+      std::cout << " FULL" << std::endl;
     }
 
     ++WQ_FULL;
@@ -508,8 +495,7 @@ bool CACHE::add_wq(const PACKET& packet)
   WQ.back().event_cycle = current_cycle + (warmup_complete[packet.cpu] ? HIT_LATENCY : 0);
 
   if constexpr (champsim::debug_print) {
-    if (warmup_complete[packet.cpu])
-      std::cout << " ADDED" << std::endl;
+    std::cout << " ADDED" << std::endl;
   }
 
   WQ_TO_CACHE++;
@@ -584,18 +570,15 @@ bool CACHE::add_pq(const PACKET& packet)
   PQ_ACCESS++;
 
   if constexpr (champsim::debug_print) {
-    if (warmup_complete[packet.cpu]) {
-      std::cout << "[" << NAME << "_WQ] " << __func__ << " instr_id: " << packet.instr_id << " address: " << std::hex << (packet.address >> OFFSET_BITS);
-      std::cout << " full_addr: " << packet.address << " v_address: " << packet.v_address << std::dec << " type: " << +packet.type << " occupancy: " << PQ.size();
-    }
+    std::cout << "[" << NAME << "_WQ] " << __func__ << " instr_id: " << packet.instr_id << " address: " << std::hex << (packet.address >> OFFSET_BITS);
+    std::cout << " full_addr: " << packet.address << " v_address: " << packet.v_address << std::dec << " type: " << +packet.type << " occupancy: " << PQ.size();
   }
 
   // check occupancy
   if (std::size(PQ) >= PQ_SIZE) {
 
     if constexpr (champsim::debug_print) {
-      if (warmup_complete[packet.cpu])
-        std::cout << " FULL" << std::endl;
+      std::cout << " FULL" << std::endl;
     }
 
     PQ_FULL++;
@@ -608,8 +591,7 @@ bool CACHE::add_pq(const PACKET& packet)
   PQ.back().event_cycle = current_cycle + (warmup_complete[packet.cpu] ? HIT_LATENCY : 0);
 
   if constexpr (champsim::debug_print) {
-    if (warmup_complete[packet.cpu])
-      std::cout << " ADDED" << std::endl;
+    std::cout << " ADDED" << std::endl;
   }
 
   PQ_TO_CACHE++;
@@ -638,13 +620,11 @@ void CACHE::return_data(const PACKET& packet)
   mshr_entry->event_cycle = current_cycle + (warmup_complete[cpu] ? FILL_LATENCY : 0);
 
   if constexpr (champsim::debug_print) {
-    if (warmup_complete[packet.cpu]) {
-      std::cout << "[" << NAME << "_MSHR] " << __func__ << " instr_id: " << mshr_entry->instr_id;
-      std::cout << " address: " << std::hex << (mshr_entry->address >> OFFSET_BITS) << " full_addr: " << mshr_entry->address;
-      std::cout << " data: " << mshr_entry->data << std::dec;
-      std::cout << " index: " << std::distance(MSHR.begin(), mshr_entry) << " occupancy: " << get_occupancy(0, 0);
-      std::cout << " event: " << mshr_entry->event_cycle << " current: " << current_cycle << std::endl;
-    }
+    std::cout << "[" << NAME << "_MSHR] " << __func__ << " instr_id: " << mshr_entry->instr_id;
+    std::cout << " address: " << std::hex << (mshr_entry->address >> OFFSET_BITS) << " full_addr: " << mshr_entry->address;
+    std::cout << " data: " << mshr_entry->data << std::dec;
+    std::cout << " index: " << std::distance(MSHR.begin(), mshr_entry) << " occupancy: " << get_occupancy(0, 0);
+    std::cout << " event: " << mshr_entry->event_cycle << " current: " << current_cycle << std::endl;
   }
 
   // Order this entry after previously-returned entries, but before non-returned

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -7,7 +7,7 @@
 #include "champsim.h"
 #include "instruction.h"
 
-#define DEADLOCK_CYCLE 1000000
+constexpr uint64_t DEADLOCK_CYCLE = 1000000;
 
 extern uint8_t warmup_complete[NUM_CPUS];
 extern uint8_t MAX_INSTR_DESTINATIONS;
@@ -132,9 +132,11 @@ void O3_CPU::init_instruction(ooo_model_instr arch_instr)
   // handle branch prediction
   if (arch_instr.is_branch) {
 
-    DP(if (warmup_complete[cpu]) {
-      cout << "[BRANCH] instr_id: " << instr_unique_id << " ip: " << hex << arch_instr.ip << dec << " taken: " << +arch_instr.branch_taken << endl;
-    });
+    if constexpr (champsim::debug_print) {
+      if (warmup_complete[cpu]) {
+        std::cout << "[BRANCH] instr_id: " << instr_unique_id << " ip: " << std::hex << arch_instr.ip << std::dec << " taken: " << +arch_instr.branch_taken << std::endl;
+      }
+    }
 
     num_branch++;
 
@@ -416,9 +418,11 @@ void O3_CPU::schedule_instruction()
         assert(ready_to_execute.size() < ROB.size());
         ready_to_execute.push(rob_it);
 
-        DP(if (warmup_complete[cpu]) {
-          std::cout << "[ready_to_execute] " << __func__ << " instr_id: " << rob_it->instr_id << " is added to ready_to_execute" << std::endl;
-        });
+        if constexpr (champsim::debug_print) {
+          if (warmup_complete[cpu]) {
+            std::cout << "[ready_to_execute] " << __func__ << " instr_id: " << rob_it->instr_id << " is added to ready_to_execute" << std::endl;
+          }
+        }
       }
     }
 
@@ -486,9 +490,11 @@ void O3_CPU::do_execution(champsim::circular_buffer<ooo_model_instr>::iterator r
   // ADD LATENCY
   rob_it->event_cycle = current_cycle + (warmup_complete[cpu] ? EXEC_LATENCY : 0);
 
-  DP(if (warmup_complete[cpu]) {
-    std::cout << "[ROB] " << __func__ << " non-memory instr_id: " << rob_it->instr_id << " event_cycle: " << rob_it->event_cycle << std::endl;
-  });
+  if constexpr (champsim::debug_print) {
+    if (warmup_complete[cpu]) {
+      std::cout << "[ROB] " << __func__ << " non-memory instr_id: " << rob_it->instr_id << " event_cycle: " << rob_it->event_cycle << std::endl;
+    }
+  }
 }
 
 void O3_CPU::schedule_memory_instruction()
@@ -581,10 +587,12 @@ void O3_CPU::do_memory_scheduling(champsim::circular_buffer<ooo_model_instr>::it
     if (rob_it->executed == 0) // it could be already set to COMPLETED due to store-to-load forwarding
       rob_it->executed = INFLIGHT;
 
-    DP(if (warmup_complete[cpu]) {
-      cout << "[ROB] " << __func__ << " instr_id: " << rob_it->instr_id;
-      cout << " scheduled all num_mem_ops: " << rob_it->num_mem_ops << endl;
-    });
+    if constexpr (champsim::debug_print) {
+      if (warmup_complete[cpu]) {
+        std::cout << "[ROB] " << __func__ << " instr_id: " << rob_it->instr_id;
+        std::cout << " scheduled all num_mem_ops: " << rob_it->num_mem_ops << std::endl;
+      }
+    }
   }
 }
 
@@ -644,7 +652,11 @@ bool O3_CPU::do_translate_store(std::vector<LSQ_ENTRY>::iterator sq_it)
   data_packet.type = RFO;
   data_packet.sq_index_depend_on_me = {sq_it};
 
-  DP(if (warmup_complete[cpu]) { std::cout << "[SQ] " << __func__ << " instr_id: " << sq_it->instr_id << " is issued for translating" << std::endl; })
+  if constexpr (champsim::debug_print) {
+    if (warmup_complete[cpu]) {
+      std::cout << "[SQ] " << __func__ << " instr_id: " << sq_it->instr_id << " is issued for translating" << std::endl;
+    }
+  }
 
   return DTLB_bus.issue_read(data_packet);
 }
@@ -655,11 +667,13 @@ void O3_CPU::execute_store(std::vector<LSQ_ENTRY>::iterator sq_it)
   sq_it->rob_index->event_cycle = current_cycle;
   assert(sq_it->rob_index->num_mem_ops >= 0);
 
-  DP(if (warmup_complete[cpu]) {
-    std::cout << "[SQ] " << __func__ << " instr_id: " << sq_it->instr_id << std::hex;
-    std::cout << " full_address: " << sq_it->physical_address << std::dec << " remain_mem_ops: " << sq_it->rob_index->num_mem_ops;
-    std::cout << " event_cycle: " << sq_it->event_cycle << std::endl;
-  });
+  if constexpr (champsim::debug_print) {
+    if (warmup_complete[cpu]) {
+      std::cout << "[SQ] " << __func__ << " instr_id: " << sq_it->instr_id << std::hex;
+      std::cout << " full_address: " << sq_it->physical_address << std::dec << " remain_mem_ops: " << sq_it->rob_index->num_mem_ops;
+      std::cout << " event_cycle: " << sq_it->event_cycle << std::endl;
+    }
+  }
 
   // resolve RAW dependency after DTLB access
   // check if this store has dependent loads
@@ -691,9 +705,11 @@ bool O3_CPU::do_translate_load(std::vector<LSQ_ENTRY>::iterator lq_it)
   data_packet.type = LOAD;
   data_packet.lq_index_depend_on_me = {lq_it};
 
-  DP(if (warmup_complete[cpu]) {
-    std::cout << "[LQ] " << __func__ << " instr_id: " << lq_it->instr_id << " rob_index: " << lq_it->rob_index << " is issued for translating" << std::endl;
-  })
+  if constexpr (champsim::debug_print) {
+    if (warmup_complete[cpu]) {
+      std::cout << "[LQ] " << __func__ << " instr_id: " << lq_it->instr_id << " is issued for translating" << std::endl;
+    }
+  }
 
   return DTLB_bus.issue_read(data_packet);
 }
@@ -755,9 +771,11 @@ void O3_CPU::complete_inflight_instruction()
           assert(ready_to_execute.size() < ROB.size());
           ready_to_execute.push(dependent);
 
-          DP(if (warmup_complete[cpu]) {
-            std::cout << "[ready_to_execute] " << __func__ << " instr_id: " << dependent->instr_id << " is added to ready_to_execute" << std::endl;
-          })
+          if constexpr (champsim::debug_print) {
+            if (warmup_complete[cpu]) {
+              std::cout << "[ready_to_execute] " << __func__ << " instr_id: " << dependent->instr_id << " is added to ready_to_execute" << std::endl;
+            }
+          }
         }
       }
     }
@@ -893,7 +911,11 @@ void O3_CPU::retire_rob()
     }
 
     // release ROB entry
-    DP(if (warmup_complete[cpu]) { cout << "[ROB] " << __func__ << " instr_id: " << ROB.front().instr_id << " is retired" << endl; });
+    if constexpr (champsim::debug_print) {
+      if (warmup_complete[cpu]) {
+        std::cout << "[ROB] " << __func__ << " instr_id: " << ROB.front().instr_id << " is retired" << std::endl;
+      }
+    }
 
     ROB.pop_front();
     num_retired++;

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -133,9 +133,7 @@ void O3_CPU::init_instruction(ooo_model_instr arch_instr)
   if (arch_instr.is_branch) {
 
     if constexpr (champsim::debug_print) {
-      if (warmup_complete[cpu]) {
-        std::cout << "[BRANCH] instr_id: " << instr_unique_id << " ip: " << std::hex << arch_instr.ip << std::dec << " taken: " << +arch_instr.branch_taken << std::endl;
-      }
+      std::cout << "[BRANCH] instr_id: " << instr_unique_id << " ip: " << std::hex << arch_instr.ip << std::dec << " taken: " << +arch_instr.branch_taken << std::endl;
     }
 
     num_branch++;
@@ -419,9 +417,7 @@ void O3_CPU::schedule_instruction()
         ready_to_execute.push(rob_it);
 
         if constexpr (champsim::debug_print) {
-          if (warmup_complete[cpu]) {
-            std::cout << "[ready_to_execute] " << __func__ << " instr_id: " << rob_it->instr_id << " is added to ready_to_execute" << std::endl;
-          }
+          std::cout << "[ready_to_execute] " << __func__ << " instr_id: " << rob_it->instr_id << " is added to ready_to_execute" << std::endl;
         }
       }
     }
@@ -491,9 +487,7 @@ void O3_CPU::do_execution(champsim::circular_buffer<ooo_model_instr>::iterator r
   rob_it->event_cycle = current_cycle + (warmup_complete[cpu] ? EXEC_LATENCY : 0);
 
   if constexpr (champsim::debug_print) {
-    if (warmup_complete[cpu]) {
-      std::cout << "[ROB] " << __func__ << " non-memory instr_id: " << rob_it->instr_id << " event_cycle: " << rob_it->event_cycle << std::endl;
-    }
+    std::cout << "[ROB] " << __func__ << " non-memory instr_id: " << rob_it->instr_id << " event_cycle: " << rob_it->event_cycle << std::endl;
   }
 }
 
@@ -588,10 +582,8 @@ void O3_CPU::do_memory_scheduling(champsim::circular_buffer<ooo_model_instr>::it
       rob_it->executed = INFLIGHT;
 
     if constexpr (champsim::debug_print) {
-      if (warmup_complete[cpu]) {
-        std::cout << "[ROB] " << __func__ << " instr_id: " << rob_it->instr_id;
-        std::cout << " scheduled all num_mem_ops: " << rob_it->num_mem_ops << std::endl;
-      }
+      std::cout << "[ROB] " << __func__ << " instr_id: " << rob_it->instr_id;
+      std::cout << " scheduled all num_mem_ops: " << rob_it->num_mem_ops << std::endl;
     }
   }
 }
@@ -653,9 +645,7 @@ bool O3_CPU::do_translate_store(std::vector<LSQ_ENTRY>::iterator sq_it)
   data_packet.sq_index_depend_on_me = {sq_it};
 
   if constexpr (champsim::debug_print) {
-    if (warmup_complete[cpu]) {
-      std::cout << "[SQ] " << __func__ << " instr_id: " << sq_it->instr_id << " is issued for translating" << std::endl;
-    }
+    std::cout << "[SQ] " << __func__ << " instr_id: " << sq_it->instr_id << " is issued for translating" << std::endl;
   }
 
   return DTLB_bus.issue_read(data_packet);
@@ -668,11 +658,9 @@ void O3_CPU::execute_store(std::vector<LSQ_ENTRY>::iterator sq_it)
   assert(sq_it->rob_index->num_mem_ops >= 0);
 
   if constexpr (champsim::debug_print) {
-    if (warmup_complete[cpu]) {
-      std::cout << "[SQ] " << __func__ << " instr_id: " << sq_it->instr_id << std::hex;
-      std::cout << " full_address: " << sq_it->physical_address << std::dec << " remain_mem_ops: " << sq_it->rob_index->num_mem_ops;
-      std::cout << " event_cycle: " << sq_it->event_cycle << std::endl;
-    }
+    std::cout << "[SQ] " << __func__ << " instr_id: " << sq_it->instr_id << std::hex;
+    std::cout << " full_address: " << sq_it->physical_address << std::dec << " remain_mem_ops: " << sq_it->rob_index->num_mem_ops;
+    std::cout << " event_cycle: " << sq_it->event_cycle << std::endl;
   }
 
   // resolve RAW dependency after DTLB access
@@ -706,9 +694,7 @@ bool O3_CPU::do_translate_load(std::vector<LSQ_ENTRY>::iterator lq_it)
   data_packet.lq_index_depend_on_me = {lq_it};
 
   if constexpr (champsim::debug_print) {
-    if (warmup_complete[cpu]) {
-      std::cout << "[LQ] " << __func__ << " instr_id: " << lq_it->instr_id << " is issued for translating" << std::endl;
-    }
+    std::cout << "[LQ] " << __func__ << " instr_id: " << lq_it->instr_id << " is issued for translating" << std::endl;
   }
 
   return DTLB_bus.issue_read(data_packet);
@@ -772,9 +758,7 @@ void O3_CPU::complete_inflight_instruction()
           ready_to_execute.push(dependent);
 
           if constexpr (champsim::debug_print) {
-            if (warmup_complete[cpu]) {
-              std::cout << "[ready_to_execute] " << __func__ << " instr_id: " << dependent->instr_id << " is added to ready_to_execute" << std::endl;
-            }
+            std::cout << "[ready_to_execute] " << __func__ << " instr_id: " << dependent->instr_id << " is added to ready_to_execute" << std::endl;
           }
         }
       }
@@ -912,9 +896,7 @@ void O3_CPU::retire_rob()
 
     // release ROB entry
     if constexpr (champsim::debug_print) {
-      if (warmup_complete[cpu]) {
-        std::cout << "[ROB] " << __func__ << " instr_id: " << ROB.front().instr_id << " is retired" << std::endl;
-      }
+      std::cout << "[ROB] " << __func__ << " instr_id: " << ROB.front().instr_id << " is retired" << std::endl;
     }
 
     ROB.pop_front();

--- a/src/ptw.cc
+++ b/src/ptw.cc
@@ -28,14 +28,12 @@ void PageTableWalker::handle_read()
     PACKET& handle_pkt = RQ.front();
 
     if constexpr (champsim::debug_print) {
-      if (warmup_complete[handle_pkt.cpu]) {
-        std::cout << "[" << NAME << "] " << __func__ << " instr_id: " << handle_pkt.instr_id;
-        std::cout << " address: " << std::hex << (handle_pkt.address >> LOG2_PAGE_SIZE) << " full_addr: " << handle_pkt.address;
-        std::cout << " full_v_addr: " << handle_pkt.v_address;
-        std::cout << " data: " << handle_pkt.data << std::dec;
-        std::cout << " translation_level: " << +handle_pkt.translation_level;
-        std::cout << " event: " << handle_pkt.event_cycle << " current: " << current_cycle << std::endl;
-      }
+      std::cout << "[" << NAME << "] " << __func__ << " instr_id: " << handle_pkt.instr_id;
+      std::cout << " address: " << std::hex << (handle_pkt.address >> LOG2_PAGE_SIZE) << " full_addr: " << handle_pkt.address;
+      std::cout << " full_v_addr: " << handle_pkt.v_address;
+      std::cout << " data: " << handle_pkt.data << std::dec;
+      std::cout << " translation_level: " << +handle_pkt.translation_level;
+      std::cout << " event: " << handle_pkt.event_cycle << " current: " << current_cycle << std::endl;
     }
 
     auto ptw_addr = splice_bits(CR3_addr, vmem.get_offset(handle_pkt.address, vmem.pt_levels - 1) * PTE_BYTES, LOG2_PAGE_SIZE);
@@ -92,15 +90,13 @@ void PageTableWalker::handle_fill()
         fill_mshr->address = fill_mshr->v_address;
 
         if constexpr (champsim::debug_print) {
-          if (warmup_complete[fill_mshr->cpu]) {
-            std::cout << "[" << NAME << "] " << __func__ << " instr_id: " << fill_mshr->instr_id;
-            std::cout << " address: " << std::hex << (fill_mshr->address >> LOG2_PAGE_SIZE) << " full_addr: " << fill_mshr->address;
-            std::cout << " full_v_addr: " << fill_mshr->v_address;
-            std::cout << " data: " << fill_mshr->data << std::dec;
-            std::cout << " translation_level: " << +fill_mshr->translation_level;
-            std::cout << " index: " << std::distance(MSHR.begin(), fill_mshr) << " occupancy: " << get_occupancy(0, 0);
-            std::cout << " event: " << fill_mshr->event_cycle << " current: " << current_cycle << std::endl;
-          }
+          std::cout << "[" << NAME << "] " << __func__ << " instr_id: " << fill_mshr->instr_id;
+          std::cout << " address: " << std::hex << (fill_mshr->address >> LOG2_PAGE_SIZE) << " full_addr: " << fill_mshr->address;
+          std::cout << " full_v_addr: " << fill_mshr->v_address;
+          std::cout << " data: " << fill_mshr->data << std::dec;
+          std::cout << " translation_level: " << +fill_mshr->translation_level;
+          std::cout << " index: " << std::distance(MSHR.begin(), fill_mshr) << " occupancy: " << get_occupancy(0, 0);
+          std::cout << " event: " << fill_mshr->event_cycle << " current: " << current_cycle << std::endl;
         }
 
         for (auto ret : fill_mshr->to_return)
@@ -127,15 +123,13 @@ void PageTableWalker::handle_fill()
           PSCL2.fill_cache(addr, fill_mshr->v_address);
 
         if constexpr (champsim::debug_print) {
-          if (warmup_complete[fill_mshr->cpu]) {
-            std::cout << "[" << NAME << "] " << __func__ << " instr_id: " << fill_mshr->instr_id;
-            std::cout << " address: " << std::hex << (fill_mshr->address >> LOG2_PAGE_SIZE) << " full_addr: " << fill_mshr->address;
-            std::cout << " full_v_addr: " << fill_mshr->v_address;
-            std::cout << " data: " << fill_mshr->data << std::dec;
-            std::cout << " translation_level: " << +fill_mshr->translation_level;
-            std::cout << " index: " << std::distance(MSHR.begin(), fill_mshr) << " occupancy: " << get_occupancy(0, 0);
-            std::cout << " event: " << fill_mshr->event_cycle << " current: " << current_cycle << std::endl;
-          }
+          std::cout << "[" << NAME << "] " << __func__ << " instr_id: " << fill_mshr->instr_id;
+          std::cout << " address: " << std::hex << (fill_mshr->address >> LOG2_PAGE_SIZE) << " full_addr: " << fill_mshr->address;
+          std::cout << " full_v_addr: " << fill_mshr->v_address;
+          std::cout << " data: " << fill_mshr->data << std::dec;
+          std::cout << " translation_level: " << +fill_mshr->translation_level;
+          std::cout << " index: " << std::distance(MSHR.begin(), fill_mshr) << " occupancy: " << get_occupancy(0, 0);
+          std::cout << " event: " << fill_mshr->event_cycle << " current: " << current_cycle << std::endl;
         }
 
         PACKET packet = *fill_mshr;
@@ -193,15 +187,13 @@ void PageTableWalker::return_data(const PACKET& packet)
       mshr_entry.event_cycle = current_cycle;
 
       if constexpr (champsim::debug_print) {
-        if (warmup_complete[cpu]) {
-          std::cout << "[" << NAME << "_MSHR] " << __func__ << " instr_id: " << mshr_entry.instr_id;
-          std::cout << " address: " << std::hex << mshr_entry.address;
-          std::cout << " v_address: " << mshr_entry.v_address;
-          std::cout << " data: " << mshr_entry.data << std::dec;
-          std::cout << " translation_level: " << +mshr_entry.translation_level;
-          std::cout << " occupancy: " << get_occupancy(0, mshr_entry.address);
-          std::cout << " event: " << mshr_entry.event_cycle << " current: " << current_cycle << std::endl;
-        }
+        std::cout << "[" << NAME << "_MSHR] " << __func__ << " instr_id: " << mshr_entry.instr_id;
+        std::cout << " address: " << std::hex << mshr_entry.address;
+        std::cout << " v_address: " << mshr_entry.v_address;
+        std::cout << " data: " << mshr_entry.data << std::dec;
+        std::cout << " translation_level: " << +mshr_entry.translation_level;
+        std::cout << " occupancy: " << get_occupancy(0, mshr_entry.address);
+        std::cout << " event: " << mshr_entry.event_cycle << " current: " << current_cycle << std::endl;
       }
     }
   }

--- a/src/ptw.cc
+++ b/src/ptw.cc
@@ -1,6 +1,7 @@
 #include "ptw.h"
 
 #include "champsim.h"
+#include "champsim_constants.h"
 #include "util.h"
 #include "vmem.h"
 

--- a/src/ptw.cc
+++ b/src/ptw.cc
@@ -26,14 +26,16 @@ void PageTableWalker::handle_read()
   while (reads_this_cycle > 0 && RQ.has_ready() && std::size(MSHR) != MSHR_SIZE) {
     PACKET& handle_pkt = RQ.front();
 
-    DP(if (warmup_complete[handle_pkt.cpu]) {
-      std::cout << "[" << NAME << "] " << __func__ << " instr_id: " << handle_pkt.instr_id;
-      std::cout << " address: " << std::hex << (handle_pkt.address >> LOG2_PAGE_SIZE) << " full_addr: " << handle_pkt.address;
-      std::cout << " full_v_addr: " << handle_pkt.v_address;
-      std::cout << " data: " << handle_pkt.data << std::dec;
-      std::cout << " translation_level: " << +handle_pkt.translation_level;
-      std::cout << " event: " << handle_pkt.event_cycle << " current: " << current_cycle << std::endl;
-    });
+    if constexpr (champsim::debug_print) {
+      if (warmup_complete[handle_pkt.cpu]) {
+        std::cout << "[" << NAME << "] " << __func__ << " instr_id: " << handle_pkt.instr_id;
+        std::cout << " address: " << std::hex << (handle_pkt.address >> LOG2_PAGE_SIZE) << " full_addr: " << handle_pkt.address;
+        std::cout << " full_v_addr: " << handle_pkt.v_address;
+        std::cout << " data: " << handle_pkt.data << std::dec;
+        std::cout << " translation_level: " << +handle_pkt.translation_level;
+        std::cout << " event: " << handle_pkt.event_cycle << " current: " << current_cycle << std::endl;
+      }
+    }
 
     auto ptw_addr = splice_bits(CR3_addr, vmem.get_offset(handle_pkt.address, vmem.pt_levels - 1) * PTE_BYTES, LOG2_PAGE_SIZE);
     auto ptw_level = vmem.pt_levels - 1;
@@ -88,15 +90,17 @@ void PageTableWalker::handle_fill()
         fill_mshr->data = addr;
         fill_mshr->address = fill_mshr->v_address;
 
-        DP(if (warmup_complete[packet->cpu]) {
-          std::cout << "[" << NAME << "] " << __func__ << " instr_id: " << fill_mshr->instr_id;
-          std::cout << " address: " << std::hex << (fill_mshr->address >> LOG2_PAGE_SIZE) << " full_addr: " << fill_mshr->address;
-          std::cout << " full_v_addr: " << fill_mshr->v_address;
-          std::cout << " data: " << fill_mshr->data << std::dec;
-          std::cout << " translation_level: " << +fill_mshr->translation_level;
-          std::cout << " index: " << std::distance(MSHR.begin(), fill_mshr) << " occupancy: " << get_occupancy(0, 0);
-          std::cout << " event: " << fill_mshr->event_cycle << " current: " << current_cycle << std::endl;
-        });
+        if constexpr (champsim::debug_print) {
+          if (warmup_complete[fill_mshr->cpu]) {
+            std::cout << "[" << NAME << "] " << __func__ << " instr_id: " << fill_mshr->instr_id;
+            std::cout << " address: " << std::hex << (fill_mshr->address >> LOG2_PAGE_SIZE) << " full_addr: " << fill_mshr->address;
+            std::cout << " full_v_addr: " << fill_mshr->v_address;
+            std::cout << " data: " << fill_mshr->data << std::dec;
+            std::cout << " translation_level: " << +fill_mshr->translation_level;
+            std::cout << " index: " << std::distance(MSHR.begin(), fill_mshr) << " occupancy: " << get_occupancy(0, 0);
+            std::cout << " event: " << fill_mshr->event_cycle << " current: " << current_cycle << std::endl;
+          }
+        }
 
         for (auto ret : fill_mshr->to_return)
           ret->return_data(*fill_mshr);
@@ -121,15 +125,17 @@ void PageTableWalker::handle_fill()
         if (fill_mshr->translation_level == PSCL2.level)
           PSCL2.fill_cache(addr, fill_mshr->v_address);
 
-        DP(if (warmup_complete[packet->cpu]) {
-          std::cout << "[" << NAME << "] " << __func__ << " instr_id: " << fill_mshr->instr_id;
-          std::cout << " address: " << std::hex << (fill_mshr->address >> LOG2_PAGE_SIZE) << " full_addr: " << fill_mshr->address;
-          std::cout << " full_v_addr: " << fill_mshr->v_address;
-          std::cout << " data: " << fill_mshr->data << std::dec;
-          std::cout << " translation_level: " << +fill_mshr->translation_level;
-          std::cout << " index: " << std::distance(MSHR.begin(), fill_mshr) << " occupancy: " << get_occupancy(0, 0);
-          std::cout << " event: " << fill_mshr->event_cycle << " current: " << current_cycle << std::endl;
-        });
+        if constexpr (champsim::debug_print) {
+          if (warmup_complete[fill_mshr->cpu]) {
+            std::cout << "[" << NAME << "] " << __func__ << " instr_id: " << fill_mshr->instr_id;
+            std::cout << " address: " << std::hex << (fill_mshr->address >> LOG2_PAGE_SIZE) << " full_addr: " << fill_mshr->address;
+            std::cout << " full_v_addr: " << fill_mshr->v_address;
+            std::cout << " data: " << fill_mshr->data << std::dec;
+            std::cout << " translation_level: " << +fill_mshr->translation_level;
+            std::cout << " index: " << std::distance(MSHR.begin(), fill_mshr) << " occupancy: " << get_occupancy(0, 0);
+            std::cout << " event: " << fill_mshr->event_cycle << " current: " << current_cycle << std::endl;
+          }
+        }
 
         PACKET packet = *fill_mshr;
         packet.cpu = cpu;
@@ -185,15 +191,17 @@ void PageTableWalker::return_data(const PACKET& packet)
     if (eq_addr<PACKET>{packet.address, LOG2_BLOCK_SIZE}(mshr_entry)) {
       mshr_entry.event_cycle = current_cycle;
 
-      DP(if (warmup_complete[cpu]) {
-        std::cout << "[" << NAME << "_MSHR] " << __func__ << " instr_id: " << mshr_entry.instr_id;
-        std::cout << " address: " << std::hex << mshr_entry.address;
-        std::cout << " v_address: " << mshr_entry.v_address;
-        std::cout << " data: " << mshr_entry.data << std::dec;
-        std::cout << " translation_level: " << +mshr_entry.translation_level;
-        std::cout << " occupancy: " << get_occupancy(0, mshr_entry.address);
-        std::cout << " event: " << mshr_entry.event_cycle << " current: " << current_cycle << std::endl;
-      });
+      if constexpr (champsim::debug_print) {
+        if (warmup_complete[cpu]) {
+          std::cout << "[" << NAME << "_MSHR] " << __func__ << " instr_id: " << mshr_entry.instr_id;
+          std::cout << " address: " << std::hex << mshr_entry.address;
+          std::cout << " v_address: " << mshr_entry.v_address;
+          std::cout << " data: " << mshr_entry.data << std::dec;
+          std::cout << " translation_level: " << +mshr_entry.translation_level;
+          std::cout << " occupancy: " << get_occupancy(0, mshr_entry.address);
+          std::cout << " event: " << mshr_entry.event_cycle << " current: " << current_cycle << std::endl;
+        }
+      }
     }
   }
 

--- a/src/vmem.cc
+++ b/src/vmem.cc
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <iostream>
 #include <numeric>
 #include <random>
 

--- a/src/vmem.cc
+++ b/src/vmem.cc
@@ -6,7 +6,7 @@
 #include <numeric>
 #include <random>
 
-#include "champsim.h"
+#include "champsim_constants.h"
 #include "util.h"
 
 VirtualMemory::VirtualMemory(uint64_t capacity, uint64_t pg_size, uint32_t page_table_levels, uint64_t random_seed, uint64_t minor_fault_penalty)


### PR DESCRIPTION
The C preprocessor is a very powerful tool, but it is dangerous. It bypasses the type-checking of the compiler and can obscure scopes. In my opinion, there are some good uses of the preprocessor (and we use one particularly in ChampSim's configuration step), but most are bad uses. This patch removes some bad uses:

  - The `DP(x)` macro is replaced with `if constexpr (champsim::debug_print)`, requiring that they always compile.
  - Numerous `#defines` defining constants replaced with typed `constexpr` values.
  - Some vestigial compilation conditionals removed.