### PR TITLE
Fixed bug in basic_btb

### DIFF
--- a/btb/basic_btb/basic_btb.cc
+++ b/btb/basic_btb/basic_btb.cc
@@ -119,9 +119,9 @@ void O3_CPU::update_btb(uint64_t ip, uint64_t branch_target, uint8_t taken, uint
     auto btb_entry = std::find_if(set_begin, set_end, [ip](auto x) { return x.ip_tag == ip; });
 
     // no prediction for this entry so far, so allocate one
-    if (btb_entry == set_end && (branch_target != 0) && taken) {
+    if (btb_entry == set_end) {
       btb_entry = std::min_element(set_begin, set_end, [](auto x, auto y) { return x.last_cycle_used < y.last_cycle_used; });
-      btb_entry->always_taken = true;
+      btb_entry->always_taken = ((branch_target != 0) && taken); // Mark the branch always taken if it was taken this time
     }
 
     *btb_entry = {ip, branch_target, btb_entry->always_taken && taken, current_cycle};

--- a/test/900-btb-bounds-check.cc
+++ b/test/900-btb-bounds-check.cc
@@ -1,0 +1,17 @@
+#include "catch.hpp"
+#include "mocks.hpp"
+#include "ooo_cpu.h"
+
+TEST_CASE("The basic_btb module does not overflow its bounds.") {
+    do_nothing_MRC mock_L1I, mock_L1D;
+    O3_CPU uut{0, 1.0, {32, 8, 2}, 64, 32, 32, 352, 128, 72, 2, 2, 2, 128, 1, 2, 2, 1, 1, 1, 1, 0, 0, &mock_L1I, &mock_L1D, O3_CPU::bbranchDbimodal, O3_CPU::tbtbDbasic_btb};
+    O3_CPU other_cpu{0, 1.0, {32, 8, 2}, 64, 32, 32, 352, 128, 72, 2, 2, 2, 128, 1, 2, 2, 1, 1, 1, 1, 0, 0, &mock_L1I, &mock_L1D, O3_CPU::bbranchDbimodal, O3_CPU::tbtbDbasic_btb};
+
+    // Populate the other_cpu's BTB tables
+    other_cpu.initialize();
+    other_cpu.impl_update_btb(0xffffffff, 0, true, BRANCH_DIRECT_CALL);
+
+    // Access the table from the uut
+    uut.impl_btb_prediction(0xdeadbeef, BRANCH_DIRECT_CALL);
+}
+


### PR DESCRIPTION
The BTB module had a sneaky bug. If:

 - There is more than one core, and
 - The BTB mispredicts a direct branch, and
 - The IP was one less than a multiple of 1024, and
 - The IP was not present in the BTB

Then, there would be a buffer overflow and a later prediction to some other core will segfault. This patch includes a test to demonstrate that the bug exists as well as a fix for that bug.