### PR TITLE
Fixed bug in DIB check

### DIFF
--- a/config/instantiation_file.py
+++ b/config/instantiation_file.py
@@ -5,7 +5,7 @@ from . import util
 
 ptw_fmtstr = 'PageTableWalker {name}("{name}", {cpu}, {frequency}, {{{{{pscl5_set}, {pscl5_way}, vmem.shamt(4)}}, {{{pscl4_set}, {pscl4_way}, vmem.shamt(3)}}, {{{pscl3_set}, {pscl3_way}, vmem.shamt(2)}}, {{{pscl2_set}, {pscl2_way}, vmem.shamt(1)}}}}, {ptw_rq_size}, {ptw_mshr_size}, {ptw_max_read}, {ptw_max_write}, 1, &{lower_level}, vmem);\n'
 
-cpu_fmtstr = '{{{index}, {frequency}, {{{DIB[sets]}, {DIB[ways]}, {DIB[window_size]}}}, {ifetch_buffer_size}, {dispatch_buffer_size}, {decode_buffer_size}, {rob_size}, {lq_size}, {sq_size}, {fetch_width}, {decode_width}, {dispatch_width}, {scheduler_size}, {execute_width}, {lq_width}, {sq_width}, {retire_width}, {mispredict_penalty}, {decode_latency}, {dispatch_latency}, {schedule_latency}, {execute_latency}, &{L1I}, &{L1D}, {branch_enum_string}, {btb_enum_string}}}'
+cpu_fmtstr = '{{{index}, {frequency}, {{{DIB[sets]}, {DIB[ways]}, {DIB[window_size]}}}, {ifetch_buffer_size}, {dispatch_buffer_size}, {decode_buffer_size}, {rob_size}, {lq_size}, {sq_size}, {fetch_width}, {decode_width}, {dispatch_width}, {scheduler_size}, {execute_width}, {lq_width}, {sq_width}, {retire_width}, {mispredict_penalty}, {decode_latency}, {dispatch_latency}, {schedule_latency}, {execute_latency}, &{L1I}, {L1I}.MAX_READ, &{L1D}, {L1D}.MAX_READ, {branch_enum_string}, {btb_enum_string}}}'
 
 pmem_fmtstr = 'MEMORY_CONTROLLER {name}({frequency}, {io_freq}, {tRP}, {tRCD}, {tCAS}, {turn_around_time});\n'
 vmem_fmtstr = 'VirtualMemory vmem(lg2({size}), 1 << 12, {num_levels}, {minor_fault_penalty}, {dram_name});\n'

--- a/inc/instruction.h
+++ b/inc/instruction.h
@@ -73,6 +73,7 @@ struct ooo_model_instr {
   uint8_t branch_type = NOT_BRANCH;
   uint64_t branch_target = 0;
 
+  uint8_t dib_checked = 0;
   uint8_t fetched = 0;
   uint8_t decoded = 0;
   uint8_t scheduled = 0;

--- a/inc/ooo_cpu.h
+++ b/inc/ooo_cpu.h
@@ -98,6 +98,7 @@ public:
   const std::size_t IFETCH_BUFFER_SIZE, DISPATCH_BUFFER_SIZE, DECODE_BUFFER_SIZE, ROB_SIZE, SQ_SIZE;
   const unsigned FETCH_WIDTH, DECODE_WIDTH, DISPATCH_WIDTH, SCHEDULER_SIZE, EXEC_WIDTH, LQ_WIDTH, SQ_WIDTH, RETIRE_WIDTH;
   const unsigned BRANCH_MISPREDICT_PENALTY, DISPATCH_LATENCY, DECODE_LATENCY, SCHEDULING_LATENCY, EXEC_LATENCY;
+  const unsigned L1I_BANDWIDTH, L1D_BANDWIDTH;
 
   // branch
   uint8_t fetch_stall = 0;
@@ -160,13 +161,13 @@ public:
          std::size_t dispatch_buffer_size, std::size_t rob_size, std::size_t lq_size, std::size_t sq_size, unsigned fetch_width, unsigned decode_width,
          unsigned dispatch_width, unsigned schedule_width, unsigned execute_width, unsigned lq_width, unsigned sq_width, unsigned retire_width,
          unsigned mispredict_penalty, unsigned decode_latency, unsigned dispatch_latency, unsigned schedule_latency, unsigned execute_latency,
-         MemoryRequestConsumer* l1i, MemoryRequestConsumer* l1d, std::bitset<NUM_BRANCH_MODULES> bpred_type, std::bitset<NUM_BTB_MODULES> btb_type)
+         MemoryRequestConsumer* l1i, unsigned l1i_bw, MemoryRequestConsumer* l1d, unsigned l1d_bw, std::bitset<NUM_BRANCH_MODULES> bpred_type, std::bitset<NUM_BTB_MODULES> btb_type)
       : champsim::operable(freq_scale), cpu(cpu), DIB{std::move(dib)}, LQ(lq_size), IFETCH_BUFFER_SIZE(ifetch_buffer_size),
         DISPATCH_BUFFER_SIZE(dispatch_buffer_size), DECODE_BUFFER_SIZE(decode_buffer_size), ROB_SIZE(rob_size), SQ_SIZE(sq_size), FETCH_WIDTH(fetch_width),
         DECODE_WIDTH(decode_width), DISPATCH_WIDTH(dispatch_width), SCHEDULER_SIZE(schedule_width), EXEC_WIDTH(execute_width), LQ_WIDTH(lq_width),
         SQ_WIDTH(sq_width), RETIRE_WIDTH(retire_width), BRANCH_MISPREDICT_PENALTY(mispredict_penalty), DISPATCH_LATENCY(dispatch_latency),
-        DECODE_LATENCY(decode_latency), SCHEDULING_LATENCY(schedule_latency), EXEC_LATENCY(execute_latency), L1I_bus(cpu, l1i), L1D_bus(cpu, l1d),
-        bpred_type(bpred_type), btb_type(btb_type)
+        DECODE_LATENCY(decode_latency), SCHEDULING_LATENCY(schedule_latency), EXEC_LATENCY(execute_latency), L1I_BANDWIDTH(l1i_bw), L1D_BANDWIDTH(l1d_bw),
+        L1I_bus(cpu, l1i), L1D_bus(cpu, l1d), bpred_type(bpred_type), btb_type(btb_type)
   {
   }
 };

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -256,7 +256,7 @@ void O3_CPU::do_check_dib(ooo_model_instr& instr)
 void O3_CPU::fetch_instruction()
 {
   // Fetch a single cache line
-  std::size_t to_read = static_cast<CACHE*>(L1I_bus.lower_level)->MAX_READ;
+  std::size_t to_read = L1I_BANDWIDTH;
   auto l1i_req_begin = std::find_if(std::begin(IFETCH_BUFFER), std::end(IFETCH_BUFFER), [](const ooo_model_instr& x) { return !x.fetched; });
   while (to_read > 0 && l1i_req_begin != std::end(IFETCH_BUFFER)) {
     // Find the chunk of instructions in the block
@@ -621,7 +621,7 @@ void O3_CPU::complete_inflight_instruction()
 
 void O3_CPU::handle_memory_return()
 {
-  for (int l1i_bw = FETCH_WIDTH, to_read = static_cast<CACHE*>(L1I_bus.lower_level)->MAX_READ; l1i_bw > 0 && to_read > 0 && !L1I_bus.PROCESSED.empty();
+  for (int l1i_bw = FETCH_WIDTH, to_read = L1I_BANDWIDTH; l1i_bw > 0 && to_read > 0 && !L1I_bus.PROCESSED.empty();
        --to_read) {
     PACKET& l1i_entry = L1I_bus.PROCESSED.front();
 
@@ -645,7 +645,7 @@ void O3_CPU::handle_memory_return()
   }
 
   auto l1d_it = std::begin(L1D_bus.PROCESSED);
-  for (auto l1d_bw = static_cast<CACHE*>(L1D_bus.lower_level)->MAX_READ; l1d_bw > 0 && l1d_it != std::end(L1D_bus.PROCESSED); --l1d_bw, ++l1d_it) {
+  for (auto l1d_bw = L1D_BANDWIDTH; l1d_bw > 0 && l1d_it != std::end(L1D_bus.PROCESSED); --l1d_bw, ++l1d_it) {
     for (auto& lq_entry : LQ) {
       if (lq_entry.has_value() && lq_entry->fetch_issued && lq_entry->virtual_address >> LOG2_BLOCK_SIZE == l1d_it->v_address >> LOG2_BLOCK_SIZE) {
         lq_entry->rob_entry.num_mem_ops--;

--- a/test/140-single-dib-lookup.cc
+++ b/test/140-single-dib-lookup.cc
@@ -1,0 +1,85 @@
+#include "catch.hpp"
+#include "mocks.hpp"
+#include "ooo_cpu.h"
+
+/*
+ * A MemoryRequestConsumer that releases blocks when instructed to
+ */
+class release_MRC : public MemoryRequestConsumer, public champsim::operable
+{
+  std::deque<PACKET> packets;
+  unsigned mpacket_count = 0;
+
+  void add(PACKET pkt) {
+      packets.push_back(pkt);
+      ++mpacket_count;
+  }
+
+  public:
+    release_MRC() : MemoryRequestConsumer(), champsim::operable(1) {}
+
+    void operate() override {}
+
+    bool add_rq(const PACKET &pkt) override { add(pkt); return true; }
+    bool add_wq(const PACKET &pkt) override { add(pkt); return true; }
+    bool add_pq(const PACKET &pkt) override { add(pkt); return true; }
+
+    uint32_t get_occupancy(uint8_t queue_type, uint64_t address) override { return std::size(packets); }
+    uint32_t get_size(uint8_t queue_type, uint64_t address) override { return std::numeric_limits<uint32_t>::max(); }
+
+    unsigned packet_count() const { return mpacket_count; }
+
+    void release(uint64_t addr)
+    {
+        auto pkt_it = std::find_if(std::begin(packets), std::end(packets), [addr](auto x){ return x.address == addr; });
+        if (pkt_it != std::end(packets)) {
+            for (auto ret : pkt_it->to_return) {
+                ret->return_data(*pkt_it);
+            }
+        }
+        packets.erase(pkt_it);
+    }
+};
+
+ooo_model_instr inst(uint64_t addr)
+{
+    input_instr i;
+    i.ip = addr;
+    return ooo_model_instr{0, i};
+}
+
+SCENARIO("A late-added instruction does not miss the IFB") {
+  GIVEN("An IFETCH_BUFFER with one inflight instruction") {
+    release_MRC mock_L1I;
+    do_nothing_MRC mock_L1D;
+    O3_CPU uut{0, 1.0, {32, 8, 2}, 64, 32, 32, 352, 128, 72, 2, 2, 2, 128, 1, 2, 2, 1, 1, 1, 1, 1, 0, &mock_L1I, 1, &mock_L1D, 1, O3_CPU::bbranchDbimodal, O3_CPU::tbtbDbasic_btb};
+
+    uut.IFETCH_BUFFER.push_back(inst(0xdeadbeef));
+    for (auto &instr : uut.IFETCH_BUFFER)
+      instr.event_cycle = uut.current_cycle;
+
+    for (int i = 0; i < 3; ++i) {
+      for (auto op : std::array<champsim::operable*,3>{{&uut, &mock_L1I, &mock_L1D}})
+        op->_operate();
+    }
+
+    CHECK(mock_L1I.packet_count() == 1);
+
+    WHEN("A new instruction is added, and the first request returns") {
+      mock_L1I.release(0xdeadbeef);
+
+      uut.IFETCH_BUFFER.push_back(inst(0xdeadbeee)); // same cache line as first instruction
+
+      for (int i = 0; i < 3; ++i) {
+          for (auto op : std::array<champsim::operable*,3>{{&uut, &mock_L1I, &mock_L1D}})
+              op->_operate();
+      }
+
+      THEN("The IFETCH_BUFFER still has one member") {
+        REQUIRE(std::size(uut.IFETCH_BUFFER) == 1);
+        REQUIRE(uut.IFETCH_BUFFER.front().ip == 0xdeadbeee);
+      }
+    }
+  }
+}
+

--- a/test/200-rob-scheduling.cc
+++ b/test/200-rob-scheduling.cc
@@ -8,7 +8,7 @@ SCENARIO("The scheduler can detect RAW hazards") {
     constexpr unsigned schedule_latency = 1;
 
     do_nothing_MRC mock_L1I, mock_L1D;
-    O3_CPU uut{0, 1.0, {32, 8, 2}, 64, 32, 32, 352, 128, 72, 2, 2, 2, schedule_width, 1, 2, 2, 1, 1, 1, 1, schedule_latency, 0, &mock_L1I, &mock_L1D, O3_CPU::bbranchDbimodal, O3_CPU::tbtbDbasic_btb};
+    O3_CPU uut{0, 1.0, {32, 8, 2}, 64, 32, 32, 352, 128, 72, 2, 2, 2, schedule_width, 1, 2, 2, 1, 1, 1, 1, schedule_latency, 0, &mock_L1I, 1, &mock_L1D, 1, O3_CPU::bbranchDbimodal, O3_CPU::tbtbDbasic_btb};
 
     uut.ROB.push_back(ooo_model_instr{0, input_instr{}});
     for (auto &instr : uut.ROB)
@@ -34,7 +34,7 @@ SCENARIO("The scheduler can detect RAW hazards") {
     constexpr unsigned schedule_latency = 1;
 
     do_nothing_MRC mock_L1I, mock_L1D;
-    O3_CPU uut{0, 1.0, {32, 8, 2}, 64, 32, 32, 352, 128, 72, 2, 2, 2, schedule_width, 1, 2, 2, 1, 1, 1, 1, schedule_latency, 0, &mock_L1I, &mock_L1D, O3_CPU::bbranchDbimodal, O3_CPU::tbtbDbasic_btb};
+    O3_CPU uut{0, 1.0, {32, 8, 2}, 64, 32, 32, 352, 128, 72, 2, 2, 2, schedule_width, 1, 2, 2, 1, 1, 1, 1, schedule_latency, 0, &mock_L1I, 1, &mock_L1D, 1, O3_CPU::bbranchDbimodal, O3_CPU::tbtbDbasic_btb};
 
     input_instr dependent_instr;
     dependent_instr.source_registers[0] = 42;
@@ -70,7 +70,7 @@ SCENARIO("The scheduler can detect RAW hazards") {
     constexpr unsigned schedule_latency = 1;
 
     do_nothing_MRC mock_L1I, mock_L1D;
-    O3_CPU uut{0, 1.0, {32, 8, 2}, 64, 32, 32, 352, 128, 72, 2, 2, 2, schedule_width, 1, 2, 2, 1, 1, 1, 1, schedule_latency, 0, &mock_L1I, &mock_L1D, O3_CPU::bbranchDbimodal, O3_CPU::tbtbDbasic_btb};
+    O3_CPU uut{0, 1.0, {32, 8, 2}, 64, 32, 32, 352, 128, 72, 2, 2, 2, schedule_width, 1, 2, 2, 1, 1, 1, 1, schedule_latency, 0, &mock_L1I, 1, &mock_L1D, 1, O3_CPU::bbranchDbimodal, O3_CPU::tbtbDbasic_btb};
 
     input_instr dependent_instr;
     dependent_instr.source_registers[0] = 42;

--- a/test/300-retire-from-rob.cc
+++ b/test/300-retire-from-rob.cc
@@ -6,7 +6,7 @@ SCENARIO("Completed instructions are retired") {
   GIVEN("An empty ROB") {
     do_nothing_MRC mock_L1I, mock_L1D;
     constexpr std::size_t retire_bandwidth = 1;
-    O3_CPU uut{0, 1.0, {32, 8, 2}, 64, 32, 32, 352, 128, 72, 2, 2, 2, 128, 1, 2, 2, retire_bandwidth, 1, 1, 1, 0, 0, &mock_L1I, &mock_L1D, O3_CPU::bbranchDbimodal, O3_CPU::tbtbDbasic_btb};
+    O3_CPU uut{0, 1.0, {32, 8, 2}, 64, 32, 32, 352, 128, 72, 2, 2, 2, 128, 1, 2, 2, retire_bandwidth, 1, 1, 1, 0, 0, &mock_L1I, 1, &mock_L1D, 1, O3_CPU::bbranchDbimodal, O3_CPU::tbtbDbasic_btb};
 
     auto old_rob_occupancy = std::size(uut.ROB);
     auto old_num_retired = uut.num_retired;
@@ -25,7 +25,7 @@ SCENARIO("Completed instructions are retired") {
   GIVEN("A ROB with a single instruction") {
     do_nothing_MRC mock_L1I, mock_L1D;
     constexpr std::size_t retire_bandwidth = 1;
-    O3_CPU uut{0, 1.0, {32, 8, 2}, 64, 32, 32, 352, 128, 72, 2, 2, 2, 128, 1, 2, 2, retire_bandwidth, 1, 1, 1, 0, 0, &mock_L1I, &mock_L1D, O3_CPU::bbranchDbimodal, O3_CPU::tbtbDbasic_btb};
+    O3_CPU uut{0, 1.0, {32, 8, 2}, 64, 32, 32, 352, 128, 72, 2, 2, 2, 128, 1, 2, 2, retire_bandwidth, 1, 1, 1, 0, 0, &mock_L1I, 1, &mock_L1D, 1, O3_CPU::bbranchDbimodal, O3_CPU::tbtbDbasic_btb};
 
     uut.ROB.push_back(ooo_model_instr{0, input_instr{}});
 
@@ -58,7 +58,7 @@ SCENARIO("Completed instructions are retired") {
   GIVEN("A ROB with two instructions") {
     do_nothing_MRC mock_L1I, mock_L1D;
     constexpr std::size_t retire_bandwidth = 2;
-    O3_CPU uut{0, 1.0, {32, 8, 2}, 64, 32, 32, 352, 128, 72, 2, 2, 2, 128, 1, 2, 2, retire_bandwidth, 1, 1, 1, 0, 0, &mock_L1I, &mock_L1D, O3_CPU::bbranchDbimodal, O3_CPU::tbtbDbasic_btb};
+    O3_CPU uut{0, 1.0, {32, 8, 2}, 64, 32, 32, 352, 128, 72, 2, 2, 2, 128, 1, 2, 2, retire_bandwidth, 1, 1, 1, 0, 0, &mock_L1I, 1, &mock_L1D, 1, O3_CPU::bbranchDbimodal, O3_CPU::tbtbDbasic_btb};
 
     std::vector test_instructions( retire_bandwidth, ooo_model_instr{0,input_instr{}} );
 
@@ -97,7 +97,7 @@ SCENARIO("Completed instructions are retired") {
   GIVEN("A ROB with twice as many instructions as retire bandwidth") {
     do_nothing_MRC mock_L1I, mock_L1D;
     constexpr std::size_t retire_bandwidth = 1;
-    O3_CPU uut{0, 1.0, {32, 8, 2}, 64, 32, 32, 352, 128, 72, 2, 2, 2, 128, 1, 2, 2, retire_bandwidth, 1, 1, 1, 0, 0, &mock_L1I, &mock_L1D, O3_CPU::bbranchDbimodal, O3_CPU::tbtbDbasic_btb};
+    O3_CPU uut{0, 1.0, {32, 8, 2}, 64, 32, 32, 352, 128, 72, 2, 2, 2, 128, 1, 2, 2, retire_bandwidth, 1, 1, 1, 0, 0, &mock_L1I, 1, &mock_L1D, 1, O3_CPU::bbranchDbimodal, O3_CPU::tbtbDbasic_btb};
 
     std::vector test_instructions( 2*retire_bandwidth, ooo_model_instr{0,input_instr{}} );
 

--- a/test/900-btb-bounds-check.cc
+++ b/test/900-btb-bounds-check.cc
@@ -4,8 +4,8 @@
 
 TEST_CASE("The basic_btb module does not overflow its bounds.") {
     do_nothing_MRC mock_L1I, mock_L1D;
-    O3_CPU uut{0, 1.0, {32, 8, 2}, 64, 32, 32, 352, 128, 72, 2, 2, 2, 128, 1, 2, 2, 1, 1, 1, 1, 0, 0, &mock_L1I, &mock_L1D, O3_CPU::bbranchDbimodal, O3_CPU::tbtbDbasic_btb};
-    O3_CPU other_cpu{0, 1.0, {32, 8, 2}, 64, 32, 32, 352, 128, 72, 2, 2, 2, 128, 1, 2, 2, 1, 1, 1, 1, 0, 0, &mock_L1I, &mock_L1D, O3_CPU::bbranchDbimodal, O3_CPU::tbtbDbasic_btb};
+    O3_CPU uut{0, 1.0, {32, 8, 2}, 64, 32, 32, 352, 128, 72, 2, 2, 2, 128, 1, 2, 2, 1, 1, 1, 1, 0, 0, &mock_L1I, 1, &mock_L1D, 1, O3_CPU::bbranchDbimodal, O3_CPU::tbtbDbasic_btb};
+    O3_CPU other_cpu{0, 1.0, {32, 8, 2}, 64, 32, 32, 352, 128, 72, 2, 2, 2, 128, 1, 2, 2, 1, 1, 1, 1, 0, 0, &mock_L1I, 1, &mock_L1D, 1, O3_CPU::bbranchDbimodal, O3_CPU::tbtbDbasic_btb};
 
     // Populate the other_cpu's BTB tables
     other_cpu.initialize();

--- a/test/mocks.hpp
+++ b/test/mocks.hpp
@@ -1,6 +1,7 @@
 #include <deque>
 #include <limits>
 
+#include "cache.h"
 #include "memory_class.h"
 #include "operable.h"
 
@@ -105,98 +106,62 @@ class counting_MRP : public MemoryRequestProducer
   }
 };
 
+template <typename Fun>
+class queue_issue_MRP : public MemoryRequestProducer, public champsim::operable
+{
+  public:
+    struct result_data {
+      PACKET pkt;
+      uint64_t issue_time;
+      uint64_t return_time;
+    };
+    std::deque<result_data> packets;
+
+    Fun issue_func;
+
+    queue_issue_MRP(MemoryRequestConsumer* ll, Fun func) : MemoryRequestProducer(ll), champsim::operable(1), issue_func(func) {}
+
+    void operate() override {}
+
+    bool issue(const PACKET &pkt) {
+      auto copy = pkt;
+      copy.to_return = {this};
+      packets.push_back({copy, current_cycle, 0});
+      return issue_func(*static_cast<CACHE*>(lower_level), copy);
+    }
+
+    void return_data(const PACKET &pkt) override {
+      auto it = std::find_if(std::rbegin(packets), std::rend(packets), [addr=pkt.address](auto x) {
+          return x.pkt.address == addr;
+          });
+      it->return_time = current_cycle;
+    }
+};
+
 /*
  * A MemoryRequestProducer that sends its packets to the write queue and notes when packets are returned
  */
-class to_wq_MRP : public MemoryRequestProducer, public champsim::operable
+class to_wq_MRP : public queue_issue_MRP<decltype(std::mem_fn(&CACHE::add_wq))>
 {
   public:
-    struct result_data {
-      PACKET pkt;
-      uint64_t issue_time;
-      uint64_t return_time;
-    };
-    std::deque<result_data> packets;
-
-    to_wq_MRP(MemoryRequestConsumer* ll) : MemoryRequestProducer(ll), champsim::operable(1) {}
-
-    void operate() override {}
-
-    bool issue(const PACKET &pkt) {
-      auto copy = pkt;
-      copy.to_return = {this};
-      packets.push_back({copy, current_cycle, 0});
-      return lower_level->add_wq(copy);
-    }
-
-    void return_data(const PACKET &pkt) override {
-      auto it = std::find_if(std::rbegin(packets), std::rend(packets), [addr=pkt.address](auto x) {
-          return x.pkt.address == addr;
-          });
-      it->return_time = current_cycle;
-    }
+    to_wq_MRP(MemoryRequestConsumer* ll) : queue_issue_MRP(ll, std::mem_fn(&CACHE::add_wq)) {}
 };
 
 /*
  * A MemoryRequestProducer that sends its packets to the read queue and notes when packets are returned
  */
-class to_rq_MRP : public MemoryRequestProducer, public champsim::operable
+class to_rq_MRP : public queue_issue_MRP<decltype(std::mem_fn(&CACHE::add_rq))>
 {
   public:
-    struct result_data {
-      PACKET pkt;
-      uint64_t issue_time;
-      uint64_t return_time;
-    };
-    std::deque<result_data> packets;
-
-    to_rq_MRP(MemoryRequestConsumer* ll) : MemoryRequestProducer(ll), champsim::operable(1) {}
-
-    void operate() override {}
-
-    bool issue(const PACKET &pkt) {
-      auto copy = pkt;
-      copy.to_return = {this};
-      packets.push_back({copy, current_cycle, 0});
-      return lower_level->add_rq(copy);
-    }
-
-    void return_data(const PACKET &pkt) override {
-      auto it = std::find_if(std::rbegin(packets), std::rend(packets), [addr=pkt.address](auto x) {
-          return x.pkt.address == addr;
-          });
-      it->return_time = current_cycle;
-    }
+    to_rq_MRP(MemoryRequestConsumer* ll) : queue_issue_MRP(ll, std::mem_fn(&CACHE::add_rq)) {}
 };
 
 /*
  * A MemoryRequestProducer that sends its packets to the read queue and notes when packets are returned
  */
-class to_pq_MRP : public MemoryRequestProducer, public champsim::operable
+class to_pq_MRP : public queue_issue_MRP<decltype(std::mem_fn(&CACHE::add_pq))>
 {
   public:
-    struct result_data {
-      PACKET pkt;
-      uint64_t issue_time;
-      uint64_t return_time;
-    };
-    std::deque<result_data> packets;
-
-    to_pq_MRP(MemoryRequestConsumer* ll) : MemoryRequestProducer(ll), champsim::operable(1) {}
-
-    void operate() override {}
-
-    bool issue(const PACKET &pkt) {
-      auto copy = pkt;
-      copy.to_return = {this};
-      packets.push_back({copy, current_cycle, 0});
-      return lower_level->add_pq(copy);
-    }
-
-    void return_data(const PACKET &pkt) override {
-      auto it = std::find_if(std::rbegin(packets), std::rend(packets), [addr=pkt.address](auto x) {
-          return x.pkt.address == addr;
-          });
-      it->return_time = current_cycle;
-    }
+    to_pq_MRP(MemoryRequestConsumer* ll) : queue_issue_MRP(ll, std::mem_fn(&CACHE::add_pq)) {}
 };
+

--- a/test/mocks.hpp
+++ b/test/mocks.hpp
@@ -92,6 +92,45 @@ class filter_MRC : public MemoryRequestConsumer, public champsim::operable
 };
 
 /*
+ * A MemoryRequestConsumer that releases blocks when instructed to
+ */
+class release_MRC : public MemoryRequestConsumer, public champsim::operable
+{
+  std::deque<PACKET> packets;
+  unsigned mpacket_count = 0;
+
+  void add(PACKET pkt) {
+      packets.push_back(pkt);
+      ++mpacket_count;
+  }
+
+  public:
+    release_MRC() : MemoryRequestConsumer(), champsim::operable(1) {}
+
+    void operate() override {}
+
+    bool add_rq(const PACKET &pkt) override { add(pkt); return true; }
+    bool add_wq(const PACKET &pkt) override { add(pkt); return true; }
+    bool add_pq(const PACKET &pkt) override { add(pkt); return true; }
+
+    uint32_t get_occupancy(uint8_t queue_type, uint64_t address) override { return std::size(packets); }
+    uint32_t get_size(uint8_t queue_type, uint64_t address) override { return std::numeric_limits<uint32_t>::max(); }
+
+    unsigned packet_count() const { return mpacket_count; }
+
+    void release(uint64_t addr)
+    {
+        auto pkt_it = std::find_if(std::begin(packets), std::end(packets), [addr](auto x){ return x.address == addr; });
+        if (pkt_it != std::end(packets)) {
+            for (auto ret : pkt_it->to_return) {
+                ret->return_data(*pkt_it);
+            }
+        }
+        packets.erase(pkt_it);
+    }
+};
+
+/*
  * A MemoryRequestProducer that counts how many returns it receives
  */
 class counting_MRP : public MemoryRequestProducer


### PR DESCRIPTION
This patch fixes a bug where undefined behavior (and possibly a double-free fault) could be reached through the following process:

1. A fetch is issued for block X (1)
2. More instructions are added to the IFB, which include instructions in block X
3. The fetch for X (1) returns
4. A fetch is issued for block X (2)
5. The two fetches do not get merged because the merging does not look in the CacheBus::PROCESSED queue.
6. The dependents on X (1) get marked as completed and promoted to decode
7. The dependents on X (1) get decoded and added to the DIB
8. The dependents on X (2) check the DIB (again), find a match, and get marked as both fetched and decoded
9. The dependents on X (2) promote out of the IFB
10. The fetch for X (2) returns

After this patch, the instruction contains a flag noting whether the DIB has been checked or not. The DIB must be checked before fetch and may only be checked exactly once.