### PR TITLE
Fixed bug sending evicted address to replacement policy on fill

### DIFF
--- a/src/cache.cc
+++ b/src/cache.cc
@@ -48,7 +48,7 @@ bool CACHE::handle_writeback(PACKET& handle_pkt)
   BLOCK& fill_block = block[set * NUM_WAY + way];
 
   if (way < NUM_WAY) { // HIT
-    impl_replacement_update_state(handle_pkt.cpu, set, way, fill_block.address, handle_pkt.ip, 0, handle_pkt.type, 1);
+    impl_replacement_update_state(handle_pkt.cpu, set, way, fill_block.address, handle_pkt.ip, 0, handle_pkt.type, true);
 
     // COLLECT STATS
     sim_stats.back().hits[handle_pkt.cpu][handle_pkt.type]++;
@@ -129,7 +129,7 @@ void CACHE::readlike_hit(std::size_t set, std::size_t way, const PACKET& handle_
   }
 
   // update replacement policy
-  impl_replacement_update_state(handle_pkt.cpu, set, way, hit_block.address, handle_pkt.ip, 0, handle_pkt.type, 1);
+  impl_replacement_update_state(handle_pkt.cpu, set, way, hit_block.address, handle_pkt.ip, 0, handle_pkt.type, true);
 
   // COLLECT STATS
   sim_stats.back().hits[handle_pkt.cpu][handle_pkt.type]++;
@@ -277,12 +277,11 @@ bool CACHE::filllike_miss(std::size_t set, std::size_t way, const PACKET& handle
     fill_block.instr_id = handle_pkt.instr_id;
 
     fill_block.pf_metadata = impl_prefetcher_cache_fill(pkt_address, set, way, handle_pkt.type == PREFETCH, evicting_address, handle_pkt.pf_metadata);
+    impl_replacement_update_state(handle_pkt.cpu, set, way, handle_pkt.address, handle_pkt.ip, evicting_address, handle_pkt.type, false);
   } else {
     impl_prefetcher_cache_fill(pkt_address, set, way, handle_pkt.type == PREFETCH, 0, handle_pkt.pf_metadata); // FIXME ignored result
+    impl_replacement_update_state(handle_pkt.cpu, set, way, handle_pkt.address, handle_pkt.ip, 0, handle_pkt.type, false);
   }
-
-  // update replacement policy
-  impl_replacement_update_state(handle_pkt.cpu, set, way, handle_pkt.address, handle_pkt.ip, 0, handle_pkt.type, 0);
 
   // COLLECT STATS
   sim_stats.back().misses[handle_pkt.cpu][handle_pkt.type]++;


### PR DESCRIPTION
Resolves #268 

Somewhere along the line, it looks like the evicted address stopped being sent to the replacement policy. This patch resolves that bug. This bug highlights to me that it is important to test the module interfaces. However, it's not immediately clear to me how we can mock the interfaces for proper testing. I'll look for an idea and either submit it as a different patch or part of this one. Until we can test this change, I'm inclined to let it sit.