### PR TITLE
Fixed broken DPC3 link

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -38,7 +38,7 @@ jobs:
       
     # TODO run an actual set of checks
     - name: Run tests
-      run: ./bin/champsim -w50000000 -i50000000 -- https://hpca23.cse.tamu.edu/champsim-traces/speccpu/400.perlbench-41B.champsimtrace.xz > result.txt
+      run: ./bin/champsim -w50000000 -i50000000 -- https://dpc3.compas.cs.stonybrook.edu/champsim-traces/speccpu/400.perlbench-41B.champsimtrace.xz > result.txt
 
     # We upload the generated files under github actions assets
     - name: Upload Results

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ $ make
 
 # Download DPC-3 trace
 
-Professor Daniel Jimenez at Texas A&M University kindly provided traces for the 3rd Data Prefetching Championship (DPC-3). They can be found here (http://hpca23.cse.tamu.edu/champsim-traces/speccpu). A set of traces used for the 2nd Cache Replacement Championship (CRC-2) can be found from this link. (http://bit.ly/2t2nkUj)
+Traces used for the 3rd Data Prefetching Championship (DPC-3) can be found here. (https://dpc3.compas.cs.stonybrook.edu/champsim-traces/speccpu/) A set of traces used for the 2nd Cache Replacement Championship (CRC-2) can be found from this link. (http://bit.ly/2t2nkUj)
+
+Storage for these traces is kindly provided by Daniel Jimenez (Texas A&M University) and Mike Ferdman (Stony Brook University). If you find yourself frequently using ChampSim, it is highly encouraged that you maintain your own repository of traces, in case the links ever break.
 
 # Run simulation
 


### PR DESCRIPTION
Resolves #275.

Texas A&M no longer allowed us to host the traces on their servers. Stony Brook University has generously offered to host them instead. This patch fixes the broken link.