### PR TITLE
Check for the update of a zero target in the BTB

### DIFF
--- a/btb/basic_btb/basic_btb.cc
+++ b/btb/basic_btb/basic_btb.cc
@@ -10,6 +10,7 @@
 #include <bitset>
 #include <deque>
 #include <map>
+#include <assert.h>
 
 #include "ooo_cpu.h"
 #include "util.h"
@@ -127,6 +128,8 @@ void O3_CPU::update_btb(uint64_t ip, uint64_t branch_target, uint8_t taken, uint
       btb_entry->always_taken = ((branch_target != 0) && taken); // Mark the branch always taken if it was taken this time
     }
 
+    assert(branch_target != 0);
+    
     *btb_entry = {ip, branch_target, btb_entry->always_taken && taken, current_cycle};
   }
 }


### PR DESCRIPTION
This is a test in order to demonstrate that the BTB is updated sometimes with a zero target. The added assert triggers when running for example server_039.champsimtrace.xz (IPC-1).

This pull request is a test for the pull request #258. BTB should not be updated (and an entry should not be added) on a branch with a target == 0.