### PR TITLE
Fix upper level prefetch

### DIFF
--- a/src/cache.cc
+++ b/src/cache.cc
@@ -205,11 +205,10 @@ bool CACHE::handle_miss(const PACKET& handle_pkt)
 
     if (handle_pkt.fill_this_level)
       fwd_pkt.to_return = {this};
-    else {
-      fwd_pkt.fill_this_level = true; // We will fill the next level
+    else
       fwd_pkt.to_return.clear();
-    }
-
+    
+    fwd_pkt.fill_this_level = true; // We will always fill the lower level
     fwd_pkt.prefetch_from_this = false;
 
     bool success;

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -207,7 +207,7 @@ bool CACHE::handle_miss(const PACKET& handle_pkt)
       fwd_pkt.to_return = {this};
     else
       fwd_pkt.to_return.clear();
-    
+
     fwd_pkt.fill_this_level = true; // We will always fill the lower level
     fwd_pkt.prefetch_from_this = false;
 

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -205,8 +205,10 @@ bool CACHE::handle_miss(const PACKET& handle_pkt)
 
     if (handle_pkt.fill_this_level)
       fwd_pkt.to_return = {this};
-    else
+    else {
+      fwd_pkt.fill_this_level = true; // We will fill the next level
       fwd_pkt.to_return.clear();
+    }
 
     fwd_pkt.prefetch_from_this = false;
 

--- a/test/421-prefetch-fill-level.cc
+++ b/test/421-prefetch-fill-level.cc
@@ -72,3 +72,97 @@ SCENARIO("A prefetch can be issued without creating an MSHR") {
   }
 }
 
+SCENARIO("A prefetch fill the first level") {
+  GIVEN("An empty cache") {
+    constexpr uint64_t hit_latency = 1;
+    constexpr uint64_t fill_latency = 10;
+    do_nothing_MRC mock_ll;
+    CACHE::NonTranslatingQueues uut_queues{1, 32, 32, 32, 0, hit_latency, LOG2_BLOCK_SIZE, false};
+    CACHE uut{"421-uut", 1, 1, 8, 32, fill_latency, 1, 1, 0, false, false, false, (1<<LOAD)|(1<<PREFETCH), uut_queues, &mock_ll, CACHE::pprefetcherDno, CACHE::rreplacementDlru};
+
+    // Initialize the prefetching and replacement
+    uut.impl_prefetcher_initialize();
+    uut.impl_replacement_initialize();
+
+    // Turn off warmup
+    uut.warmup = false;
+    uut_queues.warmup = false;
+    uut.begin_phase();
+    uut_queues.begin_phase();
+
+    WHEN("A prefetch is issued with 'fill_this_level == true'") {
+      auto seed_result = uut.prefetch_line(0xdeadbeef, true, 0);
+      REQUIRE(seed_result);
+
+      for (int i = 0; i < 1000; i++) {
+        uut_queues._operate();
+        uut._operate();
+        mock_ll._operate();
+      }
+
+      // We ensure that the block fill the first level
+      bool find = false;
+      for (auto i: uut.block) if (find = (i.address == 0xdeadbeef)) break;
+
+      THEN("The packet fill the cache") {
+        REQUIRE(find);
+      }
+    }
+  }
+}
+
+SCENARIO("A prefetch not fill the first level and fill the second level") {
+  GIVEN("An empty cache") {
+    constexpr uint64_t hit_latency = 1;
+    constexpr uint64_t fill_latency = 10;
+    do_nothing_MRC mock_ll;
+
+    CACHE::NonTranslatingQueues uut_queues{1, 32, 32, 32, 0, hit_latency, LOG2_BLOCK_SIZE, false};
+    CACHE::NonTranslatingQueues uul_queues{1, 32, 32, 32, 0, hit_latency, LOG2_BLOCK_SIZE, false};
+
+    CACHE uul{"421-uul", 2, 2, 8, 32, fill_latency, 1, 1, 0, false, false, false, (1<<LOAD)|(1<<PREFETCH), uul_queues, &mock_ll, CACHE::pprefetcherDno, CACHE::rreplacementDlru};
+    CACHE uut{"421-uut", 1, 1, 8, 32, fill_latency, 1, 1, 0, false, false, false, (1<<LOAD)|(1<<PREFETCH), uut_queues, &uul, CACHE::pprefetcherDno, CACHE::rreplacementDlru};
+
+    // Initialize the prefetching and replacement
+    uut.impl_prefetcher_initialize();
+    uut.impl_replacement_initialize();
+    uul.impl_prefetcher_initialize();
+    uul.impl_replacement_initialize();
+
+    // Turn off warmup
+    uut.warmup = false;
+    uut_queues.warmup = false;
+    uut.begin_phase();
+    uut_queues.begin_phase();
+
+    uul.warmup = false;
+    uul_queues.warmup = false;
+    uul.begin_phase();
+    uul_queues.begin_phase();
+
+    WHEN("A prefetch is issued with 'fill_this_level == false'") {
+      auto seed_result = uut.prefetch_line(0xdeadbeef, false, 0);
+      REQUIRE(seed_result);
+
+      for (int i = 0; i < 100; i++) {
+        uut_queues._operate();
+        uut._operate();
+        uul_queues._operate();
+        uul._operate();
+        mock_ll._operate();
+      }
+
+      THEN("The packet do not fill the first level") {
+        bool find_block = false;
+        for (auto i: uut.block) if (find_block = (i.address == 0xdeadbeef)) break;
+        REQUIRE(!find_block);
+      }
+
+      THEN("The packet fill the second level") {
+        bool find_block = false;
+        for (auto i: uul.block) if (find_block = (i.address == 0xdeadbeef)) break;
+        REQUIRE(find_block);
+      }
+    }
+  }
+}


### PR DESCRIPTION
When a prefetch is issue with `fill_this_level == true`, the prefetch request never fill the lower level. This patch fix the bug, and add two test to verify the behavior.

# Why does this bug happen?

The flag `fill_this_level` packet flag is never set to true

# Fix 

After the first MSHR miss, the `fill_this_level` flag is set to true.

https://github.com/agusnt/ChampSim/blob/90c9e5b09f39c146c3cda872a7b8ad8cb0111776/src/cache.cc#L208-L211