### PR TITLE
Added support for Apple devices

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,11 @@ jobs:
       with:
         submodules: 'true'
 
-    - name: Set up
+    - name: Set up pkg-config
+      if: startsWith(matrix.config.os, 'macos')
+      run: brew install pkg-config
+      
+    - name: Set up vcpkg
       run: |
         vcpkg/bootstrap-vcpkg.sh
         vcpkg/vcpkg install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,11 +104,11 @@ jobs:
           }
 
         # AppleClang
-        #- {
-        #    name: "macOS Clang",
-        #    os: macos-latest,
-        #    cxx: "clang++",
-        #  }
+        - {
+            name: "macOS Clang",
+            os: macos-latest,
+            cxx: "clang++",
+          }
 
         # MSVC 2022
         #- {

--- a/inc/tracereader.h
+++ b/inc/tracereader.h
@@ -49,9 +49,11 @@ public:
 protected:
   static FILE* get_fptr(std::string fname);
 
-  std::unique_ptr<FILE, decltype(&detail::pclose_file)> fp{get_fptr(trace_string), &detail::pclose_file};
 #if defined(__GNUG__) && !defined(__APPLE__)
+  std::unique_ptr<FILE, decltype(&detail::pclose_file)> fp{get_fptr(trace_string), &detail::pclose_file};
   __gnu_cxx::stdio_filebuf<char> filebuf{fp.get(), std::ios::in};
+#elif defined(__APPLE__)
+  FILE* fp = get_fptr(trace_string);
 #endif
 
   uint8_t cpu;

--- a/src/tracereader.cc
+++ b/src/tracereader.cc
@@ -62,7 +62,7 @@ void tracereader::refresh_buffer()
   eof_ = trace_file.eof();
 #else
   bytes_read = fread(std::data(raw_buf), sizeof(char), std::size(raw_buf), fp);
-  eof_ = (bytes_read > 0);
+  eof_ = !(bytes_read > 0);
 #endif
 
   // Transform bytes into trace format instructions


### PR DESCRIPTION
This patch changes how the trace file pointer is instantiated on Mac devices and the file is read. I've confirmed it works on M1's.