### PR TITLE
Used nlohmann::json for JSON output

### DIFF
--- a/inc/cache.h
+++ b/inc/cache.h
@@ -43,6 +43,7 @@ struct cache_stats {
   std::array<std::array<uint64_t, NUM_CPUS>, NUM_TYPES> hits = {};
   std::array<std::array<uint64_t, NUM_CPUS>, NUM_TYPES> misses = {};
 
+  double avg_miss_latency = 0;
   uint64_t total_miss_latency = 0;
 };
 

--- a/inc/stats_printer.h
+++ b/inc/stats_printer.h
@@ -56,20 +56,8 @@ class json_printer
 {
   std::ostream& stream;
 
-  void print(O3_CPU::stats_type);
-  void print(CACHE::stats_type);
-  void print(DRAM_CHANNEL::stats_type);
-
-  std::size_t indent_level = 0;
-  std::string indent() const { return std::string(2 * indent_level, ' '); }
-
-  void print(std::vector<O3_CPU::stats_type> stats_list);
-  void print(std::vector<CACHE::stats_type> stats_list);
-  void print(std::vector<DRAM_CHANNEL::stats_type> stats_list);
-
 public:
   json_printer(std::ostream& str) : stream(str) {}
-  void print(phase_stats& stats);
   void print(std::vector<phase_stats>& stats);
 };
 } // namespace champsim

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -17,6 +17,7 @@
 #include "cache.h"
 
 #include <algorithm>
+#include <cmath>
 #include <iomanip>
 #include <iterator>
 #include <numeric>
@@ -513,7 +514,11 @@ void CACHE::end_phase(unsigned finished_cpu)
   roi_stats.back().pf_useless = sim_stats.back().pf_useless;
   roi_stats.back().pf_fill = sim_stats.back().pf_fill;
 
-  roi_stats.back().total_miss_latency = sim_stats.back().total_miss_latency;
+  auto total_miss = 0ull;
+  for (auto type : {LOAD, RFO, PREFETCH, WRITE, TRANSLATION}) {
+    total_miss = std::accumulate(std::begin(roi_stats.back().hits.at(type)), std::end(roi_stats.back().hits.at(type)), total_miss);
+  }
+  roi_stats.back().avg_miss_latency = std::ceil(sim_stats.back().total_miss_latency) / total_miss;
 }
 
 bool CACHE::should_activate_prefetcher(const PACKET& pkt) const { return ((1 << pkt.type) & pref_activate_mask) && !pkt.prefetch_from_this; }

--- a/src/json_printer.cc
+++ b/src/json_printer.cc
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-#include <iomanip>
-#include <iostream>
-#include <numeric>
+#include <algorithm>
 #include <utility>
+
+#include <nlohmann/json.hpp>
 
 #include "stats_printer.h"
 
-void champsim::json_printer::print(O3_CPU::stats_type stats)
+void to_json(nlohmann::json& j, const O3_CPU::stats_type stats)
 {
-  constexpr std::array<std::pair<std::string_view, std::size_t>, 6> types{
+  std::array<std::pair<std::string, std::size_t>, 6> types{
       {std::pair{"BRANCH_DIRECT_JUMP", BRANCH_DIRECT_JUMP}, std::pair{"BRANCH_INDIRECT", BRANCH_INDIRECT}, std::pair{"BRANCH_CONDITIONAL", BRANCH_CONDITIONAL},
        std::pair{"BRANCH_DIRECT_CALL", BRANCH_DIRECT_CALL}, std::pair{"BRANCH_INDIRECT_CALL", BRANCH_INDIRECT_CALL},
        std::pair{"BRANCH_RETURN", BRANCH_RETURN}}};
@@ -31,199 +31,76 @@ void champsim::json_printer::print(O3_CPU::stats_type stats)
   auto total_mispredictions = std::ceil(
       std::accumulate(std::begin(types), std::end(types), 0ll, [btm = stats.branch_type_misses](auto acc, auto next) { return acc + btm[next.second]; }));
 
-  stream << indent() << "{" << std::endl;
-  ++indent_level;
-  stream << indent() << "\"instructions\": " << stats.instrs() << "," << std::endl;
-  stream << indent() << "\"cycles\": " << stats.cycles() << "," << std::endl;
-  stream << indent() << "\"Avg ROB occupancy at mispredict\": " << std::ceil(stats.total_rob_occupancy_at_branch_mispredict) / std::ceil(total_mispredictions)
-         << ", " << std::endl;
+  std::map<std::string, std::size_t> mpki{};
+  for (auto [name, idx] : types)
+    mpki.emplace(name, stats.branch_type_misses[idx]);
 
-  stream << indent() << "\"mispredict\": {" << std::endl;
-  ++indent_level;
-  for (std::size_t i = 0; i < std::size(types); ++i) {
-    if (i != 0)
-      stream << "," << std::endl;
-    stream << indent() << "\"" << types[i].first << "\": " << stats.branch_type_misses[types[i].second];
-  }
-  stream << std::endl;
-  --indent_level;
-  stream << indent() << "}" << std::endl;
-  --indent_level;
-  stream << indent() << "}";
+  j = nlohmann::json{
+    {"instructions", stats.instrs()},
+    {"cycles", stats.cycles()},
+    {"Avg ROB occupancy at mispredict", std::ceil(stats.total_rob_occupancy_at_branch_mispredict) / std::ceil(total_mispredictions)},
+    {"mispredict", mpki}
+  };
 }
 
-void champsim::json_printer::print(CACHE::stats_type stats)
+void to_json(nlohmann::json& j, const CACHE::stats_type stats)
 {
   constexpr std::array<std::pair<std::string_view, std::size_t>, 5> types{
       {std::pair{"LOAD", LOAD}, std::pair{"RFO", RFO}, std::pair{"PREFETCH", PREFETCH}, std::pair{"WRITE", WRITE}, std::pair{"TRANSLATION", TRANSLATION}}};
 
-  stream << indent() << "\"" << stats.name << "\": {" << std::endl;
-  ++indent_level;
+  std::map<std::string, nlohmann::json> statsmap;
+  statsmap.emplace("prefetch requested", stats.pf_requested);
+  statsmap.emplace("prefetch issued", stats.pf_issued);
+  statsmap.emplace("useful prefetch", stats.pf_useful);
+  statsmap.emplace("useless prefetch", stats.pf_useless);
+  statsmap.emplace("miss latency", stats.avg_miss_latency);
   for (const auto& type : types) {
-    stream << indent() << "\"" << type.first << "\": {" << std::endl;
-    ++indent_level;
-
-    stream << indent() << "\"hit\": [";
-    for (std::size_t i = 0; i < std::size(stats.hits[type.second]); ++i) {
-      if (i != 0)
-        stream << ", ";
-      stream << stats.hits[type.second][i];
-    }
-    stream << "]," << std::endl;
-
-    stream << indent() << "\"miss\": [";
-    for (std::size_t i = 0; i < std::size(stats.misses[type.second]); ++i) {
-      if (i != 0)
-        stream << ", ";
-      stream << stats.misses[type.second][i];
-    }
-    stream << "]" << std::endl;
-
-    --indent_level;
-    stream << indent() << "}," << std::endl;
+    statsmap.emplace(type.first, nlohmann::json{
+      {"hit", stats.hits[type.second]},
+      {"miss", stats.misses[type.second]}
+    });
   }
 
-  stream << indent() << "\"prefetch requested\": " << stats.pf_requested << "," << std::endl;
-  stream << indent() << "\"prefetch issued\": " << stats.pf_issued << "," << std::endl;
-  stream << indent() << "\"useful prefetch\": " << stats.pf_useful << "," << std::endl;
-  stream << indent() << "\"useless prefetch\": " << stats.pf_useless << "," << std::endl;
-
-  double TOTAL_MISS = 0;
-  for (const auto& type : types)
-    TOTAL_MISS += std::accumulate(std::begin(stats.misses.at(type.second)), std::end(stats.misses.at(type.second)), TOTAL_MISS);
-  if (TOTAL_MISS > 0)
-    stream << indent() << "\"miss latency\": " << (std::ceil(stats.total_miss_latency)) / TOTAL_MISS << std::endl;
-  else
-    stream << indent() << "\"miss latency\": null" << std::endl;
-  --indent_level;
-  stream << indent() << "}";
+  j = statsmap;
 }
 
-void champsim::json_printer::print(DRAM_CHANNEL::stats_type stats)
+void to_json(nlohmann::json& j, const DRAM_CHANNEL::stats_type stats)
 {
-  stream << indent() << "{" << std::endl;
-  ++indent_level;
-  stream << indent() << "\"RQ ROW_BUFFER_HIT\": " << stats.RQ_ROW_BUFFER_HIT << "," << std::endl;
-  stream << indent() << "\"RQ ROW_BUFFER_MISS\": " << stats.RQ_ROW_BUFFER_MISS << "," << std::endl;
-  stream << indent() << "\"WQ ROW_BUFFER_HIT\": " << stats.WQ_ROW_BUFFER_HIT << "," << std::endl;
-  stream << indent() << "\"WQ ROW_BUFFER_MISS\": " << stats.WQ_ROW_BUFFER_MISS << "," << std::endl;
-  stream << indent() << "\"WQ FULL\": " << stats.WQ_FULL << "," << std::endl;
-  if (stats.dbus_count_congested > 0)
-    stream << indent() << "\"AVG DBUS CONGESTED CYCLE\": " << std::ceil(stats.dbus_cycle_congested) / std::ceil(stats.dbus_count_congested) << std::endl;
-  else
-    stream << indent() << "\"AVG DBUS CONGESTED CYCLE\": null" << std::endl;
-  --indent_level;
-  stream << indent() << "}";
+  j = nlohmann::json{
+    {"RQ ROW_BUFFER_HIT", stats.RQ_ROW_BUFFER_HIT},
+    {"RQ ROW_BUFFER_MISS", stats.RQ_ROW_BUFFER_MISS},
+    {"WQ ROW_BUFFER_HIT", stats.WQ_ROW_BUFFER_HIT},
+    {"WQ ROW_BUFFER_MISS", stats.WQ_ROW_BUFFER_MISS},
+    {"AVG DBUS CONGESTED CYCLE", std::ceil(stats.dbus_cycle_congested) / std::ceil(stats.dbus_count_congested)}
+  };
 }
 
-void champsim::json_printer::print(std::vector<O3_CPU::stats_type> stats_list)
-{
-  stream << indent() << "\"cores\": [" << std::endl;
-  ++indent_level;
+namespace champsim {
+  void to_json(nlohmann::json& j, const champsim::phase_stats stats)
+  {
+    std::map<std::string, nlohmann::json> roi_stats;
+    roi_stats.emplace("cores", stats.roi_cpu_stats);
+    roi_stats.emplace("DRAM", stats.roi_dram_stats);
+    for (auto x : stats.roi_cache_stats)
+      roi_stats.emplace(x.name, x);
 
-  bool first = true;
-  for (const auto& stats : stats_list) {
-    if (!first)
-      stream << "," << std::endl;
-    print(stats);
-    first = false;
+    std::map<std::string, nlohmann::json> sim_stats;
+    sim_stats.emplace("cores", stats.sim_cpu_stats);
+    sim_stats.emplace("DRAM", stats.sim_dram_stats);
+    for (auto x : stats.sim_cache_stats)
+      sim_stats.emplace(x.name, x);
+
+    std::map<std::string, nlohmann::json> statsmap{
+      {"name", stats.name},
+      {"traces", stats.trace_names}
+    };
+    statsmap.emplace("roi", roi_stats);
+    statsmap.emplace("sim", sim_stats);
+    j = statsmap;
   }
-  stream << std::endl;
-
-  --indent_level;
-  stream << indent() << "]";
-}
-
-void champsim::json_printer::print(std::vector<CACHE::stats_type> stats_list)
-{
-  bool first = true;
-  for (const auto& stats : stats_list) {
-    if (!first)
-      stream << "," << std::endl;
-    print(stats);
-    first = false;
-  }
-}
-
-void champsim::json_printer::print(std::vector<DRAM_CHANNEL::stats_type> stats_list)
-{
-  stream << indent() << "\"DRAM\": [" << std::endl;
-  ++indent_level;
-
-  bool first = true;
-  for (const auto& stats : stats_list) {
-    if (!first)
-      stream << "," << std::endl;
-    print(stats);
-    first = false;
-  }
-  stream << std::endl;
-
-  --indent_level;
-  stream << indent() << "]" << std::endl;
-}
-
-void champsim::json_printer::print(champsim::phase_stats& stats)
-{
-  stream << indent() << "{" << std::endl;
-  ++indent_level;
-
-  stream << indent() << "\"name\": \"" << stats.name << "\"," << std::endl;
-  stream << indent() << "\"traces\": [" << std::endl;
-  ++indent_level;
-
-  bool first = true;
-  for (auto t : stats.trace_names) {
-    if (!first)
-      stream << "," << std::endl;
-    stream << indent() << "\"" << t << "\"";
-    first = false;
-  }
-
-  --indent_level;
-  stream << std::endl << indent() << "]," << std::endl;
-
-  stream << indent() << "\"roi\": {" << std::endl;
-  ++indent_level;
-
-  print(stats.roi_cpu_stats);
-  stream << "," << std::endl;
-
-  print(stats.roi_cache_stats);
-  stream << "," << std::endl;
-
-  print(stats.roi_dram_stats);
-  stream << std::endl;
-
-  --indent_level;
-  stream << indent() << "}," << std::endl;
-
-  stream << indent() << "\"sim\": {" << std::endl;
-  ++indent_level;
-
-  print(stats.sim_cpu_stats);
-  stream << "," << std::endl;
-
-  print(stats.sim_cache_stats);
-  stream << "," << std::endl;
-
-  print(stats.sim_dram_stats);
-  stream << std::endl;
-
-  --indent_level;
-  stream << indent() << "}" << std::endl;
-  --indent_level;
-  stream << indent() << "}" << std::endl;
 }
 
 void champsim::json_printer::print(std::vector<phase_stats>& stats)
 {
-  stream << "[" << std::endl;
-  ++indent_level;
-
-  for (auto p : stats)
-    print(p);
-
-  stream << "]" << std::endl;
-  --indent_level;
+  stream << nlohmann::json::array_t{std::begin(stats), std::end(stats)};
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -156,8 +156,7 @@ int main(int argc, char** argv)
 
   auto phase_stats = zip_phase_stats(phases, ooo_cpu, caches, DRAM);
 
-  champsim::plain_printer default_print{std::cout};
-  default_print.print(phase_stats);
+  champsim::plain_printer{std::cout}.print(phase_stats);
 
   for (CACHE& cache : caches)
     cache.impl_prefetcher_final_stats();
@@ -166,13 +165,10 @@ int main(int argc, char** argv)
     cache.impl_replacement_final_stats();
 
   if (knob_json_out) {
-    if (json_file.is_open()) {
-      champsim::json_printer printer{json_file};
-      printer.print(phase_stats);
-    } else {
-      champsim::json_printer printer{std::cout};
-      printer.print(phase_stats);
-    }
+    if (json_file.is_open())
+      champsim::json_printer{json_file}.print(phase_stats);
+    else
+      champsim::json_printer{std::cout}.print(phase_stats);
   }
 
   return 0;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,6 +2,7 @@
   "name": "champsim",
   "version-string": "1.0",
   "dependencies": [
+    "nlohmann-json",
     "catch2"
   ]
 }


### PR DESCRIPTION
This patch adds use of `nlohmann::json` as a JSON writer. It results in a heavy reduction in the size of the JSON writer code while providing better guarantees of correctness. We can also later use it if we ever want to read JSON files in the C++ side.