### PR TITLE
Always taken not used for conditional branches

### DIFF
--- a/btb/basic_btb/basic_btb.cc
+++ b/btb/basic_btb/basic_btb.cc
@@ -126,17 +126,11 @@ void O3_CPU::update_btb(uint64_t ip, uint64_t branch_target, uint8_t taken, uint
     type = ::branch_info::INDIRECT;
   else if (branch_type == BRANCH_RETURN)
     type = ::branch_info::RETURN;
-  else if ((branch_target == 0) || !taken)
+  else if (branch_type == BRANCH_CONDITIONAL)
     type = ::branch_info::CONDITIONAL;
 
   auto opt_entry = ::BTB.at(this).check_hit({ip, branch_target, type});
   if (opt_entry.has_value()) {
-    if (taken) {
-      if (opt_entry->type == ::branch_info::CONDITIONAL && type == ::branch_info::ALWAYS_TAKEN) {
-        type = ::branch_info::CONDITIONAL;
-      }
-    }
-
     opt_entry->type = type;
     if (branch_target != 0)
       opt_entry->target = branch_target;

--- a/test/cpp/src/165-basic-btb-no-evict-on-unknown-target.cc
+++ b/test/cpp/src/165-basic-btb-no-evict-on-unknown-target.cc
@@ -1,3 +1,4 @@
+#define CATCH_CONFIG_ENABLE_PAIR_STRINGMAKER
 #include <catch.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
 #include <algorithm>
@@ -18,7 +19,7 @@ struct AllEqualMatcher : Catch::Matchers::MatcherGenericBase {
     }
 
     std::string describe() const override {
-        return "All match {" + Catch::to_string(val_.first) + ", " + Catch::to_string(val_.second) + "}";
+        return "Matches {" + Catch::to_string(val_.first) + ", " + Catch::to_string(val_.second) + "}";
     }
 
 private:
@@ -43,18 +44,18 @@ TEST_CASE("The basic_btb does not fill not-taken branches") {
     // Check that all of the addresses are in the BTB
     std::vector<std::pair<uint64_t, uint8_t>> seed_check_result{};
     std::transform(std::cbegin(seed_ip), std::cend(seed_ip), std::back_inserter(seed_check_result), [&](auto ip){ return uut.impl_btb_prediction(ip); });
-    REQUIRE_THAT(seed_check_result, Catch::Matchers::AllMatch(::AllEqualMatcher{std::pair{fake_target, (uint8_t)true}}));
+    CHECK_THAT(seed_check_result, Catch::Matchers::AllMatch(::AllEqualMatcher{std::pair{fake_target, (uint8_t)true}}));
 
     // Attempt to fill with not-taken
     uut.impl_update_btb(test_ip, 0, false, BRANCH_CONDITIONAL);
 
     // The first seeded IP is still present
     auto [seed_predicted_target, seed_always_taken] = uut.impl_btb_prediction(seed_ip.front());
-    REQUIRE_FALSE(seed_predicted_target == 0); // Branch target should be known
-    REQUIRE(seed_always_taken);
+    CHECK_FALSE(seed_predicted_target == 0); // Branch target should be known
+    CHECK(seed_always_taken);
 
     // The block is not filled
     auto [predicted_target, always_taken] = uut.impl_btb_prediction(test_ip);
-    REQUIRE(predicted_target == 0); // Branch target should not be known
+    CHECK(predicted_target == 0); // Branch target should not be known
 }
 

--- a/test/cpp/src/166-issue296-basic-btb-no-mispredict-on-not-taken.cc
+++ b/test/cpp/src/166-issue296-basic-btb-no-mispredict-on-not-taken.cc
@@ -2,6 +2,19 @@
 #include "mocks.hpp"
 #include "ooo_cpu.h"
 
+TEST_CASE("The basic_btb correctly marks conditional branches as always taken if they have always been taken") {
+    do_nothing_MRC mock_L1I, mock_L1D;
+    O3_CPU uut{0, 1.0, {32, 8, {2}, {2}}, 64, 32, 32, 352, 128, 72, 2, 2, 2, 128, 1, 2, 2, 1, 1, 1, 1, 0, 0, &mock_L1I, 1, &mock_L1D, 1, O3_CPU::bbranchDbimodal, O3_CPU::tbtbDbasic_btb};
+
+    // Access the table from the uut
+    uut.initialize();
+    uut.impl_update_btb(0x66b60c, 0x66b5f0, true, BRANCH_CONDITIONAL);
+    uut.impl_update_btb(0x66b600, 0x66b60c, true, BRANCH_CONDITIONAL);
+    uut.impl_update_btb(0x66b60c, 0x66b5f0, true, BRANCH_CONDITIONAL);
+    auto [predicted_target, always_taken] = uut.impl_btb_prediction(0x66b60c);
+    REQUIRE(always_taken == true); // Branch should assumed to be always taken
+}
+
 TEST_CASE("The basic_btb correctly marks conditional branches as not always taken after they are not taken once") {
     do_nothing_MRC mock_L1I, mock_L1D;
     O3_CPU uut{0, 1.0, {32, 8, {2}, {2}}, 64, 32, 32, 352, 128, 72, 2, 2, 2, 128, 1, 2, 2, 1, 1, 1, 1, 0, 0, &mock_L1I, 1, &mock_L1D, 1, O3_CPU::bbranchDbimodal, O3_CPU::tbtbDbasic_btb};

--- a/test/cpp/src/166-issue296-basic-btb-no-mispredict-on-not-taken.cc
+++ b/test/cpp/src/166-issue296-basic-btb-no-mispredict-on-not-taken.cc
@@ -2,19 +2,6 @@
 #include "mocks.hpp"
 #include "ooo_cpu.h"
 
-TEST_CASE("The basic_btb correctly marks conditional branches as always taken if they have always been taken") {
-    do_nothing_MRC mock_L1I, mock_L1D;
-    O3_CPU uut{0, 1.0, {32, 8, {2}, {2}}, 64, 32, 32, 352, 128, 72, 2, 2, 2, 128, 1, 2, 2, 1, 1, 1, 1, 0, 0, &mock_L1I, 1, &mock_L1D, 1, O3_CPU::bbranchDbimodal, O3_CPU::tbtbDbasic_btb};
-
-    // Access the table from the uut
-    uut.initialize();
-    uut.impl_update_btb(0x66b60c, 0x66b5f0, true, BRANCH_CONDITIONAL);
-    uut.impl_update_btb(0x66b600, 0x66b60c, true, BRANCH_CONDITIONAL);
-    uut.impl_update_btb(0x66b60c, 0x66b5f0, true, BRANCH_CONDITIONAL);
-    auto [predicted_target, always_taken] = uut.impl_btb_prediction(0x66b60c);
-    REQUIRE(always_taken == true); // Branch should assumed to be always taken
-}
-
 TEST_CASE("The basic_btb correctly marks conditional branches as not always taken after they are not taken once") {
     do_nothing_MRC mock_L1I, mock_L1D;
     O3_CPU uut{0, 1.0, {32, 8, {2}, {2}}, 64, 32, 32, 352, 128, 72, 2, 2, 2, 128, 1, 2, 2, 1, 1, 1, 1, 0, 0, &mock_L1I, 1, &mock_L1D, 1, O3_CPU::bbranchDbimodal, O3_CPU::tbtbDbasic_btb};


### PR DESCRIPTION
This is a necessary fix after the last patch on the BTB. I believe it is not good to use the BTB to predict conditional branches, so always taken info is now only for inconditional branches.

