### PR TITLE
Make unknown prefetch_activate values a compile-time error

### DIFF
--- a/config/instantiation_file.py
+++ b/config/instantiation_file.py
@@ -167,9 +167,8 @@ def get_instantiation_lines(cores, caches, ptws, pmem, vmem):
         yield from (v.format(**elem) for k,v in local_cache_builder_parts.items() if k[0] in elem and k[1] == elem[k[0]])
 
         # Create prefetch activation masks
-        if elem.get('prefetch_activate'):
-            type_list = ('LOAD', 'RFO', 'PREFETCH', 'WRITEBACK', 'TRANSLATION')
-            yield '.prefetch_activate({})'.format(', '.join(t for t in type_list if t in elem.get('prefetch_activate', tuple())))
+        if 'prefetch_activate' in elem:
+            yield '.prefetch_activate({})'.format(', '.join('access_type::'+t for t in elem['prefetch_activate']))
 
         if elem.get('_replacement_data'):
             yield '.replacement<{}>()'.format(' | '.join('CACHE::r{}'.format(k['name']) for k in elem['_replacement_data']))

--- a/config/parse.py
+++ b/config/parse.py
@@ -59,7 +59,8 @@ def filter_inaccessible(system, roots, key='lower_level'):
 
 def split_string_or_list(val, delim=','):
     if isinstance(val, str):
-        return [t.strip() for t in val.split(delim)]
+        retval = (t.strip() for t in val.split(delim))
+        return [v for v in retval if v]
     return val
 
 def parse_config_in_context(merged_configs, branch_context, btb_context, prefetcher_context, replacement_context, compile_all_modules):

--- a/config/parse.py
+++ b/config/parse.py
@@ -57,6 +57,11 @@ def duplicate_to_length(elements, n):
 def filter_inaccessible(system, roots, key='lower_level'):
     return util.combine_named(*(util.iter_system(system, r, key=key) for r in roots))
 
+def split_string_or_list(val, delim=','):
+    if isinstance(val, str):
+        return [t.strip() for t in val.split(delim)]
+    return val
+
 def parse_config_in_context(merged_configs, branch_context, btb_context, prefetcher_context, replacement_context, compile_all_modules):
     config_file = util.chain(merged_configs, default_root)
 
@@ -159,6 +164,11 @@ def parse_config_in_context(merged_configs, branch_context, btb_context, prefetc
     for c in caches.values():
         c.setdefault('prefetcher', 'no_instr' if c.get('_is_instruction_cache') else 'no')
         c.setdefault('replacement', 'lru')
+
+    # Set prefetcher_activate
+    for c in caches.values():
+        if 'prefetch_activate' in c:
+            c['prefetch_activate'] = split_string_or_list(c['prefetch_activate'])
 
     tlb_path = itertools.chain.from_iterable(util.iter_system(caches, cpu[name]) for cpu,name in itertools.product(cores, ('ITLB', 'DTLB')))
     l1d_path = itertools.chain.from_iterable(util.iter_system(caches, cpu[name]) for cpu,name in itertools.product(cores, ('L1I', 'L1D')))

--- a/inc/cache.h
+++ b/inc/cache.h
@@ -46,8 +46,8 @@ struct cache_stats {
   uint64_t pf_useless = 0;
   uint64_t pf_fill = 0;
 
-  std::array<std::array<uint64_t, NUM_CPUS>, static_cast<std::size_t>(access_type::NUM_TYPES)> hits = {};
-  std::array<std::array<uint64_t, NUM_CPUS>, static_cast<std::size_t>(access_type::NUM_TYPES)> misses = {};
+  std::array<std::array<uint64_t, NUM_CPUS>, champsim::to_underlying(access_type::NUM_TYPES)> hits = {};
+  std::array<std::array<uint64_t, NUM_CPUS>, champsim::to_underlying(access_type::NUM_TYPES)> misses = {};
 
   double avg_miss_latency = 0;
   uint64_t total_miss_latency = 0;
@@ -170,7 +170,7 @@ public:
   const bool match_offset_bits;
   const bool virtual_prefetch;
   bool ever_seen_data = false;
-  const unsigned pref_activate_mask = (1 << static_cast<int>(access_type::LOAD)) | (1 << static_cast<int>(access_type::PREFETCH));
+  const unsigned pref_activate_mask = (1 << champsim::to_underlying(access_type::LOAD)) | (1 << champsim::to_underlying(access_type::PREFETCH));
 
   using stats_type = cache_stats;
 
@@ -423,7 +423,7 @@ public:
     template <typename... Elems>
     self_type& prefetch_activate(Elems... pref_act_elems)
     {
-      m_pref_act_mask = ((1u << static_cast<unsigned>(pref_act_elems)) | ... | 0);
+      m_pref_act_mask = ((1u << champsim::to_underlying(pref_act_elems)) | ... | 0);
       return *this;
     }
     self_type& upper_levels(std::vector<CACHE::channel_type*>&& uls_)

--- a/inc/cache.h
+++ b/inc/cache.h
@@ -40,8 +40,8 @@ struct cache_stats {
   uint64_t pf_useless = 0;
   uint64_t pf_fill = 0;
 
-  std::array<std::array<uint64_t, NUM_CPUS>, NUM_TYPES> hits = {};
-  std::array<std::array<uint64_t, NUM_CPUS>, NUM_TYPES> misses = {};
+  std::array<std::array<uint64_t, NUM_CPUS>, static_cast<std::size_t>(access_type::NUM_TYPES)> hits = {};
+  std::array<std::array<uint64_t, NUM_CPUS>, static_cast<std::size_t>(access_type::NUM_TYPES)> misses = {};
 
   uint64_t total_miss_latency = 0;
 };
@@ -163,7 +163,7 @@ public:
   const bool match_offset_bits;
   const bool virtual_prefetch;
   bool ever_seen_data = false;
-  const unsigned pref_activate_mask = (1 << static_cast<int>(LOAD)) | (1 << static_cast<int>(PREFETCH));
+  const unsigned pref_activate_mask = (1 << static_cast<int>(access_type::LOAD)) | (1 << static_cast<int>(access_type::PREFETCH));
 
   using stats_type = cache_stats;
 
@@ -398,7 +398,7 @@ public:
     template <typename... Elems>
     self_type& prefetch_activate(Elems... pref_act_elems)
     {
-      m_pref_act_mask = ((1u << pref_act_elems) | ... | 0);
+      m_pref_act_mask = ((1u << static_cast<unsigned>(pref_act_elems)) | ... | 0);
       return *this;
     }
     self_type& upper_levels(std::vector<CACHE::channel_type*>&& uls_)

--- a/inc/channel.h
+++ b/inc/channel.h
@@ -17,6 +17,7 @@
 #ifndef CHANNEL_H
 #define CHANNEL_H
 
+#include <array>
 #include <cstdint>
 #include <deque>
 #include <functional>

--- a/inc/channel.h
+++ b/inc/channel.h
@@ -21,13 +21,14 @@
 #include <deque>
 #include <functional>
 #include <limits>
+#include <string_view>
 #include <vector>
 
 #include "util.h"
 
 struct ooo_model_instr;
 
-enum access_type {
+enum class access_type : unsigned {
   LOAD = 0,
   RFO,
   PREFETCH,
@@ -35,6 +36,9 @@ enum access_type {
   TRANSLATION,
   NUM_TYPES,
 };
+
+using namespace std::literals::string_view_literals;
+inline constexpr std::array<std::string_view, static_cast<std::size_t>(access_type::NUM_TYPES)> access_type_names{"LOAD"sv, "RFO"sv, "PREFETCH"sv, "WRITE"sv, "TRANSLATION"};
 
 namespace champsim
 {
@@ -63,7 +67,7 @@ class channel
     bool response_requested = true;
 
     uint8_t asid[2] = {std::numeric_limits<uint8_t>::max(), std::numeric_limits<uint8_t>::max()};
-    access_type type{LOAD};
+    access_type type{access_type::LOAD};
 
     uint32_t pf_metadata = 0;
     uint32_t cpu = std::numeric_limits<uint32_t>::max();

--- a/inc/defaults.hpp
+++ b/inc/defaults.hpp
@@ -54,7 +54,7 @@ const auto default_l1i = CACHE::Builder{}
                              .reset_prefetch_as_load()
                              .set_virtual_prefetch()
                              .set_wq_checks_full_addr()
-                             .prefetch_activate(LOAD, PREFETCH)
+                             .prefetch_activate(access_type::LOAD, access_type::PREFETCH)
                              // Specifying default prefetchers and replacement policies like this is probably dangerous
                              // since the names could change.
                              // We're doing it anyway, for now.
@@ -74,7 +74,7 @@ const auto default_l1d = CACHE::Builder{}
                              .reset_prefetch_as_load()
                              .reset_virtual_prefetch()
                              .set_wq_checks_full_addr()
-                             .prefetch_activate(LOAD, PREFETCH)
+                             .prefetch_activate(access_type::LOAD, access_type::PREFETCH)
                              .prefetcher<CACHE::pprefetcherDno>()
                              .replacement<CACHE::rreplacementDlru>();
 
@@ -91,7 +91,7 @@ const auto default_l2c = CACHE::Builder{}
                              .reset_prefetch_as_load()
                              .reset_virtual_prefetch()
                              .reset_wq_checks_full_addr()
-                             .prefetch_activate(LOAD, PREFETCH)
+                             .prefetch_activate(access_type::LOAD, access_type::PREFETCH)
                              .prefetcher<CACHE::pprefetcherDno>()
                              .replacement<CACHE::rreplacementDlru>();
 
@@ -108,7 +108,7 @@ const auto default_itlb = CACHE::Builder{}
                               .reset_prefetch_as_load()
                               .set_virtual_prefetch()
                               .set_wq_checks_full_addr()
-                              .prefetch_activate(LOAD, PREFETCH)
+                              .prefetch_activate(access_type::LOAD, access_type::PREFETCH)
                               .prefetcher<CACHE::pprefetcherDno>()
                               .replacement<CACHE::rreplacementDlru>();
 
@@ -125,7 +125,7 @@ const auto default_dtlb = CACHE::Builder{}
                               .reset_prefetch_as_load()
                               .reset_virtual_prefetch()
                               .set_wq_checks_full_addr()
-                              .prefetch_activate(LOAD, PREFETCH)
+                              .prefetch_activate(access_type::LOAD, access_type::PREFETCH)
                               .prefetcher<CACHE::pprefetcherDno>()
                               .replacement<CACHE::rreplacementDlru>();
 
@@ -142,7 +142,7 @@ const auto default_stlb = CACHE::Builder{}
                               .reset_prefetch_as_load()
                               .reset_virtual_prefetch()
                               .reset_wq_checks_full_addr()
-                              .prefetch_activate(LOAD, PREFETCH)
+                              .prefetch_activate(access_type::LOAD, access_type::PREFETCH)
                               .prefetcher<CACHE::pprefetcherDno>()
                               .replacement<CACHE::rreplacementDlru>();
 
@@ -160,7 +160,7 @@ const auto default_llc = CACHE::Builder{}
                              .reset_prefetch_as_load()
                              .reset_virtual_prefetch()
                              .reset_wq_checks_full_addr()
-                             .prefetch_activate(LOAD, PREFETCH)
+                             .prefetch_activate(access_type::LOAD, access_type::PREFETCH)
                              .prefetcher<CACHE::pprefetcherDno>()
                              .replacement<CACHE::rreplacementDlru>();
 

--- a/inc/util/bits.h
+++ b/inc/util/bits.h
@@ -23,11 +23,24 @@
 
 #include "../msl/bits.h"
 
+#include <utility>
+
 namespace champsim
 {
 using msl::bitmask;
 using msl::lg2;
 using msl::splice_bits;
+
+/*
+ * A forward-port of C++23's function of the same name.
+ * This avoids static_cast'ing an enumeration to an integer type other than its underlying type,
+ * an action that could dodge -Wconversion
+ */
+template <typename E>
+constexpr std::underlying_type_t<E> to_underlying(E e) noexcept
+{
+  return static_cast<std::underlying_type_t<E>>(e);
+}
 } // namespace champsim
 
 #endif

--- a/replacement/drrip/drrip.cc
+++ b/replacement/drrip/drrip.cc
@@ -45,7 +45,7 @@ void CACHE::update_replacement_state(uint32_t triggering_cpu, uint32_t set, uint
                                      uint8_t hit)
 {
   // do not update replacement state for writebacks
-  if (type == WRITE) {
+  if (access_type{type} == access_type::WRITE) {
     ::rrpv[this][set * NUM_WAY + way] = ::maxRRPV - 1;
     return;
   }

--- a/replacement/lru/lru.cc
+++ b/replacement/lru/lru.cc
@@ -27,7 +27,7 @@ void CACHE::update_replacement_state(uint32_t triggering_cpu, uint32_t set, uint
                                      uint8_t hit)
 {
   // Mark the way as being used on the current cycle
-  if (!hit || type != WRITE) // Skip this for writeback hits
+  if (!hit || access_type{type} != access_type::WRITE) // Skip this for writeback hits
     ::last_used_cycles[this].at(set * NUM_WAY + way) = current_cycle;
 }
 

--- a/replacement/ship/ship.cc
+++ b/replacement/ship/ship.cc
@@ -81,7 +81,7 @@ void CACHE::update_replacement_state(uint32_t triggering_cpu, uint32_t set, uint
                                      uint8_t hit)
 {
   // handle writeback access
-  if (type == WRITE) {
+  if (access_type{type} == access_type::WRITE) {
     if (!hit)
       ::rrpv_values[this][set * NUM_WAY + way] = ::maxRRPV - 1;
 

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -17,7 +17,6 @@
 #include "cache.h"
 
 #include <algorithm>
-#include <array>
 #include <cmath>
 #include <iomanip>
 

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -17,6 +17,7 @@
 #include "cache.h"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <iomanip>
 

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -288,7 +288,7 @@ auto CACHE::initiate_tag_check(champsim::channel* ul)
 
     if constexpr (champsim::debug_print) {
       fmt::print("[TAG] initiate_tag_check instr_id: {} full_addr: {:x} full_v_addr: {:x} type: {} event: {}\n", retval.instr_id, retval.address,
-                 retval.v_address, access_type_names.at(retval.type), retval.event_cycle);
+                 retval.v_address, access_type_names.at(static_cast<std::size_t>(retval.type)), retval.event_cycle);
     }
 
     return retval;
@@ -584,8 +584,8 @@ void CACHE::end_phase(unsigned finished_cpu)
   roi_stats.pf_fill = sim_stats.pf_fill;
 
   auto total_miss = 0ull;
-  for (auto type : {LOAD, RFO, PREFETCH, WRITE, TRANSLATION}) {
-    total_miss = std::accumulate(std::begin(roi_stats.hits.at(type)), std::end(roi_stats.hits.at(type)), total_miss);
+  for (auto type : {access_type::LOAD, access_type::RFO, access_type::PREFETCH, access_type::WRITE, access_type::TRANSLATION}) {
+    total_miss = std::accumulate(std::begin(roi_stats.hits.at(static_cast<std::size_t>(type))), std::end(roi_stats.hits.at(static_cast<std::size_t>(type))), total_miss);
   }
   roi_stats.avg_miss_latency = std::ceil(sim_stats.total_miss_latency) / std::ceil(total_miss);
 

--- a/src/channel.cc
+++ b/src/channel.cc
@@ -131,7 +131,7 @@ bool champsim::channel::do_add_queue(R& queue, std::size_t queue_size, const typ
 bool champsim::channel::add_rq(const request_type& packet)
 {
   if constexpr (champsim::debug_print) {
-    fmt::print("[channel_rq] {} instr_id: {} address: {:x} v_address: {:x} type: {}\n", __func__, packet.address, packet.v_address, access_type_names.at(static_cast<std::size_t>(packet.type)));
+    fmt::print("[channel_rq] {} instr_id: {} address: {:x} v_address: {:x} type: {}\n", __func__, packet.address, packet.v_address, access_type_names.at(champsim::to_underlying(packet.type)));
   }
 
   sim_stats.RQ_ACCESS++;
@@ -149,7 +149,7 @@ bool champsim::channel::add_rq(const request_type& packet)
 bool champsim::channel::add_wq(const request_type& packet)
 {
   if constexpr (champsim::debug_print) {
-    fmt::print("[channel_wq] {} instr_id: {} address: {:x} v_address: {:x} type: {}\n", __func__, packet.address, packet.v_address, access_type_names.at(static_cast<std::size_t>(packet.type)));
+    fmt::print("[channel_wq] {} instr_id: {} address: {:x} v_address: {:x} type: {}\n", __func__, packet.address, packet.v_address, access_type_names.at(champsim::to_underlying(packet.type)));
   }
 
   sim_stats.WQ_ACCESS++;
@@ -167,7 +167,7 @@ bool champsim::channel::add_wq(const request_type& packet)
 bool champsim::channel::add_pq(const request_type& packet)
 {
   if constexpr (champsim::debug_print) {
-    fmt::print("[channel_pq] {} instr_id: {} address: {:x} v_address: {:x} type: {}\n", __func__, packet.address, packet.v_address, access_type_names.at(static_cast<std::size_t>(packet.type)));
+    fmt::print("[channel_pq] {} instr_id: {} address: {:x} v_address: {:x} type: {}\n", __func__, packet.address, packet.v_address, access_type_names.at(champsim::to_underlying(packet.type)));
   }
 
   sim_stats.PQ_ACCESS++;

--- a/src/channel.cc
+++ b/src/channel.cc
@@ -133,7 +133,7 @@ bool champsim::channel::add_rq(const request_type& packet)
     std::cout << " instr_id: " << packet.instr_id;
     std::cout << " address: " << std::hex << packet.address;
     std::cout << " v_addr: " << packet.v_address << std::dec;
-    std::cout << " type: " << packet.type << std::endl;
+    std::cout << " type: " << access_type_names.at(static_cast<std::size_t>(packet.type)) << std::endl;
   }
 
   sim_stats.RQ_ACCESS++;
@@ -155,7 +155,7 @@ bool champsim::channel::add_wq(const request_type& packet)
     std::cout << " instr_id: " << packet.instr_id;
     std::cout << " address: " << std::hex << packet.address;
     std::cout << " v_addr: " << packet.v_address << std::dec;
-    std::cout << " type: " << packet.type << std::endl;
+    std::cout << " type: " << access_type_names.at(static_cast<std::size_t>(packet.type)) << std::endl;
   }
 
   sim_stats.WQ_ACCESS++;
@@ -177,7 +177,7 @@ bool champsim::channel::add_pq(const request_type& packet)
     std::cout << " instr_id: " << packet.instr_id;
     std::cout << " address: " << std::hex << packet.address;
     std::cout << " v_addr: " << packet.v_address << std::dec;
-    std::cout << " type: " << packet.type << std::endl;
+    std::cout << " type: " << access_type_names.at(static_cast<std::size_t>(packet.type)) << std::endl;
   }
 
   sim_stats.PQ_ACCESS++;

--- a/src/json_printer.cc
+++ b/src/json_printer.cc
@@ -43,11 +43,11 @@ void to_json(nlohmann::json& j, const O3_CPU::stats_type stats)
 void to_json(nlohmann::json& j, const CACHE::stats_type stats)
 {
   constexpr std::array<std::pair<std::string_view, std::size_t>, 5> types{{
-    std::pair{"LOAD", static_cast<std::size_t>(access_type::LOAD)},
-    std::pair{"RFO", static_cast<std::size_t>(access_type::RFO)},
-    std::pair{"PREFETCH", static_cast<std::size_t>(access_type::PREFETCH)},
-    std::pair{"WRITE", static_cast<std::size_t>(access_type::WRITE)},
-    std::pair{"TRANSLATION", static_cast<std::size_t>(access_type::TRANSLATION)}
+    std::pair{"LOAD", champsim::to_underlying(access_type::LOAD)},
+    std::pair{"RFO", champsim::to_underlying(access_type::RFO)},
+    std::pair{"PREFETCH", champsim::to_underlying(access_type::PREFETCH)},
+    std::pair{"WRITE", champsim::to_underlying(access_type::WRITE)},
+    std::pair{"TRANSLATION", champsim::to_underlying(access_type::TRANSLATION)}
   }};
 
   std::map<std::string, nlohmann::json> statsmap;

--- a/src/json_printer.cc
+++ b/src/json_printer.cc
@@ -54,8 +54,13 @@ void champsim::json_printer::print(O3_CPU::stats_type stats)
 
 void champsim::json_printer::print(CACHE::stats_type stats)
 {
-  constexpr std::array<std::pair<std::string_view, std::size_t>, 5> types{
-      {std::pair{"LOAD", LOAD}, std::pair{"RFO", RFO}, std::pair{"PREFETCH", PREFETCH}, std::pair{"WRITE", WRITE}, std::pair{"TRANSLATION", TRANSLATION}}};
+  constexpr std::array<std::pair<std::string_view, std::size_t>, 5> types{{
+    std::pair{"LOAD", static_cast<std::size_t>(access_type::LOAD)},
+    std::pair{"RFO", static_cast<std::size_t>(access_type::RFO)},
+    std::pair{"PREFETCH", static_cast<std::size_t>(access_type::PREFETCH)},
+    std::pair{"WRITE", static_cast<std::size_t>(access_type::WRITE)},
+    std::pair{"TRANSLATION", static_cast<std::size_t>(access_type::TRANSLATION)}
+  }};
 
   stream << indent() << "\"" << stats.name << "\": {" << std::endl;
   ++indent_level;

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -691,7 +691,7 @@ bool CacheBus::issue_read(request_type data_packet)
   data_packet.address = data_packet.v_address;
   data_packet.is_translated = false;
   data_packet.cpu = cpu;
-  data_packet.type = LOAD;
+  data_packet.type = access_type::LOAD;
 
   return lower_level->add_rq(data_packet);
 }
@@ -701,7 +701,7 @@ bool CacheBus::issue_write(request_type data_packet)
   data_packet.address = data_packet.v_address;
   data_packet.is_translated = false;
   data_packet.cpu = cpu;
-  data_packet.type = WRITE;
+  data_packet.type = access_type::WRITE;
   data_packet.response_requested = false;
 
   return lower_level->add_wq(data_packet);

--- a/src/plain_printer.cc
+++ b/src/plain_printer.cc
@@ -54,8 +54,13 @@ void champsim::plain_printer::print(O3_CPU::stats_type stats)
 
 void champsim::plain_printer::print(CACHE::stats_type stats)
 {
-  constexpr std::array<std::pair<std::string_view, std::size_t>, 5> types{
-      {std::pair{"LOAD", LOAD}, std::pair{"RFO", RFO}, std::pair{"PREFETCH", PREFETCH}, std::pair{"WRITE", WRITE}, std::pair{"TRANSLATION", TRANSLATION}}};
+  constexpr std::array<std::pair<std::string_view, std::size_t>, 5> types{{
+    std::pair{"LOAD", static_cast<std::size_t>(access_type::LOAD)},
+    std::pair{"RFO", static_cast<std::size_t>(access_type::RFO)},
+    std::pair{"PREFETCH", static_cast<std::size_t>(access_type::PREFETCH)},
+    std::pair{"WRITE", static_cast<std::size_t>(access_type::WRITE)},
+    std::pair{"TRANSLATION", static_cast<std::size_t>(access_type::TRANSLATION)}
+  }};
 
   for (std::size_t cpu = 0; cpu < NUM_CPUS; ++cpu) {
     uint64_t TOTAL_HIT = 0, TOTAL_MISS = 0;

--- a/src/plain_printer.cc
+++ b/src/plain_printer.cc
@@ -54,11 +54,11 @@ void champsim::plain_printer::print(O3_CPU::stats_type stats)
 void champsim::plain_printer::print(CACHE::stats_type stats)
 {
   constexpr std::array<std::pair<std::string_view, std::size_t>, 5> types{{
-    std::pair{"LOAD", static_cast<std::size_t>(access_type::LOAD)},
-    std::pair{"RFO", static_cast<std::size_t>(access_type::RFO)},
-    std::pair{"PREFETCH", static_cast<std::size_t>(access_type::PREFETCH)},
-    std::pair{"WRITE", static_cast<std::size_t>(access_type::WRITE)},
-    std::pair{"TRANSLATION", static_cast<std::size_t>(access_type::TRANSLATION)}
+    std::pair{"LOAD", champsim::to_underlying(access_type::LOAD)},
+    std::pair{"RFO", champsim::to_underlying(access_type::RFO)},
+    std::pair{"PREFETCH", champsim::to_underlying(access_type::PREFETCH)},
+    std::pair{"WRITE", champsim::to_underlying(access_type::WRITE)},
+    std::pair{"TRANSLATION", champsim::to_underlying(access_type::TRANSLATION)}
   }};
 
   for (std::size_t cpu = 0; cpu < NUM_CPUS; ++cpu) {

--- a/src/ptw.cc
+++ b/src/ptw.cc
@@ -104,7 +104,7 @@ auto PageTableWalker::step_translation(const mshr_type& source) -> std::optional
   packet.asid[0] = source.asid[0];
   packet.asid[1] = source.asid[1];
   packet.is_translated = true;
-  packet.type = TRANSLATION;
+  packet.type = access_type::TRANSLATION;
 
   bool success = lower_level->add_rq(packet);
 

--- a/test/cpp/modules/replacement/lru_collect/lru.cc
+++ b/test/cpp/modules/replacement/lru_collect/lru.cc
@@ -32,10 +32,10 @@ void CACHE::update_replacement_state(uint32_t triggering_cpu, uint32_t set, uint
                                      uint8_t hit)
 {
   auto usc_it = test::replacement_update_state_collector.try_emplace(this);
-  usc_it.first->second.push_back({cpu, set, way, full_addr, ip, victim_addr, type, hit});
+  usc_it.first->second.push_back({cpu, set, way, full_addr, ip, victim_addr, access_type{type}, hit});
 
   // Mark the way as being used on the current cycle
-  if (!hit || type != WRITE) { // Skip this for writeback hits
+  if (!hit || access_type{type} != access_type::WRITE) { // Skip this for writeback hits
     auto luc_it = ::last_used_cycles.try_emplace(this, NUM_SET * NUM_WAY);
     luc_it.first->second.at(set * NUM_WAY + way) = current_cycle;
   }

--- a/test/cpp/src/401-hit-latency.cc
+++ b/test/cpp/src/401-hit-latency.cc
@@ -7,11 +7,11 @@
 SCENARIO("A cache returns a hit after the specified latency") {
   using namespace std::literals;
   auto [type, str] = GENERATE(table<access_type, std::string_view>({
-        std::pair{LOAD, "load"sv},
-        std::pair{RFO, "RFO"sv},
-        std::pair{PREFETCH, "prefetch"sv},
-        std::pair{WRITE, "write"sv},
-        std::pair{TRANSLATION, "translation"sv}
+        std::pair{access_type::LOAD, "load"sv},
+        std::pair{access_type::RFO, "RFO"sv},
+        std::pair{access_type::PREFETCH, "prefetch"sv},
+        std::pair{access_type::WRITE, "write"sv},
+        std::pair{access_type::TRANSLATION, "translation"sv}
       }));
 
   GIVEN("An empty cache") {
@@ -23,7 +23,7 @@ SCENARIO("A cache returns a hit after the specified latency") {
       .upper_levels({&mock_ul.queues})
       .lower_level(&mock_ll.queues)
       .hit_latency(hit_latency)
-      .prefetch_activate(LOAD, RFO, PREFETCH, WRITE, TRANSLATION)
+      .prefetch_activate(access_type::LOAD, access_type::RFO, access_type::PREFETCH, access_type::WRITE, access_type::TRANSLATION)
     };
 
     std::array<champsim::operable*, 3> elements{{&uut, &mock_ll, &mock_ul}};
@@ -36,7 +36,7 @@ SCENARIO("A cache returns a hit after the specified latency") {
     }
 
     THEN("The number of hits starts at zero") {
-      REQUIRE(uut.sim_stats.hits.at(type).at(0) == 0);
+      REQUIRE(uut.sim_stats.hits.at(static_cast<std::size_t>(type)).at(0) == 0);
     }
 
     WHEN("A " + std::string{str} + " packet is issued") {
@@ -79,7 +79,7 @@ SCENARIO("A cache returns a hit after the specified latency") {
         }
 
         THEN("The number of hits increases") {
-          REQUIRE(uut.sim_stats.hits.at(type).at(0) == 1);
+          REQUIRE(uut.sim_stats.hits.at(static_cast<std::size_t>(type)).at(0) == 1);
         }
       }
     }

--- a/test/cpp/src/401-hit-latency.cc
+++ b/test/cpp/src/401-hit-latency.cc
@@ -36,7 +36,7 @@ SCENARIO("A cache returns a hit after the specified latency") {
     }
 
     THEN("The number of hits starts at zero") {
-      REQUIRE(uut.sim_stats.hits.at(static_cast<std::size_t>(type)).at(0) == 0);
+      REQUIRE(uut.sim_stats.hits.at(champsim::to_underlying(type)).at(0) == 0);
     }
 
     WHEN("A " + std::string{str} + " packet is issued") {
@@ -79,7 +79,7 @@ SCENARIO("A cache returns a hit after the specified latency") {
         }
 
         THEN("The number of hits increases") {
-          REQUIRE(uut.sim_stats.hits.at(static_cast<std::size_t>(type)).at(0) == 1);
+          REQUIRE(uut.sim_stats.hits.at(champsim::to_underlying(type)).at(0) == 1);
         }
       }
     }

--- a/test/cpp/src/402-miss-latency.cc
+++ b/test/cpp/src/402-miss-latency.cc
@@ -7,10 +7,10 @@
 SCENARIO("A cache returns a miss after the specified latency") {
   using namespace std::literals;
   auto [type, str] = GENERATE(table<access_type, std::string_view>({
-        std::pair{LOAD, "load"sv},
-        std::pair{RFO, "RFO"sv},
-        std::pair{PREFETCH, "prefetch"sv},
-        std::pair{TRANSLATION, "translation"sv}
+        std::pair{access_type::LOAD, "load"sv},
+        std::pair{access_type::RFO, "RFO"sv},
+        std::pair{access_type::PREFETCH, "prefetch"sv},
+        std::pair{access_type::TRANSLATION, "translation"sv}
       }));
 
   GIVEN("An empty cache") {
@@ -25,7 +25,7 @@ SCENARIO("A cache returns a miss after the specified latency") {
       .lower_level(&mock_ll.queues)
       .hit_latency(hit_latency)
       .fill_latency(fill_latency)
-      .prefetch_activate(LOAD, RFO, PREFETCH, WRITE, TRANSLATION)
+      .prefetch_activate(access_type::LOAD, access_type::RFO, access_type::PREFETCH, access_type::WRITE, access_type::TRANSLATION)
     };
 
     std::array<champsim::operable*, 3> elements{{&uut, &mock_ll, &mock_ul}};
@@ -37,7 +37,7 @@ SCENARIO("A cache returns a miss after the specified latency") {
     }
 
     THEN("The number of misses starts at zero") {
-      REQUIRE(uut.sim_stats.misses.at(type).at(0) == 0);
+      REQUIRE(uut.sim_stats.misses.at(static_cast<std::size_t>(type)).at(0) == 0);
     }
 
     WHEN("A " + std::string{str} + " packet is issued") {
@@ -65,7 +65,7 @@ SCENARIO("A cache returns a miss after the specified latency") {
       }
 
       THEN("The number of misses increases") {
-        REQUIRE(uut.sim_stats.misses.at(type).at(0) == 1);
+        REQUIRE(uut.sim_stats.misses.at(static_cast<std::size_t>(type)).at(0) == 1);
       }
 
       THEN("The average miss latency increases") {
@@ -77,7 +77,7 @@ SCENARIO("A cache returns a miss after the specified latency") {
 
 SCENARIO("A cache completes a fill after the specified latency") {
   using namespace std::literals;
-  auto [type, str] = std::pair{WRITE, "write"sv};
+  auto [type, str] = std::pair{access_type::WRITE, "write"sv};
   auto match_offset = GENERATE(true, false);
 
   GIVEN("An empty cache") {
@@ -92,7 +92,7 @@ SCENARIO("A cache completes a fill after the specified latency") {
       .lower_level(&mock_ll.queues)
       .hit_latency(hit_latency)
       .fill_latency(fill_latency)
-      .prefetch_activate(LOAD, RFO, PREFETCH, WRITE, TRANSLATION);
+      .prefetch_activate(access_type::LOAD, access_type::RFO, access_type::PREFETCH, access_type::WRITE, access_type::TRANSLATION);
 
     if (match_offset)
       builder = builder.set_wq_checks_full_addr();
@@ -110,7 +110,7 @@ SCENARIO("A cache completes a fill after the specified latency") {
     }
 
     THEN("The number of misses starts at zero") {
-      REQUIRE(uut.sim_stats.misses.at(type).at(0) == 0);
+      REQUIRE(uut.sim_stats.misses.at(static_cast<std::size_t>(type)).at(0) == 0);
     }
 
     WHEN("A " + std::string{str} + " packet is issued") {
@@ -141,7 +141,7 @@ SCENARIO("A cache completes a fill after the specified latency") {
       }
 
       THEN("The number of misses increases") {
-        REQUIRE(uut.sim_stats.misses.at(type).at(0) == 1);
+        REQUIRE(uut.sim_stats.misses.at(static_cast<std::size_t>(type)).at(0) == 1);
       }
 
       THEN("The average miss latency increases") {

--- a/test/cpp/src/402-miss-latency.cc
+++ b/test/cpp/src/402-miss-latency.cc
@@ -37,7 +37,7 @@ SCENARIO("A cache returns a miss after the specified latency") {
     }
 
     THEN("The number of misses starts at zero") {
-      REQUIRE(uut.sim_stats.misses.at(static_cast<std::size_t>(type)).at(0) == 0);
+      REQUIRE(uut.sim_stats.misses.at(champsim::to_underlying(type)).at(0) == 0);
     }
 
     THEN("The MSHR occupancy starts at zero") {
@@ -81,7 +81,7 @@ SCENARIO("A cache returns a miss after the specified latency") {
       }
 
       THEN("The number of misses increases") {
-        REQUIRE(uut.sim_stats.misses.at(static_cast<std::size_t>(type)).at(0) == 1);
+        REQUIRE(uut.sim_stats.misses.at(champsim::to_underlying(type)).at(0) == 1);
       }
 
       THEN("The average miss latency increases") {
@@ -126,7 +126,7 @@ SCENARIO("A cache completes a fill after the specified latency") {
     }
 
     THEN("The number of misses starts at zero") {
-      REQUIRE(uut.sim_stats.misses.at(static_cast<std::size_t>(type)).at(0) == 0);
+      REQUIRE(uut.sim_stats.misses.at(champsim::to_underlying(type)).at(0) == 0);
     }
 
     WHEN("A " + std::string{str} + " packet is issued") {
@@ -157,7 +157,7 @@ SCENARIO("A cache completes a fill after the specified latency") {
       }
 
       THEN("The number of misses increases") {
-        REQUIRE(uut.sim_stats.misses.at(static_cast<std::size_t>(type)).at(0) == 1);
+        REQUIRE(uut.sim_stats.misses.at(champsim::to_underlying(type)).at(0) == 1);
       }
 
       THEN("The average miss latency increases") {

--- a/test/cpp/src/404-fill-bandwidth.cc
+++ b/test/cpp/src/404-fill-bandwidth.cc
@@ -111,7 +111,7 @@ SCENARIO("Writebacks respect the fill bandwidth") {
       decltype(mock_ul)::request_type seed;
       seed.address = seed_base_addr + i*BLOCK_SIZE;
       seed.instr_id = i;
-      seed.type = WRITE;
+      seed.type = access_type::WRITE;
       seed.cpu = 0;
 
       seeds.push_back(seed);

--- a/test/cpp/src/405-fill-eviction.cc
+++ b/test/cpp/src/405-fill-eviction.cc
@@ -39,7 +39,7 @@ SCENARIO("A cache evicts a block when required") {
       decltype(mock_ul_seed)::request_type test_a;
       test_a.address = 0xdeadbeef;
       test_a.cpu = 0;
-      test_a.type = WRITE;
+      test_a.type = access_type::WRITE;
       test_a.instr_id = id++;
 
       auto test_a_result = mock_ul_seed.issue(test_a);
@@ -57,7 +57,7 @@ SCENARIO("A cache evicts a block when required") {
         decltype(mock_ul_test)::request_type test_b;
         test_b.address = 0xcafebabe;
         test_b.cpu = 0;
-        test_b.type = LOAD;
+        test_b.type = access_type::LOAD;
         test_b.instr_id = id++;
 
         auto test_b_result = mock_ul_test.issue(test_b);

--- a/test/cpp/src/406-mshr-merge.cc
+++ b/test/cpp/src/406-mshr-merge.cc
@@ -45,7 +45,7 @@ SCENARIO("A cache merges two requests in the MSHR") {
       decltype(mock_ul_seed)::request_type test_a;
       test_a.address = 0xdeadbeef;
       test_a.cpu = 0;
-      test_a.type = LOAD;
+      test_a.type = access_type::LOAD;
       test_a.instr_id = id++;
 
       auto test_a_result = mock_ul_seed.issue(test_a);

--- a/test/cpp/src/423-prefetcher-activate.cc
+++ b/test/cpp/src/423-prefetcher-activate.cc
@@ -54,7 +54,7 @@ SCENARIO("A prefetch does not trigger itself") {
 
 SCENARIO("The prefetcher is triggered if the packet matches the activate field") {
   using namespace std::literals;
-  auto [type, str] = GENERATE(table<access_type, std::string_view>({std::pair{LOAD, "load"sv}, std::pair{RFO, "RFO"sv}, std::pair{PREFETCH, "prefetch"sv}, std::pair{WRITE, "write"sv}, std::pair{TRANSLATION, "translation"sv}}));
+  auto [type, str] = GENERATE(table<access_type, std::string_view>({std::pair{access_type::LOAD, "load"sv}, std::pair{access_type::RFO, "RFO"sv}, std::pair{access_type::PREFETCH, "prefetch"sv}, std::pair{access_type::WRITE, "write"sv}, std::pair{access_type::TRANSLATION, "translation"sv}}));
   GIVEN("A single cache") {
     do_nothing_MRC mock_ll;
     to_rq_MRP mock_ul;
@@ -106,11 +106,11 @@ SCENARIO("The prefetcher is triggered if the packet matches the activate field")
 SCENARIO("The prefetcher is not triggered if the packet does not match the activate field") {
   using namespace std::literals;
   auto [type, mask, str] = GENERATE(table< access_type, std::array<access_type, 4>, std::string_view >({
-        std::tuple{LOAD, std::array{RFO, PREFETCH, WRITE, TRANSLATION}, "load"sv},
-        std::tuple{RFO, std::array{LOAD, PREFETCH, WRITE, TRANSLATION}, "RFO"sv},
-        std::tuple{PREFETCH, std::array{LOAD, RFO, WRITE, TRANSLATION}, "prefetch"sv},
-        std::tuple{WRITE, std::array{LOAD, RFO, PREFETCH, TRANSLATION}, "write"sv},
-        std::tuple{TRANSLATION, std::array{LOAD, RFO, PREFETCH, WRITE}, "translation"sv}
+        std::tuple{access_type::LOAD, std::array{access_type::RFO, access_type::PREFETCH, access_type::WRITE, access_type::TRANSLATION}, "load"sv},
+        std::tuple{access_type::RFO, std::array{access_type::LOAD, access_type::PREFETCH, access_type::WRITE, access_type::TRANSLATION}, "RFO"sv},
+        std::tuple{access_type::PREFETCH, std::array{access_type::LOAD, access_type::RFO, access_type::WRITE, access_type::TRANSLATION}, "prefetch"sv},
+        std::tuple{access_type::WRITE, std::array{access_type::LOAD, access_type::RFO, access_type::PREFETCH, access_type::TRANSLATION}, "write"sv},
+        std::tuple{access_type::TRANSLATION, std::array{access_type::LOAD, access_type::RFO, access_type::PREFETCH, access_type::WRITE}, "translation"sv}
       }));
 
   GIVEN("A single cache") {

--- a/test/cpp/src/425-useless-prefetch.cc
+++ b/test/cpp/src/425-useless-prefetch.cc
@@ -53,7 +53,7 @@ SCENARIO("A cache increments the useless prefetch count when it evicts an unhit 
         decltype(mock_ul_test)::request_type test_b;
         test_b.address = 0xcafebabe;
         test_b.cpu = 0;
-        test_b.type = LOAD;
+        test_b.type = access_type::LOAD;
         test_b.instr_id = 1;
 
         auto test_b_result = mock_ul_test.issue(test_b);

--- a/test/cpp/src/431-merge-prefetch.cc
+++ b/test/cpp/src/431-merge-prefetch.cc
@@ -58,7 +58,7 @@ struct merge_testbed
 
 SCENARIO("A prefetch that hits an MSHR is dropped") {
   using namespace std::literals;
-  auto [type, str] = GENERATE(table<access_type, std::string_view>({std::pair{LOAD, "load"sv}, std::pair{RFO, "RFO"sv}, std::pair{WRITE, "write"sv}, std::pair{TRANSLATION, "translation"sv}}));
+  auto [type, str] = GENERATE(table<access_type, std::string_view>({std::pair{access_type::LOAD, "load"sv}, std::pair{access_type::RFO, "RFO"sv}, std::pair{access_type::WRITE, "write"sv}, std::pair{access_type::TRANSLATION, "translation"sv}}));
   GIVEN("A cache with a " + std::string{str} + " miss") {
     merge_testbed testbed{type};
 
@@ -69,7 +69,7 @@ SCENARIO("A prefetch that hits an MSHR is dropped") {
     }
 
     WHEN("A prefetch is issued") {
-      testbed.issue_type(PREFETCH);
+      testbed.issue_type(access_type::PREFETCH);
 
       THEN("The " + std::string{str} + " is in the MSHR") {
         REQUIRE(std::size(testbed.uut.MSHR) == 1);
@@ -82,9 +82,9 @@ SCENARIO("A prefetch that hits an MSHR is dropped") {
 
 SCENARIO("A prefetch MSHR that gets hit is promoted") {
   using namespace std::literals;
-  auto [type, str] = GENERATE(table<access_type, std::string_view>({std::pair{LOAD, "load"sv}, std::pair{RFO, "RFO"sv}, std::pair{WRITE, "write"sv}, std::pair{TRANSLATION, "translation"sv}}));
+  auto [type, str] = GENERATE(table<access_type, std::string_view>({std::pair{access_type::LOAD, "load"sv}, std::pair{access_type::RFO, "RFO"sv}, std::pair{access_type::WRITE, "write"sv}, std::pair{access_type::TRANSLATION, "translation"sv}}));
   GIVEN("A cache with a prefetch miss") {
-    merge_testbed testbed{PREFETCH};
+    merge_testbed testbed{access_type::PREFETCH};
 
     THEN("An MSHR is created") {
       REQUIRE(std::size(testbed.uut.MSHR) == 1);

--- a/test/cpp/src/441-replacement-bypass.cc
+++ b/test/cpp/src/441-replacement-bypass.cc
@@ -43,7 +43,7 @@ SCENARIO("The replacement policy can bypass") {
       decltype(mock_ul_seed)::request_type test;
       test.address = 0xdeadbeef;
       test.cpu = 0;
-      test.type = WRITE;
+      test.type = access_type::WRITE;
       auto test_result = mock_ul_seed.issue(test);
 
       THEN("The issue is received") {
@@ -61,7 +61,7 @@ SCENARIO("The replacement policy can bypass") {
         decltype(mock_ul_test)::request_type test_b;
         test_b.address = 0xcafebabe;
         test_b.cpu = 0;
-        test_b.type = LOAD;
+        test_b.type = access_type::LOAD;
         test_b.instr_id = 1;
 
         auto test_b_result = mock_ul_test.issue(test_b);

--- a/test/cpp/src/442-replacement-interface.cc
+++ b/test/cpp/src/442-replacement-interface.cc
@@ -15,7 +15,7 @@ namespace test
 
 SCENARIO("The replacement policy is not triggered on a miss, but on a fill") {
   using namespace std::literals;
-  auto [type, str] = GENERATE(table<access_type, std::string_view>({std::pair{LOAD, "load"sv}, std::pair{RFO, "RFO"sv}, std::pair{PREFETCH, "prefetch"sv}, std::pair{WRITE, "write"sv}, std::pair{TRANSLATION, "translation"sv}}));
+  auto [type, str] = GENERATE(table<access_type, std::string_view>({std::pair{access_type::LOAD, "load"sv}, std::pair{access_type::RFO, "RFO"sv}, std::pair{access_type::PREFETCH, "prefetch"sv}, std::pair{access_type::WRITE, "write"sv}, std::pair{access_type::TRANSLATION, "translation"sv}}));
   GIVEN("A single cache") {
     constexpr uint64_t hit_latency = 2;
     constexpr uint64_t fill_latency = 2;
@@ -29,7 +29,7 @@ SCENARIO("The replacement policy is not triggered on a miss, but on a fill") {
       .lower_level(&mock_ll.queues)
       .hit_latency(hit_latency)
       .fill_latency(fill_latency)
-      .prefetch_activate(1u<<type)
+      .prefetch_activate(type)
       .offset_bits(0)
       .replacement<CACHE::rtestDcppDmodulesDreplacementDlru_collect>()
     };
@@ -92,7 +92,7 @@ SCENARIO("The replacement policy is not triggered on a miss, but on a fill") {
 
 SCENARIO("The replacement policy is triggered on a hit") {
   using namespace std::literals;
-  auto [type, str] = GENERATE(table<access_type, std::string_view>({std::pair{LOAD, "load"sv}, std::pair{RFO, "RFO"sv}, std::pair{PREFETCH, "prefetch"sv}, std::pair{WRITE, "write"sv}, std::pair{TRANSLATION, "translation"sv}}));
+  auto [type, str] = GENERATE(table<access_type, std::string_view>({std::pair{access_type::LOAD, "load"sv}, std::pair{access_type::RFO, "RFO"sv}, std::pair{access_type::PREFETCH, "prefetch"sv}, std::pair{access_type::WRITE, "write"sv}, std::pair{access_type::TRANSLATION, "translation"sv}}));
   GIVEN("A cache with one element") {
     constexpr uint64_t hit_latency = 2;
     constexpr uint64_t fill_latency = 2;
@@ -106,7 +106,7 @@ SCENARIO("The replacement policy is triggered on a hit") {
       .lower_level(&mock_ll.queues)
       .hit_latency(hit_latency)
       .fill_latency(fill_latency)
-      .prefetch_activate(1u<<type)
+      .prefetch_activate(type)
       .offset_bits(0)
       .replacement<CACHE::rtestDcppDmodulesDreplacementDlru_collect>()
     };
@@ -178,7 +178,7 @@ SCENARIO("The replacement policy notes the correct eviction information") {
       .lower_level(&mock_ll.queues)
       .hit_latency(hit_latency)
       .fill_latency(fill_latency)
-      .prefetch_activate(1u<<LOAD)
+      .prefetch_activate(access_type::LOAD)
       .offset_bits(0)
       .replacement<CACHE::rtestDcppDmodulesDreplacementDlru_collect>()
     };
@@ -198,7 +198,7 @@ SCENARIO("The replacement policy notes the correct eviction information") {
       seed.v_address = 0xdeadbeef;
       seed.cpu = 0;
       seed.instr_id = id++;
-      seed.type = WRITE;
+      seed.type = access_type::WRITE;
       auto seed_result = mock_ul_seed.issue(seed);
 
       THEN("The issue is received") {
@@ -215,7 +215,7 @@ SCENARIO("The replacement policy notes the correct eviction information") {
         decltype(mock_ul_test)::request_type test = seed;
         test.address = 0xcafebabe;
         test.instr_id = id++;
-        test.type = LOAD;
+        test.type = access_type::LOAD;
         auto test_result = mock_ul_test.issue(test);
 
         // Process the miss
@@ -244,7 +244,7 @@ SCENARIO("The replacement policy notes the correct eviction information") {
           CHECK(test::replacement_update_state_collector[&uut].back().set == 0);
           CHECK(test::replacement_update_state_collector[&uut].back().way == 0);
           CHECK(test::replacement_update_state_collector[&uut].back().full_addr == test.address);
-          CHECK(test::replacement_update_state_collector[&uut].back().type == LOAD);
+          CHECK(test::replacement_update_state_collector[&uut].back().type == access_type::LOAD);
           CHECK(test::replacement_update_state_collector[&uut].back().victim_addr == seed.address);
           CHECK(test::replacement_update_state_collector[&uut].back().hit == false);
         }

--- a/test/cpp/src/repl_interface.h
+++ b/test/cpp/src/repl_interface.h
@@ -1,6 +1,8 @@
 #ifndef TEST_REPL_INTERFACE_H
 #define TEST_REPL_INTERFACE_H
 
+#include "channel.h"
+
 namespace test
 {
   struct repl_update_interface
@@ -11,7 +13,7 @@ namespace test
     uint64_t full_addr;
     uint64_t ip;
     uint64_t victim_addr;
-    uint32_t type;
+    access_type type;
     uint8_t hit;
   };
 }

--- a/test/python/test_parse.py
+++ b/test/python/test_parse.py
@@ -59,6 +59,23 @@ class DuplicateToLengthTests(unittest.TestCase):
         c = { 'name': 'c' }
         self.assertEqual(config.parse.duplicate_to_length([a,b,c], 2), [a,b])
 
+class SplitStringOrListTests(unittest.TestCase):
+
+    def test_empty_string(self):
+        self.assertEqual(config.parse.split_string_or_list(''), [])
+
+    def test_empty_list(self):
+        self.assertEqual(config.parse.split_string_or_list([]), [])
+
+    def test_list_passthrough(self):
+        self.assertEqual(config.parse.split_string_or_list(['a','b']), ['a','b'])
+
+    def test_string_split(self):
+        self.assertEqual(config.parse.split_string_or_list('a,b'), ['a','b'])
+
+    def test_string_strip(self):
+        self.assertEqual(config.parse.split_string_or_list('a, b'), ['a','b'])
+
 class FilterInaccessibleTests(unittest.TestCase):
 
     def test_empty_system(self):


### PR DESCRIPTION
Resolves #338.

This patch makes the `access_type` enum a strong type. This will break some user code that respects the types passed to prefetcher and replacement hooks, but it means that illegal values passed to `"prefetch_activate"` in the configuration file result in a compile error, rather than failing silently.