### PR TITLE
Stop simulation if the end of the trace is reached

### DIFF
--- a/inc/repeatable.h
+++ b/inc/repeatable.h
@@ -29,6 +29,8 @@ struct repeatable {
 
     return intern_();
   }
+
+  bool eof() const { return false; }
 };
 } // namespace champsim
 

--- a/inc/tracereader.h
+++ b/inc/tracereader.h
@@ -24,6 +24,7 @@
 #include <string>
 
 #include "instruction.h"
+#include "util/detect.h"
 
 namespace champsim
 {
@@ -33,6 +34,7 @@ class tracereader
   struct reader_concept {
     virtual ~reader_concept() = default;
     virtual ooo_model_instr operator()() = 0;
+    virtual bool eof() const = 0;
   };
 
   template <typename T>
@@ -40,7 +42,15 @@ class tracereader
     T intern_;
     reader_model(T&& val) : intern_(std::move(val)) {}
 
+    template <typename U>
+    using has_eof = decltype(std::declval<U>().eof());
+
     ooo_model_instr operator()() override { return intern_(); }
+    bool eof() const override {
+      if constexpr (champsim::is_detected_v<has_eof, T>)
+        return intern_.eof();
+      return false; // If an eof() member function is not provided, assume the trace never ends.
+    }
   };
 
   std::unique_ptr<reader_concept> pimpl_;
@@ -57,6 +67,8 @@ public:
     retval.instr_id = instr_unique_id++;
     return retval;
   }
+
+  auto eof() const { return pimpl_->eof(); }
 };
 
 template <typename T, typename F>
@@ -125,6 +137,6 @@ ooo_model_instr bulk_tracereader<T, F>::operator()()
 std::string get_fptr_cmd(std::string_view fname);
 } // namespace champsim
 
-champsim::tracereader get_tracereader(std::string fname, uint8_t cpu, bool is_cloudsuite);
+champsim::tracereader get_tracereader(std::string fname, uint8_t cpu, bool is_cloudsuite, bool repeat);
 
 #endif

--- a/inc/util/detect.h
+++ b/inc/util/detect.h
@@ -1,0 +1,77 @@
+/*
+ *    Copyright 2023 The ChampSim Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef UTIL_DETECT_H
+#define UTIL_DETECT_H
+
+/*
+ * This is a port of <experimental/type_traits> detection idiom
+ *
+ * The port is used here so as not to depend on the presence of the experimental header
+ */
+
+#include <type_traits>
+
+namespace champsim {
+namespace detail {
+template <class Default, class AlwaysVoid, template<class...> class Op, class... Args>
+struct detector {
+  using value_t = std::false_type;
+  using type = Default;
+};
+
+template <class Default, template<class...> class Op, class... Args>
+struct detector<Default, std::void_t<Op<Args...>>, Op, Args...> {
+  using value_t = std::true_type;
+  using type = Op<Args...>;
+};
+
+} // namespace detail
+
+struct nonesuch {
+    ~nonesuch() = delete;
+    nonesuch(nonesuch const&) = delete;
+    void operator=(nonesuch const&) = delete;
+};
+
+template <template<class...> class Op, class... Args>
+using is_detected = typename detail::detector<nonesuch, void, Op, Args...>::value_t;
+
+template <template<class...> class Op, class... Args>
+using detected_t = typename detail::detector<nonesuch, void, Op, Args...>::type;
+
+template <class Default, template<class...> class Op, class... Args>
+using detected_or = detail::detector<Default, void, Op, Args...>;
+
+template< template<class...> class Op, class... Args >
+constexpr inline bool is_detected_v = is_detected<Op, Args...>::value;
+
+template< class Default, template<class...> class Op, class... Args >
+using detected_or_t = typename detected_or<Default, Op, Args...>::type;
+
+template <class Expected, template<class...> class Op, class... Args>
+using is_detected_exact = std::is_same<Expected, detected_t<Op, Args...>>;
+
+template <class Expected, template<class...> class Op, class... Args>
+constexpr inline bool is_detected_exact_v = is_detected_exact<Expected, Op, Args...>::value;
+
+template <class To, template<class...> class Op, class... Args>
+using is_detected_convertible = std::is_convertible<detected_t<Op, Args...>, To>;
+
+template <class To, template<class...> class Op, class... Args>
+constexpr inline bool is_detected_convertible_v = is_detected_convertible<To, Op, Args...>::value;
+}
+#endif

--- a/src/champsim.cc
+++ b/src/champsim.cc
@@ -54,6 +54,8 @@ phase_stats do_phase(phase_info phase, environment& env, std::vector<tracereader
   // Perform phase
   std::vector<bool> phase_complete(std::size(env.cpu_view()), false);
   while (!std::accumulate(std::begin(phase_complete), std::end(phase_complete), true, std::logical_and{})) {
+    auto next_phase_complete = phase_complete;
+
     // Operate
     for (champsim::operable& op : operables) {
       try {
@@ -74,16 +76,25 @@ phase_stats do_phase(phase_info phase, environment& env, std::vector<tracereader
               [](const champsim::operable& lhs, const champsim::operable& rhs) { return lhs.leap_operation < rhs.leap_operation; });
 
     // Read from trace
-    for (O3_CPU& cpu : env.cpu_view())
-      std::generate_n(std::back_inserter(cpu.input_queue), cpu.IN_QUEUE_SIZE - static_cast<long>(std::size(cpu.input_queue)),
-                      std::ref(traces.at(trace_index.at(cpu.cpu))));
+    for (O3_CPU& cpu : env.cpu_view()) {
+      auto& trace = traces.at(trace_index.at(cpu.cpu));
+      for (auto pkt_count = cpu.IN_QUEUE_SIZE - static_cast<long>(std::size(cpu.input_queue)); !trace.eof() && pkt_count > 0; --pkt_count)
+        cpu.input_queue.push_back(trace());
+
+      // If any trace reaches EOF, terminate all phases
+      if (trace.eof())
+        std::fill(std::begin(next_phase_complete), std::end(next_phase_complete), true);
+    }
 
     // Check for phase finish
-    auto [elapsed_hour, elapsed_minute, elapsed_second] = elapsed_time();
     for (O3_CPU& cpu : env.cpu_view()) {
       // Phase complete
-      if (!phase_complete[cpu.cpu] && (cpu.sim_instr() >= length)) {
-        phase_complete[cpu.cpu] = true;
+      next_phase_complete[cpu.cpu] = next_phase_complete[cpu.cpu] || (cpu.sim_instr() >= length);
+    }
+
+    auto [elapsed_hour, elapsed_minute, elapsed_second] = elapsed_time();
+    for (O3_CPU& cpu : env.cpu_view()) {
+      if (next_phase_complete[cpu.cpu] != phase_complete[cpu.cpu]) {
         for (champsim::operable& op : operables)
           op.end_phase(cpu.cpu);
 
@@ -93,6 +104,8 @@ phase_stats do_phase(phase_info phase, environment& env, std::vector<tracereader
         std::cout << " (Simulation time: " << elapsed_hour << " hr " << elapsed_minute << " min " << elapsed_second << " sec) " << std::endl;
       }
     }
+
+    phase_complete = next_phase_complete;
   }
 
   auto [elapsed_hour, elapsed_minute, elapsed_second] = elapsed_time();

--- a/src/main.cc
+++ b/src/main.cc
@@ -42,7 +42,7 @@ int main(int argc, char** argv)
 
   // initialize knobs
   uint8_t knob_cloudsuite = 0;
-  uint64_t warmup_instructions = 1000000, simulation_instructions = 10000000;
+  uint64_t warmup_instructions = 0, simulation_instructions = std::numeric_limits<uint64_t>::max();
   bool knob_json_out = false;
   std::ofstream json_file;
 
@@ -87,7 +87,7 @@ int main(int argc, char** argv)
 
   std::vector<champsim::tracereader> traces;
   std::transform(std::begin(trace_names), std::end(trace_names), std::back_inserter(traces),
-                 [knob_cloudsuite, i = uint8_t(0)](auto name) mutable { return get_tracereader(name, i++, knob_cloudsuite); });
+                 [knob_cloudsuite, repeat = (simulation_instructions != std::numeric_limits<uint64_t>::max()), i = uint8_t(0)](auto name) mutable { return get_tracereader(name, i++, knob_cloudsuite, repeat); });
 
   std::vector<champsim::phase_info> phases{
       {champsim::phase_info{"Warmup", true, warmup_instructions, std::vector<std::size_t>(std::size(trace_names), 0), trace_names},

--- a/src/tracereader.cc
+++ b/src/tracereader.cc
@@ -32,10 +32,7 @@ ooo_model_instr apply_branch_target(ooo_model_instr branch, const ooo_model_inst
   return branch;
 }
 
-template <typename T, typename S>
-using reader_t = champsim::repeatable<champsim::bulk_tracereader<T, S>, uint8_t, std::string>;
-
-template <typename T>
+template <template<class, class> typename R, typename T>
 champsim::tracereader get_tracereader_for_type(std::string fname, uint8_t cpu)
 {
   bool is_gzip_compressed = (fname.substr(std::size(fname) - 2) == "gz");
@@ -43,20 +40,30 @@ champsim::tracereader get_tracereader_for_type(std::string fname, uint8_t cpu)
   bool is_bzip2_compressed = (fname.substr(std::size(fname) - 3) == "bz2");
 
   if (is_gzip_compressed)
-    return champsim::tracereader{reader_t<T, champsim::inf_istream<champsim::decomp_tags::gzip_tag_t<>>>(cpu, fname)};
+    return champsim::tracereader{R<T, champsim::inf_istream<champsim::decomp_tags::gzip_tag_t<>>>(cpu, fname)};
   else if (is_lzma_compressed)
-    return champsim::tracereader{reader_t<T, champsim::inf_istream<champsim::decomp_tags::lzma_tag_t<>>>(cpu, fname)};
+    return champsim::tracereader{R<T, champsim::inf_istream<champsim::decomp_tags::lzma_tag_t<>>>(cpu, fname)};
   else if (is_bzip2_compressed)
-    return champsim::tracereader{reader_t<T, champsim::inf_istream<champsim::decomp_tags::bzip2_tag_t>>(cpu, fname)};
+    return champsim::tracereader{R<T, champsim::inf_istream<champsim::decomp_tags::bzip2_tag_t>>(cpu, fname)};
   else
-    return champsim::tracereader{reader_t<T, std::ifstream>(cpu, fname)};
+    return champsim::tracereader{R<T, std::ifstream>(cpu, fname)};
 }
 } // namespace champsim
 
-champsim::tracereader get_tracereader(std::string fname, uint8_t cpu, bool is_cloudsuite)
+template <typename T, typename S>
+using repeatable_reader_t = champsim::repeatable<champsim::bulk_tracereader<T, S>, uint8_t, std::string>;
+
+champsim::tracereader get_tracereader(std::string fname, uint8_t cpu, bool is_cloudsuite, bool repeat)
 {
-  if (is_cloudsuite)
-    return champsim::get_tracereader_for_type<cloudsuite_instr>(fname, cpu);
-  else
-    return champsim::get_tracereader_for_type<input_instr>(fname, cpu);
+  if (is_cloudsuite) {
+    if (repeat)
+      return champsim::get_tracereader_for_type<repeatable_reader_t, cloudsuite_instr>(fname, cpu);
+    else
+      return champsim::get_tracereader_for_type<champsim::bulk_tracereader, cloudsuite_instr>(fname, cpu);
+  } else {
+    if (repeat)
+      return champsim::get_tracereader_for_type<repeatable_reader_t, input_instr>(fname, cpu);
+    else
+      return champsim::get_tracereader_for_type<champsim::bulk_tracereader, input_instr>(fname, cpu);
+  }
 }

--- a/test/cpp/src/084-tracereader-eof.cc
+++ b/test/cpp/src/084-tracereader-eof.cc
@@ -1,0 +1,11 @@
+#include <catch.hpp>
+
+#include "tracereader.h"
+
+TEST_CASE("A tracereader can be constructed from a type without an eof() member function") {
+  champsim::tracereader uut{[](){ return ooo_model_instr{0, input_instr{}}; }};
+  REQUIRE_FALSE(uut.eof());
+  (void)uut();
+  REQUIRE_FALSE(uut.eof());
+}
+


### PR DESCRIPTION
Resolves #337.

This patch adds a run-to-end feature to ChampSim. If the user does not specify `-i` on the command line, the simulation will run to the end of the trace, then stop. If the user supplies `-i`, the behavior of the simulator is unchanged.