### PR TITLE
Added useful_prefetch parameter to prefetchers

### DIFF
--- a/config/modules.py
+++ b/config/modules.py
@@ -199,7 +199,7 @@ def get_cache_module_lines(pref_data, repl_data):
 
     pref_nonbranch_variant_data = [
         ('prefetcher_initialize',),
-        ('prefetcher_cache_operate', (('uint64_t', 'addr'), ('uint64_t', 'ip'), ('uint8_t', 'cache_hit'), ('uint8_t', 'type'), ('uint32_t', 'metadata_in')), 'uint32_t', 'std::bit_xor'),
+        ('prefetcher_cache_operate', (('uint64_t', 'addr'), ('uint64_t', 'ip'), ('uint8_t', 'cache_hit'), ('bool', 'useful_prefetch'), ('uint8_t', 'type'), ('uint32_t', 'metadata_in')), 'uint32_t', 'std::bit_xor'),
         ('prefetcher_cache_fill', (('uint64_t', 'addr'), ('uint32_t', 'set'), ('uint32_t', 'way'), ('uint8_t', 'prefetch'), ('uint64_t', 'evicted_addr'), ('uint32_t', 'metadata_in')), 'uint32_t', 'std::bit_xor'),
         ('prefetcher_cycle_operate',),
         ('prefetcher_final_stats',)

--- a/inc/cache.h
+++ b/inc/cache.h
@@ -211,7 +211,7 @@ public:
     virtual ~module_concept() = default;
 
     virtual void impl_prefetcher_initialize() = 0;
-    virtual uint32_t impl_prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in) = 0;
+    virtual uint32_t impl_prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, bool useful_prefetch, uint8_t type, uint32_t metadata_in) = 0;
     virtual uint32_t impl_prefetcher_cache_fill(uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in) = 0;
     virtual void impl_prefetcher_cycle_operate() = 0;
     virtual void impl_prefetcher_final_stats() = 0;
@@ -231,7 +231,7 @@ public:
     explicit module_model(CACHE* cache) : intern_(cache) {}
 
     void impl_prefetcher_initialize();
-    uint32_t impl_prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in);
+    uint32_t impl_prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, bool useful_prefetch, uint8_t type, uint32_t metadata_in);
     uint32_t impl_prefetcher_cache_fill(uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in);
     void impl_prefetcher_cycle_operate();
     void impl_prefetcher_final_stats();
@@ -248,9 +248,9 @@ public:
   std::unique_ptr<module_concept> module_pimpl;
 
   void impl_prefetcher_initialize() { module_pimpl->impl_prefetcher_initialize(); }
-  uint32_t impl_prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in)
+  uint32_t impl_prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, bool useful_prefetch, uint8_t type, uint32_t metadata_in)
   {
-    return module_pimpl->impl_prefetcher_cache_operate(addr, ip, cache_hit, type, metadata_in);
+    return module_pimpl->impl_prefetcher_cache_operate(addr, ip, cache_hit, useful_prefetch, type, metadata_in);
   }
   uint32_t impl_prefetcher_cache_fill(uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
   {

--- a/prefetcher/ip_stride/ip_stride.cc
+++ b/prefetcher/ip_stride/ip_stride.cc
@@ -90,7 +90,7 @@ void CACHE::prefetcher_initialize() {}
 
 void CACHE::prefetcher_cycle_operate() { ::trackers[this].advance_lookahead(this); }
 
-uint32_t CACHE::prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in)
+uint32_t CACHE::prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, bool useful_prefetch, uint8_t type, uint32_t metadata_in)
 {
   ::trackers[this].initiate_lookahead(ip, addr >> LOG2_BLOCK_SIZE);
   return metadata_in;

--- a/prefetcher/next_line_instr/next_line.cc
+++ b/prefetcher/next_line_instr/next_line.cc
@@ -4,7 +4,7 @@ void CACHE::prefetcher_initialize() {}
 
 void CACHE::prefetcher_branch_operate(uint64_t ip, uint8_t branch_type, uint64_t branch_target) {}
 
-uint32_t CACHE::prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in)
+uint32_t CACHE::prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, bool useful_prefetch, uint8_t type, uint32_t metadata_in)
 {
   // assert(addr == ip); // Invariant for instruction prefetchers
   uint64_t pf_addr = addr + (1 << LOG2_BLOCK_SIZE);

--- a/prefetcher/no/no.cc
+++ b/prefetcher/no/no.cc
@@ -2,7 +2,7 @@
 
 void CACHE::prefetcher_initialize() {}
 
-uint32_t CACHE::prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in) { return metadata_in; }
+uint32_t CACHE::prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, bool useful_prefetch, uint8_t type, uint32_t metadata_in) { return metadata_in; }
 
 uint32_t CACHE::prefetcher_cache_fill(uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
 {

--- a/prefetcher/no_instr/no.cc
+++ b/prefetcher/no_instr/no.cc
@@ -6,7 +6,7 @@ void CACHE::prefetcher_initialize() {}
 
 void CACHE::prefetcher_branch_operate(uint64_t ip, uint8_t branch_type, uint64_t branch_target) {}
 
-uint32_t CACHE::prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in)
+uint32_t CACHE::prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, bool useful_prefetch, uint8_t type, uint32_t metadata_in)
 {
   assert(addr == ip); // Invariant for instruction prefetchers
   return metadata_in;

--- a/prefetcher/spp_dev/spp_dev.cc
+++ b/prefetcher/spp_dev/spp_dev.cc
@@ -34,7 +34,7 @@ void CACHE::prefetcher_initialize()
 
 void CACHE::prefetcher_cycle_operate() {}
 
-uint32_t CACHE::prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in)
+uint32_t CACHE::prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, bool useful_prefetch, uint8_t type, uint32_t metadata_in)
 {
   uint64_t page = addr >> LOG2_PAGE_SIZE;
   uint32_t page_offset = (addr >> LOG2_BLOCK_SIZE) & (PAGE_SIZE / BLOCK_SIZE - 1), last_sig = 0, curr_sig = 0, depth = 0;

--- a/prefetcher/va_ampm_lite/va_ampm_lite.cc
+++ b/prefetcher/va_ampm_lite/va_ampm_lite.cc
@@ -52,7 +52,7 @@ bool check_cl_prefetch(CACHE* cache, uint64_t v_addr)
 
 void CACHE::prefetcher_initialize() { regions.insert_or_assign(this, decltype(regions)::mapped_type{}); }
 
-uint32_t CACHE::prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in)
+uint32_t CACHE::prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, bool useful_prefetch, uint8_t type, uint32_t metadata_in)
 {
   auto [current_vpn, page_offset] = ::page_and_offset(addr);
   auto demand_region = std::find_if(std::begin(::regions.at(this)), std::end(::regions.at(this)), [vpn = current_vpn](auto x) { return x.vpn == vpn; });

--- a/test/cpp/modules/prefetcher/address_collector/address_collector.cc
+++ b/test/cpp/modules/prefetcher/address_collector/address_collector.cc
@@ -11,7 +11,7 @@ namespace test
 
 void CACHE::prefetcher_initialize() {}
 
-uint32_t CACHE::prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in)
+uint32_t CACHE::prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, bool useful_prefetch, uint8_t type, uint32_t metadata_in)
 {
   test::address_operate_collector[this].push_back(addr);
   return metadata_in;

--- a/test/cpp/modules/prefetcher/metadata_collector/metadata_collector.cc
+++ b/test/cpp/modules/prefetcher/metadata_collector/metadata_collector.cc
@@ -11,7 +11,7 @@ namespace test
 
 void CACHE::prefetcher_initialize() {}
 
-uint32_t CACHE::prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in) {
+uint32_t CACHE::prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, bool useful_prefetch, uint8_t type, uint32_t metadata_in) {
   auto it = test::metadata_operate_collector.try_emplace(this);
   it.first->second.push_back(metadata_in);
   return metadata_in;

--- a/test/cpp/modules/prefetcher/metadata_emitter/metatadata_emitter.cc
+++ b/test/cpp/modules/prefetcher/metadata_emitter/metatadata_emitter.cc
@@ -11,7 +11,7 @@ namespace test
 
 void CACHE::prefetcher_initialize() {}
 
-uint32_t CACHE::prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in) {
+uint32_t CACHE::prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, bool useful_prefetch, uint8_t type, uint32_t metadata_in) {
   auto found = test::metadata_operate_emitter.find(this);
   if (found != std::end(test::metadata_operate_emitter))
     return found->second;

--- a/test/cpp/modules/prefetcher/prefetch_hit_collector/prefetch_hit_collector.cc
+++ b/test/cpp/modules/prefetcher/prefetch_hit_collector/prefetch_hit_collector.cc
@@ -1,11 +1,20 @@
 #include "cache.h"
 
+#include <map>
+#include <vector>
+
+#include "../../../src/pref_interface.h"
+
+namespace test
+{
+  std::map<CACHE*, std::vector<pref_cache_operate_interface>> prefetch_hit_collector;
+}
+
 void CACHE::prefetcher_initialize() {}
 
 uint32_t CACHE::prefetcher_cache_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, bool useful_prefetch, uint8_t type, uint32_t metadata_in)
 {
-  uint64_t pf_addr = addr + (1 << LOG2_BLOCK_SIZE);
-  prefetch_line(pf_addr, true, metadata_in);
+  test::prefetch_hit_collector[this].push_back({addr, ip, cache_hit, useful_prefetch, type, metadata_in});
   return metadata_in;
 }
 
@@ -17,3 +26,4 @@ uint32_t CACHE::prefetcher_cache_fill(uint64_t addr, uint32_t set, uint32_t way,
 void CACHE::prefetcher_cycle_operate() {}
 
 void CACHE::prefetcher_final_stats() {}
+

--- a/test/cpp/src/420-issue-prefetch.cc
+++ b/test/cpp/src/420-issue-prefetch.cc
@@ -3,6 +3,12 @@
 #include "defaults.hpp"
 #include "cache.h"
 #include "champsim_constants.h"
+#include "pref_interface.h"
+
+namespace test
+{
+  extern std::map<CACHE*, std::vector<pref_cache_operate_interface>> prefetch_hit_collector;
+}
 
 SCENARIO("A prefetch can be issued") {
   GIVEN("An empty cache") {
@@ -16,6 +22,7 @@ SCENARIO("A prefetch can be issued") {
       .lower_level(&mock_ll.queues)
       .hit_latency(hit_latency)
       .fill_latency(fill_latency)
+      .prefetcher<CACHE::ptestDcppDmodulesDprefetcherDprefetch_hit_collector>()
     };
 
     std::array<champsim::operable*, 3> elements{{&mock_ll, &mock_ul, &uut}};
@@ -50,6 +57,8 @@ SCENARIO("A prefetch can be issued") {
       }
 
       AND_WHEN("A packet with the same address is sent") {
+        test::prefetch_hit_collector.insert_or_assign(&uut, std::vector<test::pref_cache_operate_interface>{});
+
         // Create a test packet
         decltype(mock_ul)::request_type test;
         test.address = 0xdeadbeef;
@@ -71,6 +80,15 @@ SCENARIO("A prefetch can be issued") {
         THEN("The number of useful prefetches is incremented") {
           REQUIRE(uut.sim_stats.pf_issued == 1);
           REQUIRE(uut.sim_stats.pf_useful == 1);
+        }
+
+        THEN("The packet is shown to be a prefetch hit") {
+          REQUIRE_THAT(test::prefetch_hit_collector.at(&uut), Catch::Matchers::SizeIs(1) && Catch::Matchers::AllMatch(
+                Catch::Matchers::Predicate<test::pref_cache_operate_interface>(
+                  [](test::pref_cache_operate_interface x){ return x.useful_prefetch; },
+                  "is prefetch hit"
+                )
+              ));
         }
       }
     }

--- a/test/cpp/src/pref_interface.h
+++ b/test/cpp/src/pref_interface.h
@@ -1,0 +1,18 @@
+#ifndef TEST_PREF_INTERFACE_H
+#define TEST_PREF_INTERFACE_H
+
+namespace test
+{
+  struct pref_cache_operate_interface
+  {
+    uint64_t addr;
+    uint64_t ip;
+    uint8_t cache_hit;
+    bool useful_prefetch;
+    uint8_t type;
+    uint32_t metadata_in;
+  };
+}
+
+#endif
+


### PR DESCRIPTION
Resolves #344 

This patch adds a parameter to the prefetcher cache_operate hook that indicates whether the hit block was a prefetch or not. This will help prefetchers get good feedback on their performance, and it also allows easier migration from the IPC-1 prefetchers. This is, however, a breaking change for all existing code in the name of bringing instruction prefetchers and data prefetchers together.