### PR TITLE
BRANCH_OTHER are considered conditional.

### DIFF
--- a/btb/basic_btb/basic_btb.cc
+++ b/btb/basic_btb/basic_btb.cc
@@ -100,7 +100,7 @@ void O3_CPU::update_btb(uint64_t ip, uint64_t branch_target, uint8_t taken, uint
     ::INDIRECT_BTB[this][hash % std::size(::INDIRECT_BTB[this])] = branch_target;
   }
 
-  if (branch_type == BRANCH_CONDITIONAL) {
+  if ((branch_type == BRANCH_CONDITIONAL) || (branch_type == BRANCH_OTHER)) {
     ::CONDITIONAL_HISTORY[this] <<= 1;
     ::CONDITIONAL_HISTORY[this].set(0, taken);
   }
@@ -122,7 +122,7 @@ void O3_CPU::update_btb(uint64_t ip, uint64_t branch_target, uint8_t taken, uint
     type = ::branch_info::INDIRECT;
   else if (branch_type == BRANCH_RETURN)
     type = ::branch_info::RETURN;
-  else if (branch_type == BRANCH_CONDITIONAL)
+  else if ((branch_type == BRANCH_CONDITIONAL) || (branch_type == BRANCH_OTHER))
     type = ::branch_info::CONDITIONAL;
 
   auto opt_entry = ::BTB.at(this).check_hit({ip, branch_target, type});

--- a/inc/instruction.h
+++ b/inc/instruction.h
@@ -100,7 +100,7 @@ private:
       is_branch = true;
       branch_taken = true;
       branch_type = BRANCH_INDIRECT;
-    } else if (!reads_sp && reads_ip && !writes_sp && writes_ip && reads_flags && !reads_other) {
+    } else if (!reads_sp && reads_ip && !writes_sp && writes_ip && (reads_flags || reads_other)) {
       // conditional branch
       is_branch = true;
       branch_taken = instr.branch_taken; // don't change this

--- a/inc/instruction.h
+++ b/inc/instruction.h
@@ -100,7 +100,7 @@ private:
       is_branch = true;
       branch_taken = true;
       branch_type = BRANCH_INDIRECT;
-    } else if (!reads_sp && reads_ip && !writes_sp && writes_ip && (reads_flags || reads_other)) {
+    } else if (!reads_sp && reads_ip && !writes_sp && writes_ip && reads_flags && !reads_other) {
       // conditional branch
       is_branch = true;
       branch_taken = instr.branch_taken; // don't change this

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -162,7 +162,7 @@ bool O3_CPU::do_predict_branch(ooo_model_instr& arch_instr)
     l1i->impl_prefetcher_branch_operate(arch_instr.ip, arch_instr.branch_type, predicted_branch_target);
 
     if (predicted_branch_target != arch_instr.branch_target
-        || (arch_instr.branch_type == BRANCH_CONDITIONAL
+        || (((arch_instr.branch_type == BRANCH_CONDITIONAL) || (arch_instr.branch_type == BRANCH_OTHER))
             && arch_instr.branch_taken != arch_instr.branch_prediction)) { // conditional branches are re-evaluated at decode when the target is computed
       sim_stats.total_rob_occupancy_at_branch_mispredict += std::size(ROB);
       sim_stats.branch_type_misses[arch_instr.branch_type]++;
@@ -293,7 +293,7 @@ void O3_CPU::decode_instruction()
     if (db_entry.branch_mispredicted) {
       // These branches detect the misprediction at decode
       if ((db_entry.branch_type == BRANCH_DIRECT_JUMP) || (db_entry.branch_type == BRANCH_DIRECT_CALL)
-          || (db_entry.branch_type == BRANCH_CONDITIONAL && db_entry.branch_taken == db_entry.branch_prediction)) {
+          || (((db_entry.branch_type == BRANCH_CONDITIONAL) || (db_entry.branch_type == BRANCH_OTHER)) && db_entry.branch_taken == db_entry.branch_prediction)) {
         // clear the branch_mispredicted bit so we don't attempt to resume fetch again at execute
         db_entry.branch_mispredicted = 0;
         // pay misprediction penalty


### PR DESCRIPTION
This pull request includes two fixes:

The first one is that BRANCH_OTHER considered conditional branches in ChampSim. Among other effects, the most important current "bug" is that the BTB considers them as "always_taken" which is not right.

The second ones is considering that conditional branches can also read from other registers, and not just from flag registers.

In general, I think we should avoid to have a BRANCH_OTHER type as it may be confusing. But for now, this patch fixes some current problems.
