### PR TITLE
fix: Resolved tag congestion

### DIFF
--- a/inc/util/algorithm.h
+++ b/inc/util/algorithm.h
@@ -19,6 +19,8 @@
 
 #include <algorithm>
 
+#include "util/span.h"
+
 namespace champsim
 {
 template <typename InputIt, typename OutputIt, typename F>
@@ -32,6 +34,16 @@ auto extract_if(InputIt begin, InputIt end, OutputIt d_begin, F func)
       *begin++ = std::move(*i);
   }
   return std::pair{begin, d_begin};
+}
+
+template <typename R, typename Output, typename F, typename G>
+long int transform_while_n(R& queue, Output out, long int sz, F&& test_func, G&& transform_func)
+{
+  auto [begin, end] = champsim::get_span_p(std::begin(queue), std::end(queue), sz, std::forward<F>(test_func));
+  auto retval = std::distance(begin, end);
+  std::transform(begin, end, out, std::forward<G>(transform_func));
+  queue.erase(begin, end);
+  return retval;
 }
 } // namespace champsim
 

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -253,6 +253,7 @@ bool CACHE::handle_miss(const tag_lookup_type& handle_pkt)
       }
 
       return false;
+    }
 
     // Allocate an MSHR
     if (fwd_pkt.response_requested) {

--- a/src/channel.cc
+++ b/src/channel.cc
@@ -117,8 +117,17 @@ bool champsim::channel::do_add_queue(R& queue, std::size_t queue_size, const typ
   assert(packet.address != 0);
 
   // check occupancy
-  if (std::size(queue) >= queue_size)
+  if (std::size(queue) >= queue_size) {
+    if constexpr (champsim::debug_print) {
+      fmt::print("[channel] {} instr_id: {} address: {:#x} v_address: {:#x} type: {} FULL\n", __func__, packet.instr_id, packet.address, packet.v_address,
+          access_type_names.at(champsim::to_underlying(packet.type)));
+    }
     return false; // cannot handle this request
+
+  if constexpr (champsim::debug_print) {
+    fmt::print("[channel] {} instr_id: {} address: {:#x} v_address: {:#x} type: {}\n", __func__, packet.instr_id, packet.address, packet.v_address,
+        access_type_names.at(champsim::to_underlying(packet.type)));
+  }
 
   // Insert the packet ahead of the translation misses
   auto fwd_pkt = packet;
@@ -130,11 +139,6 @@ bool champsim::channel::do_add_queue(R& queue, std::size_t queue_size, const typ
 
 bool champsim::channel::add_rq(const request_type& packet)
 {
-  if constexpr (champsim::debug_print) {
-    fmt::print("[channel_rq] {} instr_id: {} address: {:#x} v_address: {:#x} type: {}\n", __func__, packet.instr_id, packet.address, packet.v_address,
-               access_type_names.at(champsim::to_underlying(packet.type)));
-  }
-
   sim_stats.RQ_ACCESS++;
 
   auto result = do_add_queue(RQ, RQ_SIZE, packet);
@@ -149,11 +153,6 @@ bool champsim::channel::add_rq(const request_type& packet)
 
 bool champsim::channel::add_wq(const request_type& packet)
 {
-  if constexpr (champsim::debug_print) {
-    fmt::print("[channel_wq] {} instr_id: {} address: {:#x} v_address: {:#x} type: {}\n", __func__, packet.instr_id, packet.address, packet.v_address,
-               access_type_names.at(champsim::to_underlying(packet.type)));
-  }
-
   sim_stats.WQ_ACCESS++;
 
   auto result = do_add_queue(WQ, WQ_SIZE, packet);
@@ -168,11 +167,6 @@ bool champsim::channel::add_wq(const request_type& packet)
 
 bool champsim::channel::add_pq(const request_type& packet)
 {
-  if constexpr (champsim::debug_print) {
-    fmt::print("[channel_pq] {} instr_id: {} address: {:#x} v_address: {:#x} type: {}\n", __func__, packet.instr_id, packet.address, packet.v_address,
-               access_type_names.at(champsim::to_underlying(packet.type)));
-  }
-
   sim_stats.PQ_ACCESS++;
 
   auto fwd_pkt = packet;

--- a/src/channel.cc
+++ b/src/channel.cc
@@ -123,6 +123,7 @@ bool champsim::channel::do_add_queue(R& queue, std::size_t queue_size, const typ
           access_type_names.at(champsim::to_underlying(packet.type)));
     }
     return false; // cannot handle this request
+  }
 
   if constexpr (champsim::debug_print) {
     fmt::print("[channel] {} instr_id: {} address: {:#x} v_address: {:#x} type: {}\n", __func__, packet.instr_id, packet.address, packet.v_address,

--- a/test/cpp/src/045-transform-while-n.cc
+++ b/test/cpp/src/045-transform-while-n.cc
@@ -1,0 +1,64 @@
+#include <catch.hpp>
+
+#include "util/algorithm.h"
+
+#include <vector>
+
+namespace {
+template <typename T>
+bool always(T /*ignored*/)
+{
+  return true;
+}
+
+template <typename T>
+bool is_negative(T val)
+{
+  return val < 0;
+}
+
+template <typename T>
+T identity(T val)
+{
+  return val;
+}
+
+template <typename T>
+T negative(T val)
+{
+  return -1*val;
+}
+
+}
+
+TEST_CASE("transform_while_n() does not transform an empty list") {
+  std::vector<int> source{};
+  std::vector<int> destination{};
+
+  auto sz = champsim::transform_while_n(source, std::back_inserter(destination), 4000, ::always<int>, ::identity<int>);
+
+  REQUIRE_THAT(destination, Catch::Matchers::IsEmpty());
+  REQUIRE(sz == 0);
+}
+
+TEST_CASE("transform_while_n() is capped by the size parameter") {
+  auto size = GENERATE(0, 1, 2, 4, 10, 20, 100);
+  std::vector<int> source(400, -1);
+  std::vector<int> destination{};
+
+  auto sz = champsim::transform_while_n(source, std::back_inserter(destination), size, ::always<int>, ::negative<int>);
+
+  REQUIRE_THAT(destination, Catch::Matchers::RangeEquals(std::vector<int>(size, 1)));
+  REQUIRE(sz == size);
+}
+
+TEST_CASE("transform_while_n() is capped by the function parameter") {
+  std::vector<int> source(400, -1);
+  std::vector<int> destination{};
+  source.at(10) = 1;
+
+  auto sz = champsim::transform_while_n(source, std::back_inserter(destination), 4000, ::is_negative<int>, ::negative<int>);
+
+  REQUIRE_THAT(destination, Catch::Matchers::RangeEquals(std::vector<int>(10, 1)));
+  REQUIRE(sz == 10);
+}


### PR DESCRIPTION
Fixes #359.

There was a bug in the tag lookup where cascading misses in the PTW might cause the L1D to deadlock. This patch allows the `inflight_tag_check` member to drain to the `translation_stash`, allowing bandwidth for translated packets (from the PTW) to be looked up.