### PR TITLE
Fixed bug where TLB MSHR merging would lose data

### DIFF
--- a/inc/cache.h
+++ b/inc/cache.h
@@ -112,6 +112,7 @@ class CACHE : public champsim::operable
     std::vector<std::deque<response_type>*> to_return{};
 
     mshr_type(tag_lookup_type req, uint64_t cycle);
+    static mshr_type merge(mshr_type predecessor, mshr_type successor);
   };
 
   bool try_hit(const tag_lookup_type& handle_pkt);

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -504,7 +504,7 @@ bool O3_CPU::do_complete_store(const LSQ_ENTRY& sq_entry)
   data_packet.ip = sq_entry.ip;
 
   if constexpr (champsim::debug_print) {
-    fmt::print("[SQ] {} instr_id: {}\n", __func__, sq_entry.instr_id);
+    fmt::print("[SQ] {} instr_id: {} vaddr: {:x}\n", __func__, data_packet.instr_id, data_packet.v_address);
   }
 
   return L1D_bus.issue_write(data_packet);
@@ -518,7 +518,7 @@ bool O3_CPU::execute_load(const LSQ_ENTRY& lq_entry)
   data_packet.ip = lq_entry.ip;
 
   if constexpr (champsim::debug_print) {
-    fmt::print("[LQ] {} instr_id: {}\n", __func__, lq_entry.instr_id);
+    fmt::print("[LQ] {} instr_id: {} vaddr: {:#x}\n", __func__, data_packet.instr_id, data_packet.v_address);
   }
 
   return L1D_bus.issue_read(data_packet);

--- a/src/vmem.cc
+++ b/src/vmem.cc
@@ -63,7 +63,12 @@ std::pair<uint64_t, uint64_t> VirtualMemory::va_to_pa(uint32_t cpu_num, uint64_t
   if (fault)
     ppage_pop();
 
-  return {champsim::splice_bits(ppage->second, vaddr, LOG2_PAGE_SIZE), fault ? minor_fault_penalty : 0};
+  auto paddr = champsim::splice_bits(ppage->second, vaddr, LOG2_PAGE_SIZE);
+  if constexpr (champsim::debug_print) {
+    fmt::print("[VMEM] {} paddr: {:x} vaddr: {:x} fault: {}\n", __func__, paddr, vaddr, fault);
+  }
+
+  return {paddr, fault ? minor_fault_penalty : 0};
 }
 
 std::pair<uint64_t, uint64_t> VirtualMemory::get_pte_pa(uint32_t cpu_num, uint64_t vaddr, std::size_t level)
@@ -88,7 +93,7 @@ std::pair<uint64_t, uint64_t> VirtualMemory::get_pte_pa(uint32_t cpu_num, uint64
   auto offset = get_offset(vaddr, level);
   auto paddr = champsim::splice_bits(ppage->second, offset * PTE_BYTES, champsim::lg2(pte_page_size));
   if constexpr (champsim::debug_print) {
-    fmt::print("[VMEM] {} paddr: {:x} vaddr: {:x} pt_page_offset: {} translation_level: {}\n", __func__, paddr, vaddr, offset, level);
+    fmt::print("[VMEM] {} paddr: {:x} vaddr: {:x} pt_page_offset: {} translation_level: {} fault: {}\n", __func__, paddr, vaddr, offset, level, fault);
   }
 
   return {paddr, fault ? minor_fault_penalty : 0};


### PR DESCRIPTION
This patch fixes a bug where a MSHR merge in the TLB would discard the translation, resulting in occasionally failed `packet.address != 0` assertions.