### PR TITLE
Fixed bug where the wrong stats were used to calculate AMAT

### DIFF
--- a/src/cache.cc
+++ b/src/cache.cc
@@ -695,6 +695,16 @@ void CACHE::begin_phase()
 
 void CACHE::end_phase(unsigned finished_cpu)
 {
+  auto total_miss = 0ull;
+  for (auto type : {access_type::LOAD, access_type::RFO, access_type::PREFETCH, access_type::WRITE, access_type::TRANSLATION}) {
+    total_miss =
+        std::accumulate(std::begin(sim_stats.misses.at(champsim::to_underlying(type))), std::end(sim_stats.misses.at(champsim::to_underlying(type))), total_miss);
+  }
+  sim_stats.avg_miss_latency = std::ceil(sim_stats.total_miss_latency) / std::ceil(total_miss);
+
+  roi_stats.total_miss_latency = sim_stats.total_miss_latency;
+  roi_stats.avg_miss_latency = std::ceil(roi_stats.total_miss_latency) / std::ceil(total_miss);
+
   for (auto type : {access_type::LOAD, access_type::RFO, access_type::PREFETCH, access_type::WRITE, access_type::TRANSLATION}) {
     roi_stats.hits.at(champsim::to_underlying(type)).at(finished_cpu) = sim_stats.hits.at(champsim::to_underlying(type)).at(finished_cpu);
     roi_stats.misses.at(champsim::to_underlying(type)).at(finished_cpu) = sim_stats.misses.at(champsim::to_underlying(type)).at(finished_cpu);
@@ -705,13 +715,6 @@ void CACHE::end_phase(unsigned finished_cpu)
   roi_stats.pf_useful = sim_stats.pf_useful;
   roi_stats.pf_useless = sim_stats.pf_useless;
   roi_stats.pf_fill = sim_stats.pf_fill;
-
-  auto total_miss = 0ull;
-  for (auto type : {access_type::LOAD, access_type::RFO, access_type::PREFETCH, access_type::WRITE, access_type::TRANSLATION}) {
-    total_miss =
-        std::accumulate(std::begin(roi_stats.misses.at(champsim::to_underlying(type))), std::end(roi_stats.misses.at(champsim::to_underlying(type))), total_miss);
-  }
-  roi_stats.avg_miss_latency = std::ceil(sim_stats.total_miss_latency) / std::ceil(total_miss);
 
   for (auto ul : upper_levels) {
     ul->roi_stats.RQ_ACCESS = ul->sim_stats.RQ_ACCESS;

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -709,7 +709,7 @@ void CACHE::end_phase(unsigned finished_cpu)
   auto total_miss = 0ull;
   for (auto type : {access_type::LOAD, access_type::RFO, access_type::PREFETCH, access_type::WRITE, access_type::TRANSLATION}) {
     total_miss =
-        std::accumulate(std::begin(roi_stats.hits.at(champsim::to_underlying(type))), std::end(roi_stats.hits.at(champsim::to_underlying(type))), total_miss);
+        std::accumulate(std::begin(roi_stats.misses.at(champsim::to_underlying(type))), std::end(roi_stats.misses.at(champsim::to_underlying(type))), total_miss);
   }
   roi_stats.avg_miss_latency = std::ceil(sim_stats.total_miss_latency) / std::ceil(total_miss);
 

--- a/test/cpp/src/402-miss-latency.cc
+++ b/test/cpp/src/402-miss-latency.cc
@@ -87,6 +87,11 @@ SCENARIO("A cache returns a miss after the specified latency") {
       THEN("The average miss latency increases") {
         REQUIRE(uut.sim_stats.total_miss_latency == miss_latency + fill_latency);
       }
+
+      THEN("The end-of-phase average miss latency increases") {
+        uut.end_phase(0);
+        REQUIRE(uut.roi_stats.avg_miss_latency == miss_latency + fill_latency);
+      }
     }
   }
 }
@@ -165,6 +170,14 @@ SCENARIO("A cache completes a fill after the specified latency") {
           REQUIRE(uut.sim_stats.total_miss_latency == miss_latency + fill_latency);
         else
           REQUIRE(uut.sim_stats.total_miss_latency == fill_latency-1); // -1 due to ordering of elements
+      }
+
+      THEN("The end-of-phase average miss latency increases") {
+        uut.end_phase(0);
+        if (match_offset)
+          REQUIRE(uut.roi_stats.avg_miss_latency == miss_latency + fill_latency);
+        else
+          REQUIRE(uut.roi_stats.avg_miss_latency == fill_latency-1); // -1 due to ordering of elements
       }
     }
   }

--- a/test/cpp/src/402-miss-latency.cc
+++ b/test/cpp/src/402-miss-latency.cc
@@ -90,6 +90,7 @@ SCENARIO("A cache returns a miss after the specified latency") {
 
       THEN("The end-of-phase average miss latency increases") {
         uut.end_phase(0);
+        REQUIRE(uut.sim_stats.avg_miss_latency == miss_latency + fill_latency);
         REQUIRE(uut.roi_stats.avg_miss_latency == miss_latency + fill_latency);
       }
     }
@@ -174,10 +175,13 @@ SCENARIO("A cache completes a fill after the specified latency") {
 
       THEN("The end-of-phase average miss latency increases") {
         uut.end_phase(0);
-        if (match_offset)
+        if (match_offset) {
+          REQUIRE(uut.sim_stats.avg_miss_latency == miss_latency + fill_latency);
           REQUIRE(uut.roi_stats.avg_miss_latency == miss_latency + fill_latency);
-        else
+        } else {
+          REQUIRE(uut.sim_stats.avg_miss_latency == fill_latency-1); // -1 due to ordering of elements
           REQUIRE(uut.roi_stats.avg_miss_latency == fill_latency-1); // -1 due to ordering of elements
+        }
       }
     }
   }


### PR DESCRIPTION
This patch fixes a bug where the average miss time was calculated with the hits in the denominator, not the misses. This probably caused some confusion in what the numbers actually meant. This bug affected both the output to stdout and the JSON output.