### PR TITLE
Migrated documentation into docs directory

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Set Up Environment
-        run: python3 -m pip install sphinx sphinx-rtd-theme sphinx-versioning
+        run: python3 -m pip install sphinx sphinx-rtd-theme sphinx-multiversion
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build Documentation
-        run: sphinx-versioning docs _build
+        run: sphinx-multiversion docs _build
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,47 @@
+name: Update Documentation
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+      - feature/*
+      - release/*
+    paths:
+      - 'doc/**'
+
+permissions:
+  contents: write
+
+jobs:
+  publish-wiki:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set Up Environment
+        run: python3 -m pip install sphinx sphinx-rtd-theme sphinx-versioning
+
+      - uses: actions/checkout@v4
+
+      - name: Build Documentation
+        run: sphinx-versioning docs _build
+
+      - uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Install HTML sources
+        run: mv _build/${{ github.event.base_ref }} .
+
+      - uses: EndBug/add-and-commit@v9
+        with:
+          default_author: github_actions
+          message: |
+            Update documentation for branch ${{ github.event.base_ref }}.
+
+            Author: ${{ github.event.head_commit.author }}
+            Committer: ${{ github.event.head_commit.committer }}
+
+            ${{ github.event.head_commit.message }}
+
+

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/README.txt
+++ b/docs/README.txt
@@ -1,0 +1,4 @@
+To build documentation locally:
+
+python3 -m pip install sphinx sphinx-rtd-theme sphinx-multiversion
+sphinx-multiversion . _build/html

--- a/docs/_templates/versioning.html
+++ b/docs/_templates/versioning.html
@@ -1,0 +1,8 @@
+{% if versions %}
+<h3>{{ _('Versions') }}</h3>
+<ul>
+  {%- for item in versions %}
+  <li><a href="{{ item.url }}">{{ item.name }}</a></li>
+  {%- endfor %}
+</ul>
+{% endif %}

--- a/docs/_templates/versions.html
+++ b/docs/_templates/versions.html
@@ -1,0 +1,27 @@
+{%- if current_version %}
+<div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
+  <span class="rst-current-version" data-toggle="rst-current-version">
+    <span class="fa fa-book"> Other Versions</span>
+    v: {{ current_version.name }}
+    <span class="fa fa-caret-down"></span>
+  </span>
+  <div class="rst-other-versions">
+    {%- if versions.tags %}
+    <dl>
+      <dt>Tags</dt>
+      {%- for item in versions.tags %}
+      <dd><a href="{{ item.url }}">{{ item.name }}</a></dd>
+      {%- endfor %}
+    </dl>
+    {%- endif %}
+    {%- if versions.branches %}
+    <dl>
+      <dt>Branches</dt>
+      {%- for item in versions.branches %}
+      <dd><a href="{{ item.url }}">{{ item.name }}</a></dd>
+      {%- endfor %}
+    </dl>
+    {%- endif %}
+  </div>
+</div>
+{%- endif %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,57 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+sys.path.insert(0, os.path.abspath('./src'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'ChampSim'
+copyright = '2023, The ChampSim Contributors'
+author = 'The ChampSim Contributors'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.githubpages',
+    'sphinx_multiversion'
+]
+
+# The root document
+root_doc = 'src/index'
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/src/Creating-a-configuration-file.rst
+++ b/docs/src/Creating-a-configuration-file.rst
@@ -1,0 +1,186 @@
+.. _Creating_Config:
+
+================================================
+Creating a Configuration File
+================================================
+
+The configuration file is a central fixture of the ChampSim build system.
+An example configuration file (champsim_config.json) is given in the root of the repository, but it is large and unwieldy.
+Your configuration file will likely be much smaller.
+This page will walk you through many of the features of the ChampSim configuration system.
+
+The configuration file is given as an input to the configuration script as below::
+
+    ./config.sh my_config.json
+
+In fact, the configuration file is entirely optional.
+Not specifying any file will configure ChampSim with a default configuration.
+
+-------------------------------
+Your first configuration file
+-------------------------------
+
+All ChampSim configuration files are JSON files.
+We can start with the most trivial of configuration files.::
+
+    {
+    }
+
+This would specify a default configuration.
+But, this is not frequently useful.
+Let's change the branch predictor that ChampSim uses.
+Legal values for the `branch_predictor` key are directory names under the `branch/` directory, or valid paths.
+The same is true for specifying BTBs in the core and both prefetchers and replacement policies in the cache.::
+
+    { 
+        "branch_predictor": "perceptron" 
+    }
+
+This configuration file will configure ChampSim with a default configuration, but with a perceptron branch predictor instead.
+We can take this further and specify many things about our single-core system.::
+
+    {
+        "branch_predictor": "perceptron",
+
+        "rob_size": 226, "lq_size": 90, "sq_size": 85,
+        "fetch_width": 6, "decode_width": 6, "lq_width": 2, "sq_width": 1,
+
+        "decode_latency": 3, "execute_latency": 2
+    }
+
+Each of these options will specify something about our core. Next, we'll specify some of our caches.
+
+---------------------
+Cache Configuration
+---------------------
+
+We can begin by changing some features of our L1 data cache.
+We can specify its size based on the block size, the number of sets, and the number of ways.
+The following configuration file specifies a 64 KiB L1 data cache.::
+
+    {
+        "block_size": 64,
+        "L1D": { "sets": 256, "ways": 4 }
+    }
+
+Note that 64 is the default block size, specified here for clarity.
+The default prefetcher is the do-nothing prefetcher, and the default replacement policy is LRU, but they can be specified, too.::
+
+    {
+        "L1D": {
+            "sets": 256, "ways": 4,
+            "prefetcher": "next_line",
+            "replacement": "../../my/repl/path"
+        }
+    }
+
+Specifying a cache this way will create an identical L1D for each core in the configuration.
+So far, we've only handled the single-core case.
+
+--------------------------
+Multi-core configurations
+--------------------------
+
+Multi-core simulations can be enabled by specifying the `num_cores` key.::
+
+    { 
+        "num_cores": 2
+    }
+
+This will create two identical cores with default configurations.
+This can be combined with the other specifications that we have made so far to create identical cores.::
+
+    {
+        "num_cores": 2,
+        "branch_predictor": "perceptron",
+
+        "rob_size": 190,
+
+        "L1D": {
+            "sets": 256, "ways": 4,
+            "prefetcher": "next_line",
+            "replacement": "drrip"
+        }
+    }
+
+-----------------------
+Heterogeneous systems
+-----------------------
+
+ChampSim supports a variety of system configurations, including systems that are not homogeneous.
+For example, we could create two cores with different ROB sizes.
+Specify all cores in a list under the `ooo_cpu` key.::
+
+    {
+        "num_cores": 2,
+        "ooo_cpu": [
+            { "rob_size": 120 },
+            { "rob_size": 240 }
+        ]
+    }
+
+Each object in the `ooo_cpu` list specifies one core, and takes all of the options that we have discussed so far.::
+
+
+    {
+        "num_cores": 2,
+        "ooo_cpu": [
+            {
+                "branch_predictor": "bimodal",
+                "rob_size": 120, "lq_size": 90,
+                "L1D": { "prefetcher": "next_line" }
+            },
+            { 
+                "branch_predictor": "gshare",
+                "rob_size": 240, "lq_size": 70,
+                "L1D": { "prefetcher": "no" }
+            }
+        ]
+    }
+
+Each cache object can also be specified in a list under the `caches` key.
+These caches can then be referred to by their `name` key.
+In the following configuration, each core has a distinct L1 cache.::
+
+    {
+        "num_cores": 2,
+        "ooo_cpu": [
+            { "L1D": "cacheA" },
+            { "L1D": "cacheB" }
+        ],
+        "caches": [
+            { "name": "cacheA", "replacement": "lru" },
+            { "name": "cacheB", "replacement": "srrip" }
+        ]
+    }
+
+The configuration script will make every attempt to assign defaults to objects, but it may not be able to do so for.
+In the following configuration, cores 0 and 1 are attached to `llcA`, and cores 2 and 3 are attached to `llcB`.
+The script is able to assign LLC-like defaults to each of the caches specified under `"caches"`::
+
+    {
+        "num_cores": 4,
+        "ooo_cpu": [
+            { "L2C": { "lower_level": "llcA"} },
+            { "L2C": { "lower_level": "llcB"} }
+        ],
+        "caches": [
+            { "name": "llcA" },
+            { "name": "llcB" }
+        ]
+    }
+
+However, in the following, the script will not be able to assign defaults to all caches, and you may need to specify additional parameters::
+
+    {
+        "num_cores": 8,
+        "ooo_cpu": [
+            { "L2C": { "lower_level": "llcA"} },
+            { "L2C": { "lower_level": "llcB"} }
+        ],
+        "caches": [
+            { "name": "llcA", "lower_level": "L4C" },
+            { "name": "llcB", "lower_level": "L4C" },
+            { "name": "L4C" }
+        ]
+    }

--- a/docs/src/Modules.rst
+++ b/docs/src/Modules.rst
@@ -1,0 +1,95 @@
+.. _Modules:
+
+=============================
+The ChampSim Module System
+=============================
+
+ChampSim uses four kinds of modules:
+
+* Branch Direction Predictors
+* Branch Target Predictors
+* Memory Prefetchers
+* Cache Replacement Policies
+
+Each of these is implemented as a set of hook functions. Each hook must be implemented, or compilation will fail.
+
+----------------------------
+Branch Predictors
+----------------------------
+
+A branch predictor module must implement three functions.
+
+::
+
+  void O3_CPU::initialize_branch_predictor()
+
+This function is called when the core is initialized. You can use it to initialize elements of dynamic structures, such as `std::vector` or `std::map`.
+
+::
+
+  uint8_t O3_CPU::predict_branch(uint64_t ip, uint64_t predicted_target, uint8_t always_taken, uint8_t branch_type)
+
+This function is called when a prediction is needed. The parameters passed are:
+
+* ip: The instruction pointer of the branch
+* predicted_target: The predicted target of the branch. This is passed directly from the branch target predictor module and may be incorrect.
+* always_taken: A boolean value. This parameter will be nonzero if the branch target predictor determines that the branch is always taken.
+* branch_type: One of the following
+
+  * `BRANCH_DIRECT_JUMP`: Direct non-call, unconditional branches, whose target is encoded in the instruction
+  * `BRANCH_INDIRECT`: Indirect non-call, unconditional branches, whose target is stored in a register
+  * `BRANCH_CONDITIONAL`: A direct conditional branch
+  * `BRANCH_DIRECT_CALL`: A call to a procedure whose target is encoded in the instruction
+  * `BRANCH_INDIRECT_CALL`: A call to a procedure whose target is stored in a register
+  * `BRANCH_RETURN`: A return to a calling procedure
+  * `BRANCH_OTHER`: If the branch type cannot be determined
+
+::
+
+  void O3_CPU::last_branch_result(uint64_t ip, uint64_t branch_target, uint8_t taken, uint8_t branch_type)
+
+
+This function is called when a branch is resolved. The parameters are the same as in the previous hook, except that the last three are guaranteed to be correct.
+
+-----------------------------------
+Branch Target Buffers
+-----------------------------------
+
+A BTB module must implement three functions.
+
+::
+
+  void O3_CPU::initialize_btb()
+
+This function is called when the core is initialized. You can use it to initialize elements of dynamic structures, such as `std::vector` or `std::map`.
+
+::
+
+  std::pair<uint64_t, bool> O3_CPU::btb_prediction(uint64_t ip)
+
+This function is called when a prediction is needed. The parameters passed are:
+
+* ip: The instruction pointer of the branch
+
+The function should return a pair containing the predicted address and a boolean that describes if the branch is known to be always taken. If the prediction fails, the function should return a default-initialized address, e.g. `uint64_t{}`.
+
+::
+
+  void O3_CPU::update_btb(uint64_t ip, uint64_t branch_target, uint8_t taken, uint8_t branch_type)
+
+
+This function is called when a branch is resolved. The parameters are:
+
+* ip: The instruction pointer of the branch
+* branch_target: The correct target of the branch.
+* taken: A boolean value. This parameter will be nonzero if the branch was taken.
+* branch_type: One of the following
+
+  * `BRANCH_DIRECT_JUMP`: Direct non-call, unconditional branches, whose target is encoded in the instruction
+  * `BRANCH_INDIRECT`: Indirect non-call, unconditional branches, whose target is stored in a register
+  * `BRANCH_CONDITIONAL`: A direct conditional branch
+  * `BRANCH_DIRECT_CALL`: A call to a procedure whose target is encoded in the instruction
+  * `BRANCH_INDIRECT_CALL`: A call to a procedure whose target is stored in a register
+  * `BRANCH_RETURN`: A return to a calling procedure
+  * `BRANCH_OTHER`: If the branch type cannot be determined
+

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,0 +1,81 @@
+Welcome to the ChampSim wiki!
+====================================
+
+ChampSim is an open-source trace based simulator maintained at Texas A&M University and through the support of the computer architecture community.
+ChampSim was originally developed to provide a platform for microarchitectural competitions (DPC3, DPC2, CRC2, IPC1, etc.) and has since been used for the development of multiple state-of-the-art cache replacement and prefetching policies.
+
+We encourage you to read below to see if ChampSim is right for your research, class, or project!
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   Modules
+   Creating-a-configuration-file
+
+
+-------------------
+ChampSim's Goal
+-------------------
+
+The ultimate design philosophy of ChampSim is to provide an environment where an architect can realistically begin performing significant research within a month, but the simulator works right out of the box for exploration and quickly prototyping cache management ideas!
+With this in mind, ChampSim development works towards maintaining an accurate Out of Order execution and cache memory model without the overhead of larger multi-layered architectural research platforms.
+There are ChampSim-ready traces available online (from CRC2, IPC1, DPC3, and CVP) to let you quickly get started.
+The ChampSim design philosophy is summed up in three main design principles:
+
+* Low startup time: The user should be able to perform new and meaningful memory system research in one month.
+* Little architecture knowledge required: Users need only an entry-level comprehension of C++ to begin researching prefetching and replacement schemes.
+* Design configurability: The core model should be flexible enough to model a variety of commodity devices.
+
+-------------------
+What ChampSim is
+-------------------
+
+* A fast trace-based simulator that can get you started in computer architecture research quickly without a deeper understanding of microarchitecture.
+* A modular simulator, with multiple interchangeable pieces that can be configured at compile time. This leads to diverse simulation environments and enables you to simulate the system you need!
+
+----------------------
+What ChampSim is not
+----------------------
+
+* ChampSim is not ideal for research related to OS and OS-interactions... without modifications. ChampSim is a trace-based simulator, meaning that a program was executed with an instrumentation tool, like PIN or Dynamorio, to create a file that represents the instructions executed by some processor. This means that ChampSim does not have any OS interfaces or full-system mode.
+
+* The traces ChampSim uses do not currently support specific instructions aside from memory load/store operations. A non-memory instruction is not fully simulated but given a flat latency and consumes resources from the front-end core model.
+
+* **Perfect**- ChampSim is an ongoing project and while we are working on improving the models in general, there are some pieces that are in active development. We encourage you to make us aware of something you think may make this simulator even better and even submit a pull request to help further development!
+
+
+------------------
+ChampSim Features
+------------------
+
+* Heterogeneous cores
+* Configurable cache hierarchy - Size, queues, associativity
+* Different levels and interconnectivity between cache levels
+* Aggressive decoupled frontend
+* Modular components including:
+
+  * Branch predictor
+  * Cache prefetchers
+  * Cache replacement policy
+  * Branch target buffers
+  * Extendable DRAM model
+
+================
+FAQ
+================
+
+Why use trace-based simulation?
+  Trace-based simulation is much faster than full system, allowing for students and researchers to quickly jump into architectural research, configuring the system and quickly reviewing simulation results.
+  This allows for an easier collaboration with industry. The ChampSim traces contain no opcode-specific information making it impossible to reverse engineer the original program that the trace was generated from. Any sensitive information in the traces can be removed through randomization, fuzzing, or other changes to the file without disrupting the overall behavior of the application.
+  Traces are easy to distribute for competitions, collaboration, or classroom settings.
+
+Why is it called ChampSim?
+  This simulator was originally developed for quickly creating and evaluating ideas for Championships, so it's the Championship Simulator. Since its conception as a competition platform, ChampSim has grown into a research and education platform.
+
+I want to contribute! How do I do that?
+  We're glad you asked! Take a look at some of the issues and their tags or get started on a new feature for ChampSim. We are currently using the develop branch to add improvements to the overall simulator. When you're done, make a pull request and we'll review it to be merged into the develop branch of the repository.
+
+How do we cite ChampSim?
+  For now, please cite our [arXiv paper](https://arxiv.org/abs/2210.14324).
+


### PR DESCRIPTION
This patch regards my recent comment on #12.

The wiki has not lived up to expectations for documentation. The wiki is only editable by maintainers and cannot be merged alongside the code that it describes.

This patch uses Sphinx and GitHub Pages to host the documentation instead. Each branch gets its documentation copied to the `gh-pages` branch, where it is read by Pages.