### PR TITLE
Fix: Varying queue sizes now varies queue sizes

### DIFF
--- a/config/instantiation_file.py
+++ b/config/instantiation_file.py
@@ -353,8 +353,9 @@ def get_instantiation_lines(cores, caches, ptws, pmem, vmem):
     yield '#include "defaults.hpp"'
     yield '#include "vmem.h"'
     yield 'namespace champsim::configured {'
+
     struct_body = itertools.chain(
-        *((queue_fmtstr.format(name=ul_queues, **v) for ul_queues in v['upper_channels']) for v in upper_levels.values()),
+        (queue_fmtstr_result for formatted_queues in ((queue_fmtstr.format(name=ul_queues, **v) for ul_queues in v['upper_channels']) for v in upper_levels.values()) for queue_fmtstr_result in formatted_queues),
 
         (pmem_fmtstr.format(_ulptr=vector_string('&'+v for v in upper_levels[pmem['name']]['upper_channels']), **pmem),),
         (vmem_fmtstr.format(dram_name=pmem['name'], **vmem),),

--- a/config/instantiation_file.py
+++ b/config/instantiation_file.py
@@ -318,12 +318,8 @@ def module_include_files(datas):
 
     yield from (f'#include "{f}"' for _,f in filtered_candidates)
 
-def get_instantiation_lines(cores, caches, ptws, pmem, vmem):
-    '''
-    Generate the lines for a C++ file that instantiates a configuration.
-    '''
-    upper_levels = util.chain(
-            *util.collect(get_upper_levels(cores, caches, ptws), operator.itemgetter(0), upper_channel_collector),
+def decorate_queues(caches, ptws, pmem):
+    return util.chain(
             *({c['name']: cache_queue_defaults(c)} for c in caches),
             *({p['name']: ptw_queue_defaults(p)} for p in ptws),
             {pmem['name']: {
@@ -334,7 +330,17 @@ def get_instantiation_lines(cores, caches, ptws, pmem, vmem):
                     '_queue_check_full_addr':False
                 }
             }
-        )
+    )
+
+def get_queue_info(upper_levels, decoration):
+    queue_info = util.chain(upper_levels, decoration)
+    return list(itertools.chain(*(util.explode(v, 'upper_channels', 'name') for v in queue_info.values())))
+
+def get_instantiation_lines(cores, caches, ptws, pmem, vmem):
+    '''
+    Generate the lines for a C++ file that instantiates a configuration.
+    '''
+    upper_levels = util.chain(*util.collect(get_upper_levels(cores, caches, ptws), operator.itemgetter(0), upper_channel_collector))
 
     yield '// NOLINTBEGIN(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers): generated magic numbers'
     yield '#include "environment.h"'
@@ -355,7 +361,7 @@ def get_instantiation_lines(cores, caches, ptws, pmem, vmem):
     yield 'namespace champsim::configured {'
 
     struct_body = itertools.chain(
-        (queue_fmtstr_result for formatted_queues in ((queue_fmtstr.format(name=ul_queues, **v) for ul_queues in v['upper_channels']) for v in upper_levels.values()) for queue_fmtstr_result in formatted_queues),
+        (queue_fmtstr.format(**v) for v in get_queue_info(upper_levels, decorate_queues(caches, ptws, pmem))),
 
         (pmem_fmtstr.format(_ulptr=vector_string('&'+v for v in upper_levels[pmem['name']]['upper_channels']), **pmem),),
         (vmem_fmtstr.format(dram_name=pmem['name'], **vmem),),

--- a/config/util.py
+++ b/config/util.py
@@ -173,3 +173,15 @@ def yield_from_star(gen, args, n=2):
         for seq,return_value in zip(retvals, instance_retval):
             seq.append(return_value)
     return retvals
+
+def explode(d, in_key, out_key=None):
+    '''
+    Convert a dictionary with a list member to a list with dictionary members
+    :param d: the dictionary to be extracted
+    :param in_key: the key holding the list
+    :param out_key: the key to distinguish the resulting list elements
+    '''
+    if out_key is None:
+        out_key = in_key
+    extracted = d.pop(in_key)
+    return [ { out_key: e, **d } for e in extracted ]

--- a/test/python/test_util.py
+++ b/test/python/test_util.py
@@ -278,3 +278,28 @@ class YieldFromStar(unittest.TestCase):
         self.assertEqual(first, ['identity_first', 'identity_first'])
         self.assertEqual(second, ['identity_second', 'identity_second'])
 
+class ExplodeTests(unittest.TestCase):
+    def test_empty_list(self):
+        given = { 'dog': 'rough collie', 'test': [] }
+        expected = []
+        evaluated = config.util.explode(given, 'test')
+        self.assertEqual(expected, evaluated)
+
+    def test_single_element_list(self):
+        given = { 'dog': 'rough collie', 'test': ['good'] }
+        expected = [ { 'test': 'good', 'dog': 'rough collie' } ]
+        evaluated = config.util.explode(given, 'test')
+        self.assertEqual(expected, evaluated)
+
+    def test_multiple_element_list(self):
+        given = { 'dog': 'rough collie', 'test': ['good', 'bad'] }
+        expected = [ { 'test': 'good', 'dog': 'rough collie' },  { 'test': 'bad', 'dog': 'rough collie' } ]
+        evaluated = config.util.explode(given, 'test')
+        self.assertEqual(expected, evaluated)
+
+    def test_modify_key(self):
+        given = { 'dog': 'rough collie', 'test': ['good'] }
+        expected = [ { 'newkey': 'good', 'dog': 'rough collie' } ]
+        evaluated = config.util.explode(given, 'test', 'newkey')
+        self.assertEqual(expected, evaluated)
+


### PR DESCRIPTION
Fixed a bug where the queue sizes between cache levels was always the value of the LLC's queue sizes.

Reproducing the bug: Changing the L2's rq_size to 128 still resulted in it being set to 32 in the channel instantiation in .csconfig/[BUILD#]/inc/core_inst.inc. Also in core_inst.inc, without modifying the configuration file, the channels between each cache all had the same values despite differences in the default config file. 