### PR TITLE
fix: explicit constructor calls for units types

### DIFF
--- a/inc/util/units.h
+++ b/inc/util/units.h
@@ -247,32 +247,32 @@ namespace data_literals
 /**
  * Specify a literal number of ``champsim::data::bits``.
  */
-constexpr auto operator""_b(unsigned long long val) -> bits { return {val}; }
+constexpr auto operator""_b(unsigned long long val) -> bits { return bits{val}; }
 
 /**
  * Specify a literal number of ``champsim::data::bytes``.
  */
-constexpr auto operator""_B(unsigned long long val) -> size<long long, std::ratio<1>> { return {static_cast<long long>(val)}; }
+constexpr auto operator""_B(unsigned long long val) -> size<long long, std::ratio<1>> { return size<long long, std::ratio<1>>{static_cast<long long>(val)}; }
 
 /**
  * Specify a literal number of ``champsim::data::kibibytes``.
  */
-constexpr auto operator""_kiB(unsigned long long val) -> size<long long, kibi> { return {static_cast<long long>(val)}; }
+constexpr auto operator""_kiB(unsigned long long val) -> size<long long, kibi> { return size<long long, kibi>{static_cast<long long>(val)}; }
 
 /**
  * Specify a literal number of ``champsim::data::mebibytes``.
  */
-constexpr auto operator""_MiB(unsigned long long val) -> size<long long, mebi> { return {static_cast<long long>(val)}; }
+constexpr auto operator""_MiB(unsigned long long val) -> size<long long, mebi> { return size<long long, mebi>{static_cast<long long>(val)}; }
 
 /**
  * Specify a literal number of ``champsim::data::gibibytes``.
  */
-constexpr auto operator""_GiB(unsigned long long val) -> size<long long, gibi> { return {static_cast<long long>(val)}; }
+constexpr auto operator""_GiB(unsigned long long val) -> size<long long, gibi> { return size<long long, gibi>{static_cast<long long>(val)}; }
 
 /**
  * Specify a literal number of ``champsim::data::tebibytes``.
  */
-constexpr auto operator""_TiB(unsigned long long val) -> size<long long, tebi> { return {static_cast<long long>(val)}; }
+constexpr auto operator""_TiB(unsigned long long val) -> size<long long, tebi> { return size<long long, tebi>{static_cast<long long>(val)}; }
 } // namespace data_literals
 } // namespace data
 } // namespace champsim

--- a/test/cpp/src/031-address-slice.cc
+++ b/test/cpp/src/031-address-slice.cc
@@ -15,21 +15,25 @@ TEST_CASE("An address slice is constructible from a uint64_t") {
 
   champsim::static_extent<20_b,16_b> extent_a{};
   champsim::address_slice test_a{extent_a, address};
-  REQUIRE(test_a.to<uint64_t>() == (address & champsim::bitmask(champsim::data::bits{champsim::size(extent_a)})));
+  champsim::data::bits expected_size_a{champsim::size(extent_a)};
+  REQUIRE(test_a.to<uint64_t>() == (address & champsim::bitmask(expected_size_a)));
 
   champsim::static_extent<64_b,16_b> extent_b{};
   champsim::address_slice test_b{extent_b, address};
-  REQUIRE(test_b.to<uint64_t>() == (address & champsim::bitmask(champsim::data::bits{champsim::size(extent_b)})));
+  champsim::data::bits expected_size_b{champsim::size(extent_b)};
+  REQUIRE(test_b.to<uint64_t>() == (address & champsim::bitmask(expected_size_b)));
 }
 
 TEMPLATE_TEST_CASE_SIG("An address slice is constexpr constructible from a uint64_t", "", ((uint64_t ADDR), ADDR), 0xdeadbeef, 0xffff'ffff'ffff'ffff) {
   constexpr champsim::static_extent<20_b,16_b> extent_a{};
   constexpr champsim::address_slice test_a{extent_a, ADDR};
-  STATIC_REQUIRE(test_a.to<uint64_t>() == (ADDR & champsim::bitmask(champsim::data::bits{champsim::size(extent_a)})));
+  champsim::data::bits expected_size_a{champsim::size(extent_a)};
+  STATIC_REQUIRE(test_a.to<uint64_t>() == (ADDR & champsim::bitmask(expected_size_a)));
 
   constexpr champsim::static_extent<64_b,16_b> extent_b{};
   constexpr champsim::address_slice test_b{extent_b, ADDR};
-  STATIC_REQUIRE(test_b.to<uint64_t>() == (ADDR & champsim::bitmask(champsim::data::bits{champsim::size(extent_b)})));
+  champsim::data::bits expected_size_b{champsim::size(extent_b)};
+  STATIC_REQUIRE(test_b.to<uint64_t>() == (ADDR & champsim::bitmask(expected_size_b)));
 }
 
 TEST_CASE("An address slice is constructible from a wider address_slice") {


### PR DESCRIPTION
Build fails when GCC/Clang attempts to convert an initializer list to the proper return type.

Making these constructor calls explicitly defined fixes the issue.