### PR TITLE
Added 'Publications' page to documentation

### DIFF
--- a/PUBLICATIONS_USING_CHAMPSIM.bib
+++ b/PUBLICATIONS_USING_CHAMPSIM.bib
@@ -1,0 +1,75 @@
+@misc{gober2022championship,
+  title={The Championship Simulator: Architectural Simulation for Education and Competition},
+  author={Gober, Nathan and Chacon, Gino and Wang, Lei and Gratz, Paul V. and Jim{\'e}nez, Daniel A. and Teran, Elvira and Pugsley, Seth and Kim, Jinchun},
+  year={2022},
+  eprint={2210.14324},
+  eprinttype={arxiv},
+  eprintclass={cs.AR}
+}
+
+@inproceedings{gober2020temporal,
+  title     = {Temporal ancestry prefetcher},
+  author    = {Gober, Nathan and Chacon, Gino and Jim{\'e}nez, Daniel A. and Gratz, Paul V.},
+  editor    = {Pugsley, Seth and Alameldeen, Alaa and Al-otoom, Muawya and Zhou, Huiyang},
+  booktitle = {The First Instruction Prefetching Championship},
+  publisher = {{IEEE}},
+  year      = {2020},
+  month     = {5}
+}
+
+@inproceedings{gratz2020barca,
+  title     = {Barca: Branch agnostic region searching algorithm},
+  author    = {Daniel A. Jim{\'e}nez and Gino Chacon and Gober, Nathan and Gratz, Paul V.},
+  editor    = {Pugsley, Seth and Alameldeen, Alaa and Al-otoom, Muawya and Zhou, Huiyang},
+  booktitle = {The First Instruction Prefetching Championship},
+  publisher = {{IEEE}},
+  year      = {2020},
+  month     = {5}
+}
+
+@inproceedings{bhatia2019isca,
+    author    = {Bhatia, Eshan and Chacon, Gino and Pugsley, Seth and Teran, Elvira and Gratz, Paul V. and Jim\'{e}nez, Daniel A.},
+    title     = {Perceptron-Based Prefetch Filtering},
+    pages     = {1-13},
+    doi       = {10.1145/3307650.3322207},
+    booktitle = {Proceedings of the 47th Annual International Symposium on Computer Architecture},
+    year      = {2019},
+    month     = {6},
+    publisher = {{IEEE}},
+    address   = {Phoenix, Arizona}
+}
+
+@inproceedings{pakalapati2020isca,
+    author    = {Pakalapati, Samuel and Panda, Biswabandan},
+    title     = {Bouquet of Instruction Pointers: Instruction Pointer Classifier-based Spatial Hardware Prefetching},
+    pages     = {118-131},
+    doi       = {10.1109/ISCA45697.2020.00021},
+    booktitle = {Proceedings of the 47th Annual International Symposium on Computer Architecture},
+    year      = {2019},
+    month     = {6},
+    publisher = {{IEEE}},
+    address   = {Phoenix, Arizona}
+}
+
+@inproceedings{chacon2023characterization,
+  title     = {A Characterization of the Effects of Software Instruction Prefetching on an Aggressive Front-end},
+  author    = {Chacon, Gino and Gober, Nathan and Nathella, Krishnendra and Gratz, Paul V. and Jim{\'e}nez, Daniel A.},
+  pages     = {61-70},
+  booktitle = {Proceedings of the 47th Annual International Symposium on Computer Architecture},
+  publisher = {{IEEE}},
+  year      = {2020},
+  month     = {5}
+}
+
+@inproceedings{kim2016path,
+    author    = {Kim, Jinchun and Pugsley, Seth H. and Gratz, Paul V. and Reddy, A.L. Narasimha and Wilkerson, Chris and Chishti, Zeshan},
+    title     = {Path confidence based lookahead prefetching},
+    pages     = {1-12},
+    doi       = {10.1109/MICRO.2016.7783763},
+    year      = {2016},
+    month     = {10},
+    location  = {Tai\-pei, Taiwan},
+    booktitle = {{MICRO}-49: The 49th Annual {IEEE}\{ACM} International Symposium on Microarchitecture},
+    publisher = {Association for Computing Machinery}
+}
+

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ ChampSim is the result of academic research. If you use this software in your wo
 
     Gober, N., Chacon, G., Wang, L., Gratz, P. V., Jimenez, D. A., Teran, E., Pugsley, S., & Kim, J. (2022). The Championship Simulator: Architectural Simulation for Education and Competition. https://doi.org/10.48550/arXiv.2210.14324
 
+If you use ChampSim in your work, you may submit a pull request modifying `PUBLICATIONS_USING_CHAMPSIM.bib` to have it featured in [the documentation](https://champsim.github.io/ChampSim/master/Publications-using-champsim.html).
+
 # Download dependencies
 
 ChampSim uses [vcpkg](https://vcpkg.io) to manage its dependencies. In this repository, vcpkg is included as a submodule. You can download the dependencies with

--- a/docs/README.txt
+++ b/docs/README.txt
@@ -8,5 +8,5 @@ All documentation sources are contained in the src directory.
 
 To build documentation locally:
 
-python3 -m pip -r requirements.txt
+python3 -m pip install -r requirements.txt
 sphinx-build -c . src _build/html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,6 +34,7 @@ author = 'The ChampSim Contributors'
 extensions = [
     'sphinx.ext.githubpages',
     'sphinx.ext.autodoc',
+    'sphinxcontrib.bibtex',
     'breathe'
 ]
 
@@ -53,6 +54,45 @@ breathe_projects = {
     project: "./_doxygen/xml"
 }
 breathe_default_project = project
+
+# -- sphinxcontrib.bibtex configuration --------------------------------------
+bibtex_bibfiles = ['../../PUBLICATIONS_USING_CHAMPSIM.bib']
+
+import pybtex.plugin
+from pybtex.style.sorting import BaseSortingStyle
+from pybtex.style.formatting.unsrt import Style as UnsrtStyle
+
+class YearAuthorTitleSort(BaseSortingStyle):
+    def sorting_key(self, entry):
+        year_key = 99999 - int(entry.fields.get('year', '99999'))
+        return (year_key, YearAuthorTitleSort.author_editor_key(entry), entry.fields.get('title', ''))
+
+    @staticmethod
+    def persons_key(persons):
+        return '   '.join(YearAuthorTitleSort.person_key(person) for person in persons)
+
+    @staticmethod
+    def person_key(person):
+        return '  '.join((
+            ' '.join(person.prelast_names + person.last_names),
+            ' '.join(person.first_names + person.middle_names),
+            ' '.join(person.lineage_names),
+        )).lower()
+
+    @staticmethod
+    def author_editor_key(entry):
+        if entry.persons.get('author'):
+            return YearAuthorTitleSort.persons_key(entry.persons['author'])
+        elif entry.persons.get('editor'):
+            return YearAuthorTitleSort.persons_key(entry.persons['editor'])
+        else:
+            return ''
+
+class YATStyle(UnsrtStyle):
+    default_sorting_style = 'year_author_title'
+
+pybtex.plugin.register_plugin('pybtex.style.sorting', 'year_author_title', YearAuthorTitleSort)
+pybtex.plugin.register_plugin('pybtex.style.formatting', 'year_author_title', YATStyle)
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 sphinx
 breathe
+sphinxcontrib-bibtex

--- a/docs/src/Publications-using-champsim.rst
+++ b/docs/src/Publications-using-champsim.rst
@@ -1,0 +1,20 @@
+.. _Publications:
+
+================================
+Publications
+================================
+
+ChampSim is primarily exhibited in
+
+.. bibliography::
+   :list: bullet
+   :filter: False
+
+   gober2022championship
+
+Other publications that use ChampSim for their results are listed below:
+
+.. bibliography::
+   :list: bullet
+   :style: year_author_title
+   :filter: key not in {'gober2022championship'}

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -13,6 +13,8 @@ We encourage you to read below to see if ChampSim is right for your research, cl
    Modules
    Creating-a-configuration-file
 
+ChampSim is commonly used as the basis for academic research.
+See a list of publications that use ChampSim :ref:`here <Publications>`.
 
 -------------------
 ChampSim's Goal
@@ -77,5 +79,5 @@ I want to contribute! How do I do that?
   We're glad you asked! Take a look at some of the issues and their tags or get started on a new feature for ChampSim. We are currently using the develop branch to add improvements to the overall simulator. When you're done, make a pull request and we'll review it to be merged into the develop branch of the repository.
 
 How do we cite ChampSim?
-  For now, please cite our [arXiv paper](https://arxiv.org/abs/2210.14324).
+  For now, please cite our `arXiv paper <https://arxiv.org/abs/2210.14324>`_.
 


### PR DESCRIPTION
This patch adds a page to the documentation to feature publications that use ChampSim.

Publications are sorted by year, with the newest first.

Authors can add their publication to the list by modifying `PUBLICATIONS_USING_CHAMPSIM.bib`. I'm not so certain about the name of this file. If anyone has suggestions, I'd be open to a better name.