### PR TITLE
bug fixed: entries of DIB hit buffer and decode buffer exceed the limits

### DIFF
--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -37,7 +37,6 @@ constexpr long long STAT_PRINTING_PERIOD = 10000000;
 long O3_CPU::operate()
 {
   long progress{0};
-
   progress += retire_rob();                    // retire
   progress += complete_inflight_instruction(); // finalize execution
   progress += execute_instruction();           // execute instructions
@@ -294,7 +293,9 @@ long O3_CPU::promote_to_decode()
     return x.fetch_completed && x.ready_time <= time;
   };
 
-  champsim::bandwidth available_fetch_bandwidth{FETCH_WIDTH};
+  champsim::bandwidth available_fetch_bandwidth{
+      std::min(FETCH_WIDTH, std::min(champsim::bandwidth::maximum_type{static_cast<long>(DIB_HIT_BUFFER_SIZE - std::size(DIB_HIT_BUFFER))},
+                                     champsim::bandwidth::maximum_type{static_cast<long>(DECODE_BUFFER_SIZE - std::size(DECODE_BUFFER))}))};
 
   auto fetched_check_end = std::find_if(std::begin(IFETCH_BUFFER), std::end(IFETCH_BUFFER), [](const ooo_model_instr& x) { return !x.fetch_completed; });
   // find the first not fetch completed
@@ -319,7 +320,6 @@ long O3_CPU::promote_to_decode()
   IFETCH_BUFFER.erase(window_begin, window_end);
   return progress;
 }
-
 long O3_CPU::decode_instruction()
 {
   auto is_ready = [time = current_time](const auto& x) {
@@ -723,6 +723,7 @@ long O3_CPU::retire_rob()
       fmt::print("[ROB] retire_rob instr_id: {} is retired cycle: {}\n", x.instr_id, cycle);
     });
   }
+
   auto retire_count = std::distance(retire_begin, retire_end);
   num_retired += retire_count;
   ROB.erase(retire_begin, retire_end);
@@ -813,7 +814,7 @@ void LSQ_ENTRY::finish(std::deque<ooo_model_instr>::iterator begin, std::deque<o
 
 void LSQ_ENTRY::finish(ooo_model_instr& rob_entry) const
 {
-  assert(rob_entry.instr_id == this->instr_id);
+  // assert(rob_entry.instr_id == this->instr_id);
 
   ++rob_entry.completed_mem_ops;
   assert(rob_entry.completed_mem_ops <= rob_entry.num_mem_ops());

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -814,7 +814,7 @@ void LSQ_ENTRY::finish(std::deque<ooo_model_instr>::iterator begin, std::deque<o
 
 void LSQ_ENTRY::finish(ooo_model_instr& rob_entry) const
 {
-  // assert(rob_entry.instr_id == this->instr_id);
+  assert(rob_entry.instr_id == this->instr_id);
 
   ++rob_entry.completed_mem_ops;
   assert(rob_entry.completed_mem_ops <= rob_entry.num_mem_ops());


### PR DESCRIPTION
In the current implementation of promote_to_decode(), available_fetch_bandwidth does not account for the remaining space in the DIB_HIT_BUFFER and DECODE_BUFFER. As a result, the number of entries in these buffers can exceed their sizes. I have modified the bandwidth so it will consider the available space before promote them to decode.