### PR TITLE
Update champsim_config.json to reflect low-grade DDR5 memory, fix timing issue with refresh

### DIFF
--- a/champsim_config.json
+++ b/champsim_config.json
@@ -162,19 +162,19 @@
         "data_rate": 3200,
         "channels": 1,
         "ranks": 1,
-        "bankgroups": 4,
-        "banks": 8,
+        "bankgroups": 8,
+        "banks": 4,
         "bank_rows": 65536,
         "bank_columns": 1024,
         "channel_width": 8,
         "wq_size": 64,
         "rq_size": 64,
-        "tRP":  18,
-        "tRCD": 18,
-        "tCAS": 18,
-        "tRAS": 38,
-        "refresh_period": 64,
-        "refreshes_per_period": 4096
+        "tCAS":  24,
+        "tRCD": 24,
+        "tRP": 24,
+        "tRAS": 52,
+        "refresh_period": 32,
+        "refreshes_per_period": 8192
     },
 
     "virtual_memory": {

--- a/config/parse.py
+++ b/config/parse.py
@@ -329,9 +329,9 @@ class NormalizedConfiguration:
         )
 
         pmem = util.chain(self.pmem, {
-            'name': 'DRAM', 'data_rate': 3200, 'frequency': 1600, 'channels': 1, 'ranks': 1, 'bankgroups': 4, 'banks': 8, 'bank_rows': 65536, 'bank_columns': 1024,
-            'channel_width': 8, 'wq_size': 64, 'rq_size': 64, 'tRP': 18, 'tRCD': 18, 'tCAS': 18, 'tRAS' : 38,
-            'refresh_period': 64, 'refreshes_per_period': 8192
+            'name': 'DRAM', 'data_rate': 3200, 'frequency': 1600, 'channels': 1, 'ranks': 1, 'bankgroups': 8, 'banks': 4, 'bank_rows': 65536, 'bank_columns': 1024,
+            'channel_width': 8, 'wq_size': 64, 'rq_size': 64, 'tRP': 24, 'tRCD': 24, 'tCAS': 24, 'tRAS' : 52,
+            'refresh_period': 32, 'refreshes_per_period': 8192
         })
         pmem = util.chain(pmem,(do_deprecation(pmem, pmem_deprecation_keys,pmem_deprecation_warnings)))
         

--- a/inc/dram_controller.h
+++ b/inc/dram_controller.h
@@ -138,7 +138,7 @@ struct DRAM_CHANNEL final : public champsim::operable {
   stats_type roi_stats, sim_stats;
 
   // Latencies
-  const champsim::chrono::clock::duration tRP, tRCD, tCAS, tRAS, tREF, DRAM_DBUS_TURN_AROUND_TIME, DRAM_DBUS_RETURN_TIME, DRAM_DBUS_BANKGROUP_STALL;
+  const champsim::chrono::clock::duration tRP, tRCD, tCAS, tRAS, tREF, tRFC, DRAM_DBUS_TURN_AROUND_TIME, DRAM_DBUS_RETURN_TIME, DRAM_DBUS_BANKGROUP_STALL;
 
   // data bus period
   champsim::chrono::picoseconds data_bus_period{};
@@ -164,6 +164,7 @@ struct DRAM_CHANNEL final : public champsim::operable {
 
   std::size_t bank_request_capacity() const;
   std::size_t bankgroup_request_capacity() const;
+  [[nodiscard]] champsim::data::bytes density() const;
 };
 
 class MEMORY_CONTROLLER : public champsim::operable

--- a/src/dram_controller.cc
+++ b/src/dram_controller.cc
@@ -181,7 +181,7 @@ long DRAM_CHANNEL::schedule_refresh()
     }
     // refresh is being scheduled for this bank
     if (b_req.need_refresh && !b_req.valid) {
-      b_req.ready_time = current_time + ((tRP + tRAS) * DRAM_ROWS_PER_REFRESH);
+      b_req.ready_time = current_time + (tRAS * DRAM_ROWS_PER_REFRESH);
       b_req.need_refresh = false;
       b_req.under_refresh = true;
     }

--- a/test/cpp/src/702-dram-refresh.cc
+++ b/test/cpp/src/702-dram-refresh.cc
@@ -100,8 +100,8 @@ SCENARIO("The memory controller refreshes each bank at the proper rate") {
     GIVEN("A random request stream to the memory controller") {
         champsim::channel channel_uut{32, 32, 32, champsim::data::bits{8}, false};
         const std::size_t DRAM_CHANNELS = 1;
-        const std::size_t DRAM_BANKS = 1;
-        const std::size_t DRAM_BANKGROUPS = 1;
+        const std::size_t DRAM_BANKS = 4;
+        const std::size_t DRAM_BANKGROUPS = 8;
         const std::size_t DRAM_RANKS = 1;
         const std::size_t DRAM_COLUMNS = 1024;
         const std::size_t DRAM_ROWS = 65536;
@@ -112,7 +112,7 @@ SCENARIO("The memory controller refreshes each bank at the proper rate") {
         const champsim::chrono::picoseconds tREF{refresh_period / REFRESHES_PER_PERIOD};
         
 
-        MEMORY_CONTROLLER uut{champsim::chrono::picoseconds{312}, champsim::chrono::picoseconds{624}, std::size_t{18}, std::size_t{18}, std::size_t{18},std::size_t{38}, refresh_period, {&channel_uut}, 64, 64, DRAM_CHANNELS, champsim::data::bytes{8}, DRAM_ROWS, DRAM_COLUMNS, DRAM_RANKS, DRAM_BANKGROUPS, DRAM_BANKS, REFRESHES_PER_PERIOD};
+        MEMORY_CONTROLLER uut{champsim::chrono::picoseconds{312}, champsim::chrono::picoseconds{624}, std::size_t{24}, std::size_t{24}, std::size_t{24},std::size_t{52}, refresh_period, {&channel_uut}, 64, 64, DRAM_CHANNELS, champsim::data::bytes{8}, DRAM_ROWS, DRAM_COLUMNS, DRAM_RANKS, DRAM_BANKGROUPS, DRAM_BANKS, REFRESHES_PER_PERIOD};
         uut.warmup = false;
         uut.channels[0].warmup = false;
 
@@ -128,9 +128,10 @@ SCENARIO("The memory controller refreshes each bank at the proper rate") {
             {
                 uint64_t max_latency = *std::max_element(std::begin(packet_latencies),std::end(packet_latencies));
                 uint64_t min_latency = *std::min_element(std::begin(packet_latencies),std::end(packet_latencies));
-                uint64_t expected_refresh_latency = (std::size_t{38})*(DRAM_ROWS / REFRESHES_PER_PERIOD);
+                champsim::data::gibibytes density = champsim::data::bytes(DRAM_BANKS * DRAM_BANKGROUPS * DRAM_COLUMNS * DRAM_ROWS);
+                uint64_t expected_refresh_latency = (uint64_t)std::sqrt((double)density.count() * 8.00)*(std::size_t{52});
                 uint64_t apparent_refresh_latency = max_latency - min_latency;
-                uint64_t variance = 12; //necessary, because of packet mergers and fr-fcfs scheduling
+                uint64_t variance = 15; //necessary, because of packet mergers and fr-fcfs scheduling
 
                 REQUIRE(apparent_refresh_latency < expected_refresh_latency + variance);
                 REQUIRE(apparent_refresh_latency > expected_refresh_latency - variance);

--- a/test/cpp/src/702-dram-refresh.cc
+++ b/test/cpp/src/702-dram-refresh.cc
@@ -128,7 +128,7 @@ SCENARIO("The memory controller refreshes each bank at the proper rate") {
             {
                 uint64_t max_latency = *std::max_element(std::begin(packet_latencies),std::end(packet_latencies));
                 uint64_t min_latency = *std::min_element(std::begin(packet_latencies),std::end(packet_latencies));
-                uint64_t expected_refresh_latency = (std::size_t{18} + std::size_t{38})*(DRAM_ROWS / REFRESHES_PER_PERIOD);
+                uint64_t expected_refresh_latency = (std::size_t{38})*(DRAM_ROWS / REFRESHES_PER_PERIOD);
                 uint64_t apparent_refresh_latency = max_latency - min_latency;
                 uint64_t variance = 12; //necessary, because of packet mergers and fr-fcfs scheduling
 


### PR DESCRIPTION
With a release coming up, I would like to make a final tweak to the dram.
Default config numbers are updated and taken from real DDR5 at the 3200MHz frequency and at the config's density.
Refresh period has been reduced in half to 32ms, as this is standard for DDR5.

These newer updates revealed an issue with the timings as they stood. tRAS * rows_to_refresh should approximate the refresh delay somewhat better than previously. Previously I was doing (tRP + tRAS) * rows_to_refresh, but this is very conservative in terms of timing (20-30% too high). This doesn't become an issue until we start refreshing more often like in DDR5, and then it is very noticeable.

From what I can tell, tRFC (time after a refresh is issued before a bank can be used again) does not follow a strict tRAS + tRP per-row trend, as one might expect. It seems for refresh bursts can be more or less efficient than that with timing depending on density of the dram. Overall, this change gives us a decent approximation, but we can still be off by 10-20% at times.

There is another option here, which is to add tRFC as a config parameter and stop trying to approximate it from the other timings, but this is something that is not typically given by DRAM manufacturers up front (you can find it if you dig around your bios settings for long enough). Otherwise, we are stuck with this loose approximation. If someone is trying out things that are that dependent on DRAM configuration though, then they should probably be using ramulator as the memory model.



