### PR TITLE
Attempt to Fix AMPM Performance

### DIFF
--- a/prefetcher/va_ampm_lite/va_ampm_lite.cc
+++ b/prefetcher/va_ampm_lite/va_ampm_lite.cc
@@ -41,6 +41,7 @@ uint32_t va_ampm_lite::prefetcher_cache_operate(champsim::address addr, champsim
   }
   // mark this demand access
   demand_region->access_map.at(page_offset.to<std::size_t>()) = true;
+  regions.fill(demand_region.value());
 
   // attempt to prefetch in the positive, then negative direction
   for (auto direction : {1, -1}) {
@@ -64,7 +65,10 @@ uint32_t va_ampm_lite::prefetcher_cache_operate(champsim::address addr, champsim
               regions.fill(new_region);
             }
             else
-              pf_region->prefetch_map.at(pf_page_offset.to<std::size_t>()) = true;
+            {
+              pf_region.value().prefetch_map.at(pf_page_offset.to<std::size_t>()) = true;
+              regions.fill(pf_region.value());
+            }
             prefetches_issued++;
           }
         }

--- a/prefetcher/va_ampm_lite/va_ampm_lite.h
+++ b/prefetcher/va_ampm_lite/va_ampm_lite.h
@@ -8,6 +8,7 @@
 
 #include "champsim.h"
 #include "modules.h"
+#include "msl/lru_table.h"
 
 class va_ampm_lite : public champsim::modules::prefetcher
 {
@@ -17,7 +18,8 @@ class va_ampm_lite : public champsim::modules::prefetcher
   using block_in_page = champsim::address_slice<block_in_page_extent>;
 
 public:
-  static constexpr std::size_t REGION_COUNT = 128;
+  static constexpr std::size_t REGION_SETS = 1;
+  static constexpr std::size_t REGION_WAYS = 128;
   static constexpr int MAX_DISTANCE = 256;
   static constexpr int PREFETCH_DEGREE = 2;
 
@@ -25,20 +27,22 @@ public:
     champsim::page_number vpn;
     std::vector<bool> access_map{};
     std::vector<bool> prefetch_map{};
-    uint64_t lru;
 
-    static uint64_t region_lru;
 
     region_type() : region_type(champsim::page_number{}) {}
     explicit region_type(champsim::page_number allocate_vpn)
-        : vpn(allocate_vpn), access_map(PAGE_SIZE / BLOCK_SIZE), prefetch_map(PAGE_SIZE / BLOCK_SIZE), lru(region_lru++)
+        : vpn(allocate_vpn), access_map(PAGE_SIZE / BLOCK_SIZE), prefetch_map(PAGE_SIZE / BLOCK_SIZE)
     {
     }
   };
+  
 
   using prefetcher::prefetcher;
 
-  std::array<region_type, REGION_COUNT> regions;
+  struct ampm_indexer {
+    auto operator()(const region_type& entry) const { return entry.vpn; }
+  };
+  champsim::msl::lru_table<region_type,ampm_indexer,ampm_indexer> regions{REGION_SETS,REGION_WAYS};
 
   bool check_cl_access(champsim::block_number v_addr);
   bool check_cl_prefetch(champsim::block_number v_addr);

--- a/test/cpp/src/453-va-ampm-lite-behavior.cc
+++ b/test/cpp/src/453-va-ampm-lite-behavior.cc
@@ -96,3 +96,95 @@ SCENARIO("The va_ampm_lite prefetcher issues prefetches when addresses stride in
   }
 }
 
+SCENARIO("va_ampm_lite is benchmarked") {
+  GIVEN("A cache using the va_ampm_lite prefetcher") {
+    THEN("Each function is benchmarked"){
+
+      BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_initialize()")(Catch::Benchmark::Chronometer meter){
+        do_nothing_MRC mock_ll;
+        do_nothing_MRC mock_lt;
+        to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
+        CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
+          .name("453-uut-benchmark[va_ampm_lite::prefetcher_initialize()]")
+          .upper_levels({&mock_ul.queues})
+          .lower_level(&mock_ll.queues)
+          .lower_translate(&mock_lt.queues)
+          .prefetcher<va_ampm_lite>()
+        };
+        meter.measure([&] { return uut.impl_prefetcher_initialize(); });
+
+      
+      };
+
+      BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_cache_operate()")(Catch::Benchmark::Chronometer meter){
+        do_nothing_MRC mock_ll;
+        do_nothing_MRC mock_lt;
+        to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
+        CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
+          .name("453-uut-benchmark[va_ampm_lite::prefetcher_cache_operate()]")
+          .upper_levels({&mock_ul.queues})
+          .lower_level(&mock_ll.queues)
+          .lower_translate(&mock_lt.queues)
+          .prefetcher<va_ampm_lite>()
+        };
+        meter.measure([&] { return uut.impl_prefetcher_cache_operate(champsim::address{}, champsim::address{}, 0, false, access_type::LOAD,0); });
+      };
+
+      BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_cycle_operate()")(Catch::Benchmark::Chronometer meter){
+        do_nothing_MRC mock_ll;
+        do_nothing_MRC mock_lt;
+        to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
+        CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
+          .name("453-uut-benchmark[va_ampm_lite::prefetcher_cycle_operate()]")
+          .upper_levels({&mock_ul.queues})
+          .lower_level(&mock_ll.queues)
+          .lower_translate(&mock_lt.queues)
+          .prefetcher<va_ampm_lite>()
+        };
+        meter.measure([&] { return uut.impl_prefetcher_cycle_operate(); });
+      };
+
+      BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_cache_fill()")(Catch::Benchmark::Chronometer meter){
+        do_nothing_MRC mock_ll;
+        do_nothing_MRC mock_lt;
+        to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
+        CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
+          .name("453-uut-benchmark[va_ampm_lite::prefetcher_cache_fill()]")
+          .upper_levels({&mock_ul.queues})
+          .lower_level(&mock_ll.queues)
+          .lower_translate(&mock_lt.queues)
+          .prefetcher<va_ampm_lite>()
+        };
+        meter.measure([&] { return uut.impl_prefetcher_cache_fill(champsim::address{}, long{}, long{}, uint8_t{}, champsim::address{}, uint32_t{}); });
+      };
+
+      BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_branch_operate()")(Catch::Benchmark::Chronometer meter){
+        do_nothing_MRC mock_ll;
+        do_nothing_MRC mock_lt;
+        to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
+        CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
+          .name("453-uut-benchmark[va_ampm_lite::prefetcher_branch_operate()]")
+          .upper_levels({&mock_ul.queues})
+          .lower_level(&mock_ll.queues)
+          .lower_translate(&mock_lt.queues)
+          .prefetcher<va_ampm_lite>()
+        };
+        meter.measure([&] { return uut.impl_prefetcher_branch_operate(champsim::address{}, uint8_t{}, champsim::address{}); });
+      };
+
+      BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_final_stats()")(Catch::Benchmark::Chronometer meter){
+        do_nothing_MRC mock_ll;
+        do_nothing_MRC mock_lt;
+        to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
+        CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
+          .name("453-uut-benchmark[va_ampm_lite::prefetcher_final_stats()]")
+          .upper_levels({&mock_ul.queues})
+          .lower_level(&mock_ll.queues)
+          .lower_translate(&mock_lt.queues)
+          .prefetcher<va_ampm_lite>()
+        };
+        meter.measure([&] { return uut.impl_prefetcher_final_stats(); });
+      };
+    }
+  }
+}

--- a/test/cpp/src/453-va-ampm-lite-behavior.cc
+++ b/test/cpp/src/453-va-ampm-lite-behavior.cc
@@ -98,93 +98,90 @@ SCENARIO("The va_ampm_lite prefetcher issues prefetches when addresses stride in
 
 SCENARIO("va_ampm_lite is benchmarked") {
   GIVEN("A cache using the va_ampm_lite prefetcher") {
-    THEN("Each function is benchmarked"){
-
-      BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_initialize()")(Catch::Benchmark::Chronometer meter){
-        do_nothing_MRC mock_ll;
-        do_nothing_MRC mock_lt;
-        to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
-        CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
-          .name("453-uut-benchmark[va_ampm_lite::prefetcher_initialize()]")
-          .upper_levels({&mock_ul.queues})
-          .lower_level(&mock_ll.queues)
-          .lower_translate(&mock_lt.queues)
-          .prefetcher<va_ampm_lite>()
-        };
-        meter.measure([&] { return uut.impl_prefetcher_initialize(); });
-
-      
+    BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_initialize()")(Catch::Benchmark::Chronometer meter){
+      do_nothing_MRC mock_ll;
+      do_nothing_MRC mock_lt;
+      to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
+      CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
+        .name("453-uut-benchmark[va_ampm_lite::prefetcher_initialize()]")
+        .upper_levels({&mock_ul.queues})
+        .lower_level(&mock_ll.queues)
+        .lower_translate(&mock_lt.queues)
+        .prefetcher<va_ampm_lite>()
       };
+      meter.measure([&] { return uut.impl_prefetcher_initialize(); });
 
-      BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_cache_operate()")(Catch::Benchmark::Chronometer meter){
-        do_nothing_MRC mock_ll;
-        do_nothing_MRC mock_lt;
-        to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
-        CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
-          .name("453-uut-benchmark[va_ampm_lite::prefetcher_cache_operate()]")
-          .upper_levels({&mock_ul.queues})
-          .lower_level(&mock_ll.queues)
-          .lower_translate(&mock_lt.queues)
-          .prefetcher<va_ampm_lite>()
-        };
-        meter.measure([&] { return uut.impl_prefetcher_cache_operate(champsim::address{}, champsim::address{}, false, false, access_type::LOAD,uint32_t{}); });
-      };
+    
+    };
 
-      BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_cycle_operate()")(Catch::Benchmark::Chronometer meter){
-        do_nothing_MRC mock_ll;
-        do_nothing_MRC mock_lt;
-        to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
-        CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
-          .name("453-uut-benchmark[va_ampm_lite::prefetcher_cycle_operate()]")
-          .upper_levels({&mock_ul.queues})
-          .lower_level(&mock_ll.queues)
-          .lower_translate(&mock_lt.queues)
-          .prefetcher<va_ampm_lite>()
-        };
-        meter.measure([&] { return uut.impl_prefetcher_cycle_operate(); });
+    BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_cache_operate()")(Catch::Benchmark::Chronometer meter){
+      do_nothing_MRC mock_ll;
+      do_nothing_MRC mock_lt;
+      to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
+      CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
+        .name("453-uut-benchmark[va_ampm_lite::prefetcher_cache_operate()]")
+        .upper_levels({&mock_ul.queues})
+        .lower_level(&mock_ll.queues)
+        .lower_translate(&mock_lt.queues)
+        .prefetcher<va_ampm_lite>()
       };
+      meter.measure([&] { return uut.impl_prefetcher_cache_operate(champsim::address{}, champsim::address{}, false, false, access_type::LOAD,uint32_t{}); });
+    };
 
-      BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_cache_fill()")(Catch::Benchmark::Chronometer meter){
-        do_nothing_MRC mock_ll;
-        do_nothing_MRC mock_lt;
-        to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
-        CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
-          .name("453-uut-benchmark[va_ampm_lite::prefetcher_cache_fill()]")
-          .upper_levels({&mock_ul.queues})
-          .lower_level(&mock_ll.queues)
-          .lower_translate(&mock_lt.queues)
-          .prefetcher<va_ampm_lite>()
-        };
-        meter.measure([&] { return uut.impl_prefetcher_cache_fill(champsim::address{}, long{}, long{}, uint8_t{}, champsim::address{}, uint32_t{}); });
+    BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_cycle_operate()")(Catch::Benchmark::Chronometer meter){
+      do_nothing_MRC mock_ll;
+      do_nothing_MRC mock_lt;
+      to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
+      CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
+        .name("453-uut-benchmark[va_ampm_lite::prefetcher_cycle_operate()]")
+        .upper_levels({&mock_ul.queues})
+        .lower_level(&mock_ll.queues)
+        .lower_translate(&mock_lt.queues)
+        .prefetcher<va_ampm_lite>()
       };
+      meter.measure([&] { return uut.impl_prefetcher_cycle_operate(); });
+    };
 
-      BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_branch_operate()")(Catch::Benchmark::Chronometer meter){
-        do_nothing_MRC mock_ll;
-        do_nothing_MRC mock_lt;
-        to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
-        CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
-          .name("453-uut-benchmark[va_ampm_lite::prefetcher_branch_operate()]")
-          .upper_levels({&mock_ul.queues})
-          .lower_level(&mock_ll.queues)
-          .lower_translate(&mock_lt.queues)
-          .prefetcher<va_ampm_lite>()
-        };
-        meter.measure([&] { return uut.impl_prefetcher_branch_operate(champsim::address{}, uint8_t{}, champsim::address{}); });
+    BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_cache_fill()")(Catch::Benchmark::Chronometer meter){
+      do_nothing_MRC mock_ll;
+      do_nothing_MRC mock_lt;
+      to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
+      CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
+        .name("453-uut-benchmark[va_ampm_lite::prefetcher_cache_fill()]")
+        .upper_levels({&mock_ul.queues})
+        .lower_level(&mock_ll.queues)
+        .lower_translate(&mock_lt.queues)
+        .prefetcher<va_ampm_lite>()
       };
+      meter.measure([&] { return uut.impl_prefetcher_cache_fill(champsim::address{}, long{}, long{}, uint8_t{}, champsim::address{}, uint32_t{}); });
+    };
 
-      BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_final_stats()")(Catch::Benchmark::Chronometer meter){
-        do_nothing_MRC mock_ll;
-        do_nothing_MRC mock_lt;
-        to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
-        CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
-          .name("453-uut-benchmark[va_ampm_lite::prefetcher_final_stats()]")
-          .upper_levels({&mock_ul.queues})
-          .lower_level(&mock_ll.queues)
-          .lower_translate(&mock_lt.queues)
-          .prefetcher<va_ampm_lite>()
-        };
-        meter.measure([&] { return uut.impl_prefetcher_final_stats(); });
+    BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_branch_operate()")(Catch::Benchmark::Chronometer meter){
+      do_nothing_MRC mock_ll;
+      do_nothing_MRC mock_lt;
+      to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
+      CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
+        .name("453-uut-benchmark[va_ampm_lite::prefetcher_branch_operate()]")
+        .upper_levels({&mock_ul.queues})
+        .lower_level(&mock_ll.queues)
+        .lower_translate(&mock_lt.queues)
+        .prefetcher<va_ampm_lite>()
       };
-    }
+      meter.measure([&] { return uut.impl_prefetcher_branch_operate(champsim::address{}, uint8_t{}, champsim::address{}); });
+    };
+
+    BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_final_stats()")(Catch::Benchmark::Chronometer meter){
+      do_nothing_MRC mock_ll;
+      do_nothing_MRC mock_lt;
+      to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
+      CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
+        .name("453-uut-benchmark[va_ampm_lite::prefetcher_final_stats()]")
+        .upper_levels({&mock_ul.queues})
+        .lower_level(&mock_ll.queues)
+        .lower_translate(&mock_lt.queues)
+        .prefetcher<va_ampm_lite>()
+      };
+      meter.measure([&] { return uut.impl_prefetcher_final_stats(); });
+    };
   }
 }

--- a/test/cpp/src/453-va-ampm-lite-behavior.cc
+++ b/test/cpp/src/453-va-ampm-lite-behavior.cc
@@ -182,4 +182,5 @@ TEST_CASE("va_ampm_lite benchmark") {
     };
     meter.measure([&] { return uut.impl_prefetcher_final_stats(); });
   };
+  REQUIRE(true);
 }

--- a/test/cpp/src/453-va-ampm-lite-behavior.cc
+++ b/test/cpp/src/453-va-ampm-lite-behavior.cc
@@ -127,7 +127,7 @@ SCENARIO("va_ampm_lite is benchmarked") {
           .lower_translate(&mock_lt.queues)
           .prefetcher<va_ampm_lite>()
         };
-        meter.measure([&] { return uut.impl_prefetcher_cache_operate(champsim::address{}, champsim::address{}, 0, false, access_type::LOAD,0); });
+        meter.measure([&] { return uut.impl_prefetcher_cache_operate(champsim::address{}, champsim::address{}, false, false, access_type::LOAD,uint32_t{}); });
       };
 
       BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_cycle_operate()")(Catch::Benchmark::Chronometer meter){

--- a/test/cpp/src/453-va-ampm-lite-behavior.cc
+++ b/test/cpp/src/453-va-ampm-lite-behavior.cc
@@ -182,5 +182,5 @@ TEST_CASE("va_ampm_lite benchmark") {
     };
     meter.measure([&] { return uut.impl_prefetcher_final_stats(); });
   };
-  REQUIRE(true);
+  SUCCEED();
 }

--- a/test/cpp/src/453-va-ampm-lite-behavior.cc
+++ b/test/cpp/src/453-va-ampm-lite-behavior.cc
@@ -96,92 +96,90 @@ SCENARIO("The va_ampm_lite prefetcher issues prefetches when addresses stride in
   }
 }
 
-SCENARIO("va_ampm_lite is benchmarked") {
-  GIVEN("A cache using the va_ampm_lite prefetcher") {
-    BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_initialize()")(Catch::Benchmark::Chronometer meter){
-      do_nothing_MRC mock_ll;
-      do_nothing_MRC mock_lt;
-      to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
-      CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
-        .name("453-uut-benchmark[va_ampm_lite::prefetcher_initialize()]")
-        .upper_levels({&mock_ul.queues})
-        .lower_level(&mock_ll.queues)
-        .lower_translate(&mock_lt.queues)
-        .prefetcher<va_ampm_lite>()
-      };
-      meter.measure([&] { return uut.impl_prefetcher_initialize(); });
-
-    
+TEST_CASE("va_ampm_lite benchmark") {
+  BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_initialize()")(Catch::Benchmark::Chronometer meter){
+    do_nothing_MRC mock_ll;
+    do_nothing_MRC mock_lt;
+    to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
+    CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
+      .name("453-uut-benchmark[va_ampm_lite::prefetcher_initialize()]")
+      .upper_levels({&mock_ul.queues})
+      .lower_level(&mock_ll.queues)
+      .lower_translate(&mock_lt.queues)
+      .prefetcher<va_ampm_lite>()
     };
+    meter.measure([&] { return uut.impl_prefetcher_initialize(); });
 
-    BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_cache_operate()")(Catch::Benchmark::Chronometer meter){
-      do_nothing_MRC mock_ll;
-      do_nothing_MRC mock_lt;
-      to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
-      CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
-        .name("453-uut-benchmark[va_ampm_lite::prefetcher_cache_operate()]")
-        .upper_levels({&mock_ul.queues})
-        .lower_level(&mock_ll.queues)
-        .lower_translate(&mock_lt.queues)
-        .prefetcher<va_ampm_lite>()
-      };
-      meter.measure([&] { return uut.impl_prefetcher_cache_operate(champsim::address{}, champsim::address{}, false, false, access_type::LOAD,uint32_t{}); });
-    };
+  
+  };
 
-    BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_cycle_operate()")(Catch::Benchmark::Chronometer meter){
-      do_nothing_MRC mock_ll;
-      do_nothing_MRC mock_lt;
-      to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
-      CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
-        .name("453-uut-benchmark[va_ampm_lite::prefetcher_cycle_operate()]")
-        .upper_levels({&mock_ul.queues})
-        .lower_level(&mock_ll.queues)
-        .lower_translate(&mock_lt.queues)
-        .prefetcher<va_ampm_lite>()
-      };
-      meter.measure([&] { return uut.impl_prefetcher_cycle_operate(); });
+  BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_cache_operate()")(Catch::Benchmark::Chronometer meter){
+    do_nothing_MRC mock_ll;
+    do_nothing_MRC mock_lt;
+    to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
+    CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
+      .name("453-uut-benchmark[va_ampm_lite::prefetcher_cache_operate()]")
+      .upper_levels({&mock_ul.queues})
+      .lower_level(&mock_ll.queues)
+      .lower_translate(&mock_lt.queues)
+      .prefetcher<va_ampm_lite>()
     };
+    meter.measure([&] { return uut.impl_prefetcher_cache_operate(champsim::address{}, champsim::address{}, false, false, access_type::LOAD,uint32_t{}); });
+  };
 
-    BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_cache_fill()")(Catch::Benchmark::Chronometer meter){
-      do_nothing_MRC mock_ll;
-      do_nothing_MRC mock_lt;
-      to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
-      CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
-        .name("453-uut-benchmark[va_ampm_lite::prefetcher_cache_fill()]")
-        .upper_levels({&mock_ul.queues})
-        .lower_level(&mock_ll.queues)
-        .lower_translate(&mock_lt.queues)
-        .prefetcher<va_ampm_lite>()
-      };
-      meter.measure([&] { return uut.impl_prefetcher_cache_fill(champsim::address{}, long{}, long{}, uint8_t{}, champsim::address{}, uint32_t{}); });
+  BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_cycle_operate()")(Catch::Benchmark::Chronometer meter){
+    do_nothing_MRC mock_ll;
+    do_nothing_MRC mock_lt;
+    to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
+    CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
+      .name("453-uut-benchmark[va_ampm_lite::prefetcher_cycle_operate()]")
+      .upper_levels({&mock_ul.queues})
+      .lower_level(&mock_ll.queues)
+      .lower_translate(&mock_lt.queues)
+      .prefetcher<va_ampm_lite>()
     };
+    meter.measure([&] { return uut.impl_prefetcher_cycle_operate(); });
+  };
 
-    BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_branch_operate()")(Catch::Benchmark::Chronometer meter){
-      do_nothing_MRC mock_ll;
-      do_nothing_MRC mock_lt;
-      to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
-      CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
-        .name("453-uut-benchmark[va_ampm_lite::prefetcher_branch_operate()]")
-        .upper_levels({&mock_ul.queues})
-        .lower_level(&mock_ll.queues)
-        .lower_translate(&mock_lt.queues)
-        .prefetcher<va_ampm_lite>()
-      };
-      meter.measure([&] { return uut.impl_prefetcher_branch_operate(champsim::address{}, uint8_t{}, champsim::address{}); });
+  BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_cache_fill()")(Catch::Benchmark::Chronometer meter){
+    do_nothing_MRC mock_ll;
+    do_nothing_MRC mock_lt;
+    to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
+    CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
+      .name("453-uut-benchmark[va_ampm_lite::prefetcher_cache_fill()]")
+      .upper_levels({&mock_ul.queues})
+      .lower_level(&mock_ll.queues)
+      .lower_translate(&mock_lt.queues)
+      .prefetcher<va_ampm_lite>()
     };
+    meter.measure([&] { return uut.impl_prefetcher_cache_fill(champsim::address{}, long{}, long{}, uint8_t{}, champsim::address{}, uint32_t{}); });
+  };
 
-    BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_final_stats()")(Catch::Benchmark::Chronometer meter){
-      do_nothing_MRC mock_ll;
-      do_nothing_MRC mock_lt;
-      to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
-      CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
-        .name("453-uut-benchmark[va_ampm_lite::prefetcher_final_stats()]")
-        .upper_levels({&mock_ul.queues})
-        .lower_level(&mock_ll.queues)
-        .lower_translate(&mock_lt.queues)
-        .prefetcher<va_ampm_lite>()
-      };
-      meter.measure([&] { return uut.impl_prefetcher_final_stats(); });
+  BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_branch_operate()")(Catch::Benchmark::Chronometer meter){
+    do_nothing_MRC mock_ll;
+    do_nothing_MRC mock_lt;
+    to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
+    CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
+      .name("453-uut-benchmark[va_ampm_lite::prefetcher_branch_operate()]")
+      .upper_levels({&mock_ul.queues})
+      .lower_level(&mock_ll.queues)
+      .lower_translate(&mock_lt.queues)
+      .prefetcher<va_ampm_lite>()
     };
-  }
+    meter.measure([&] { return uut.impl_prefetcher_branch_operate(champsim::address{}, uint8_t{}, champsim::address{}); });
+  };
+
+  BENCHMARK_ADVANCED("va_ampm_lite::prefetcher_final_stats()")(Catch::Benchmark::Chronometer meter){
+    do_nothing_MRC mock_ll;
+    do_nothing_MRC mock_lt;
+    to_rq_MRP mock_ul{[](auto x, auto y){ return x.v_address == y.v_address; }};
+    CACHE uut{champsim::cache_builder{champsim::defaults::default_l1d}
+      .name("453-uut-benchmark[va_ampm_lite::prefetcher_final_stats()]")
+      .upper_levels({&mock_ul.queues})
+      .lower_level(&mock_ll.queues)
+      .lower_translate(&mock_lt.queues)
+      .prefetcher<va_ampm_lite>()
+    };
+    meter.measure([&] { return uut.impl_prefetcher_final_stats(); });
+  };
 }


### PR DESCRIPTION
AMPM simulation performance is currently awful. It is nearly impossible to run simulations with it, and many simulations simply stop after a short period of time without a deadlock notification. IPC speedup seems incredibly good for certain traces, but those traces quickly livelock.

This is an attempted fix for what is causing this.

I have replaced the region-lru system with an lru-table with 128 ways. I don't believe I have modified anything else about the prefetcher besides this.

The resulting simulation time is much shorter, 50x+ faster for gcc-2226B.
However, it is currently failing the AMPM test.

I would appreciate a second set of eyes on this code to help identify why this behavior is different than the previous one, outside of different eviction policy.

Another note:
With this change, I ran a sample trace for 300k instructions and got the following results for prefetch activity:
cpu0_L2C TOTAL        ACCESS:      21353 HIT:        115 MISS:      21238
cpu0_L2C LOAD         ACCESS:      21138 HIT:         74 MISS:      21064
cpu0_L2C RFO          ACCESS:          1 HIT:          0 MISS:          1
cpu0_L2C PREFETCH     ACCESS:         92 HIT:          0 MISS:         92
cpu0_L2C WRITE        ACCESS:         29 HIT:         29 MISS:          0
cpu0_L2C TRANSLATION  ACCESS:         93 HIT:         12 MISS:         81
cpu0_L2C PREFETCH REQUESTED:         92 ISSUED:         92 USEFUL:         80 USELESS:          7

Without this change, for the same trace for 300k instructions:
cpu0_L2C TOTAL        ACCESS:      45381 HIT:       4910 MISS:      40471
cpu0_L2C LOAD         ACCESS:      21137 HIT:       4871 MISS:      16266
cpu0_L2C RFO          ACCESS:          1 HIT:          0 MISS:          1
cpu0_L2C PREFETCH     ACCESS:      24133 HIT:          3 MISS:      24130
cpu0_L2C WRITE        ACCESS:         29 HIT:         29 MISS:          0
cpu0_L2C TRANSLATION  ACCESS:         81 HIT:          7 MISS:         74
cpu0_L2C PREFETCH REQUESTED:     579638 ISSUED:      24172 USEFUL:       5590 USELESS:        322

This is a very different amount of prefetcher activity, but once again I don't see why this change would happen.