### PR TITLE
Fixed Hashed Perceptron predictor

### DIFF
--- a/branch/hashed_perceptron/folded_shift_register.h
+++ b/branch/hashed_perceptron/folded_shift_register.h
@@ -1,0 +1,99 @@
+#ifndef FOLDED_SHIFT_REGISTER_H
+#define FOLDED_SHIFT_REGISTER_H
+
+#include <vector>
+
+#include "modules.h"
+#include "util/bit_enum.h"
+#include "msl/bits.h"
+#include "msl/fwcounter.h"
+
+/**
+ * @brief A shift register that folds words before it returns its value.
+ *
+ * This class maintains a history of bits that have been pushed into it.
+ * When the user asks for its value, it folds the history in WORD_LEN chunks,
+ * returning the XOR of the words.
+ */
+template <champsim::data::bits WORD_LEN>
+class folded_shift_register {
+  /*
+   * This class uses two terms: "value" and "word". A value contains one or more packed words.
+   */
+  using value_type = unsigned long long;
+  static_assert(champsim::data::bits{std::numeric_limits<value_type>::digits} >= WORD_LEN);
+  constexpr static auto NUM_WORDS_PER_VALUE = champsim::data::bits{std::numeric_limits<value_type>::digits} / WORD_LEN; // this many 12-bit words will be kept per int in the table in the global history
+  constexpr static auto VALUE_LEN = WORD_LEN * NUM_WORDS_PER_VALUE;
+
+  value_type last_value_mask; // The last word may not be the full width of the value
+  std::vector<value_type> words; // The history is represented as a series of values
+  public:
+  folded_shift_register();
+  explicit folded_shift_register(champsim::data::bits length);
+
+  std::size_t value() const;
+
+  /**
+   *  Insert this value into the shift register
+   **/
+  void push_back(bool ins);
+};
+
+template<champsim::data::bits WORD_LEN>
+folded_shift_register<WORD_LEN>::folded_shift_register()
+  : folded_shift_register(champsim::data::bits{})
+{
+}
+
+template<champsim::data::bits WORD_LEN>
+folded_shift_register<WORD_LEN>::folded_shift_register(champsim::data::bits length)
+  : last_value_mask(champsim::msl::bitmask(length % VALUE_LEN)),
+    words( (length / VALUE_LEN) + ((length % VALUE_LEN != champsim::data::bits{}) ? 1 : 0) )
+{
+}
+
+template<champsim::data::bits WORD_LEN>
+std::size_t folded_shift_register<WORD_LEN>::value() const
+{
+  // XOR all of the entries together
+  auto joined_words = std::accumulate(std::begin(words), std::end(words), value_type{}, std::bit_xor<>{});
+
+  // Unpack the words from the accumulated values
+  std::size_t result = joined_words;
+  if constexpr (NUM_WORDS_PER_VALUE > 1) {
+    for (std::size_t i = 0; i <= NUM_WORDS_PER_VALUE; ++i) {
+      joined_words >>= champsim::to_underlying(WORD_LEN);
+      result ^= joined_words;
+    }
+  }
+  return result & champsim::msl::bitmask(champsim::data::bits{WORD_LEN});
+}
+
+template<champsim::data::bits WORD_LEN>
+void folded_shift_register<WORD_LEN>::push_back(bool ins)
+{
+  /**
+   * Find the MSB of the value. This MSB will be passed along to the next word in the array.
+   */
+  auto extract_msb = [](auto x) {
+    auto msb_loc = champsim::to_underlying(VALUE_LEN)-1;
+    return (x & (value_type{1} << msb_loc)) >> msb_loc;
+  };
+
+  auto shift_and_apply_lsb = [](auto x, auto lsb){
+    return ((x << 1) | lsb) & champsim::msl::bitmask(VALUE_LEN);
+  };
+
+  // The MSBs to be passed to the next value.
+  // The vector is initialized with the new bit, so we get our shift for free.
+  std::vector<value_type> msbs = {ins ? value_type{0x1} : value_type{0x0}};
+  std::transform(std::cbegin(words), std::cend(words), std::back_inserter(msbs), extract_msb);
+  std::transform(std::cbegin(words), std::cend(words), std::begin(msbs), std::begin(words), shift_and_apply_lsb);
+
+  // Don't apply the mask if the last value is full-width
+  if (last_value_mask != value_type{}) {
+    words.back() &= last_value_mask;
+  }
+}
+
+#endif

--- a/branch/hashed_perceptron/hashed_perceptron.h
+++ b/branch/hashed_perceptron/hashed_perceptron.h
@@ -10,46 +10,34 @@
 #include "msl/bits.h"
 #include "msl/fwcounter.h"
 
+#include "folded_shift_register.h"
+
 class hashed_perceptron : champsim::modules::branch_predictor
 {
+  using bits = champsim::data::bits; // saves some typing
   constexpr static std::size_t NTABLES = 16;         // this many tables
-  constexpr static int MAXHIST = 232;                // maximum history length
-  constexpr static int MINHIST = 3;                  // minimum history length (for table 1; table 0 is biases)
+  constexpr static bits MAXHIST{232};                // maximum history length
+  constexpr static bits MINHIST{3};                  // minimum history length (for table 1; table 0 is biases)
   constexpr static std::size_t TABLE_SIZE = 1 << 12; // 12-bit indices for the tables
-  constexpr static champsim::data::bits TABLE_INDEX_BITS{champsim::msl::lg2(TABLE_SIZE)};
-  constexpr static std::size_t NGHIST_WORDS = MAXHIST / champsim::msl::lg2(TABLE_SIZE) + 1; // this many 12-bit words will be kept in the global history
+  constexpr static bits TABLE_INDEX_BITS{champsim::msl::lg2(TABLE_SIZE)};
   constexpr static int THRESHOLD = 1;
 
-  constexpr static std::array<unsigned long, NTABLES> history_lengths = {0,  3,  4,  6,  8,  10,  14,  19,
-                                                                         26, 36, 49, 67, 91, 125, 170, MAXHIST}; // geometric global history lengths
+  constexpr static std::array<bits, NTABLES> history_lengths = {bits{},  MINHIST,  bits{4},  bits{6},  bits{8},  bits{10},  bits{14},  bits{19},
+                                                                         bits{26}, bits{36}, bits{49}, bits{67}, bits{91}, bits{125}, bits{170}, MAXHIST}; // geometric global history lengths
 
   // tables of 8-bit weights
-  std::vector<std::array<champsim::msl::sfwcounter<8>, TABLE_SIZE>> tables = [] {
-    decltype(tables) retval;
-    std::generate_n(std::back_inserter(retval), std::size(history_lengths), [] { return typename decltype(retval)::value_type{}; });
-    return retval;
-  }(); // immediately invoked
+  std::array<std::array<champsim::msl::sfwcounter<8>, TABLE_SIZE>, NTABLES> tables{};
 
-  using ghist_type = std::array<unsigned long long, NGHIST_WORDS>;
-  ghist_type ghist_words = {}; // words that store the global history
+  // words that store the global history
+  using history_type = folded_shift_register<TABLE_INDEX_BITS>;
+  std::array<history_type, NTABLES> ghist_words = []() {
+    decltype(ghist_words) retval;
+    std::transform(std::cbegin(history_lengths), std::cend(history_lengths), std::begin(retval), [](const auto len){ return history_type{len}; });
+    return retval;
+  }();
 
   int theta = 10;
   int tc = 0; // counter for threshold setting algorithm
-
-  class indexer
-  {
-    ghist_type hist_masks;
-
-  public:
-    explicit indexer(unsigned long hist_len);
-    std::size_t get_index(champsim::address pc, ghist_type ghist_words) const;
-  };
-
-  std::vector<indexer> indexers = [] {
-    decltype(indexers) retval;
-    std::transform(std::begin(history_lengths), std::end(history_lengths), std::back_inserter(retval), [](unsigned long len) { return indexer{len}; });
-    return retval;
-  }(); // immediately invoked
 
   struct perceptron_result {
     std::array<uint64_t, std::tuple_size_v<decltype(history_lengths)>> indices = {}; // remember the indices into the tables from prediction to update

--- a/inc/util/bit_enum.h
+++ b/inc/util/bit_enum.h
@@ -40,5 +40,9 @@ constexpr champsim::data::bits operator+(champsim::data::bits lhs, champsim::dat
 }
 
 constexpr champsim::data::bits operator*(unsigned long long lhs, champsim::data::bits rhs) { return champsim::data::bits{lhs * champsim::to_underlying(rhs)}; }
+constexpr champsim::data::bits operator*(champsim::data::bits lhs, unsigned long long rhs) { return rhs * lhs; }
+
+constexpr auto operator/(champsim::data::bits lhs, champsim::data::bits rhs) { return champsim::to_underlying(lhs) / champsim::to_underlying(rhs); }
+constexpr champsim::data::bits operator%(champsim::data::bits lhs, champsim::data::bits rhs) { return champsim::data::bits{champsim::to_underlying(lhs) % champsim::to_underlying(rhs)}; }
 
 #endif

--- a/test/cpp/src/174-hashed-perceptron-ghist.cc
+++ b/test/cpp/src/174-hashed-perceptron-ghist.cc
@@ -1,0 +1,153 @@
+#include <catch.hpp>
+
+#include "../../../branch/hashed_perceptron/folded_shift_register.h"
+
+using global_history = folded_shift_register<champsim::data::bits{12}>;
+
+TEST_CASE("The global history can have zero length") {
+  global_history ghist{champsim::data::bits{0}};
+
+  CHECK(ghist.value() == 0);
+  ghist.push_back(true);
+  CHECK(ghist.value() == 0);
+}
+
+TEST_CASE("The global history starts at zero") {
+  global_history ghist{champsim::data::bits{170}};
+
+  REQUIRE(ghist.value() == 0);
+}
+
+TEST_CASE("The global history accepts pushes") {
+  global_history ghist{champsim::data::bits{256}};
+
+  ghist.push_back(true);
+  ghist.push_back(false);
+  REQUIRE(ghist.value() == 2);
+
+  BENCHMARK("Pushing into a folded_shift_register") {
+    ghist.push_back(true);
+  };
+
+  BENCHMARK("Finding the value of a folded_shift_register") {
+    return ghist.value();
+  };
+}
+
+TEST_CASE("The global history loses history past its length") {
+  global_history ghist{champsim::data::bits{1}};
+
+  ghist.push_back(true);
+  ghist.push_back(false);
+  REQUIRE(ghist.value() == 0);
+}
+
+TEST_CASE("The global history fold size is at least 12") {
+  global_history ghist{champsim::data::bits{170}};
+
+  auto takens = GENERATE(range(0u,11u));
+
+  for (std::size_t i = 0; i < takens; ++i) {
+    ghist.push_back(true);
+  }
+  auto evaluated = (1ull << takens) - 1;
+
+  REQUIRE(ghist.value() == evaluated);
+}
+
+TEST_CASE("The global history folds zeros onto ones") {
+  global_history ghist{champsim::data::bits{8*24}};
+
+  auto loops_of_24 = GENERATE(1u, 3u, 5u, 7u);
+
+  for (std::size_t l = 0; l < loops_of_24; ++l) {
+    for (std::size_t i = 0; i < 6; ++i) {
+      ghist.push_back(false);
+      ghist.push_back(true);
+    } // 0x555
+    for (std::size_t i = 0; i < 6; ++i) {
+      ghist.push_back(true);
+      ghist.push_back(false);
+    } // 0xaaa
+  }
+  auto evaluated = 0xfffull;
+
+  INFO("Loops of 24: " << loops_of_24);
+  REQUIRE(ghist.value() == evaluated);
+}
+
+TEST_CASE("The global history folds ones onto zeros") {
+  global_history ghist{champsim::data::bits{8*24}};
+
+  auto loops_of_24 = GENERATE(1u, 3u, 5u, 7u);
+
+  for (std::size_t l = 0; l < loops_of_24; ++l) {
+    for (std::size_t i = 0; i < 6; ++i) {
+      ghist.push_back(true);
+      ghist.push_back(false);
+    } // 0xaaa
+    for (std::size_t i = 0; i < 6; ++i) {
+      ghist.push_back(false);
+      ghist.push_back(true);
+    } // 0x555
+  }
+  auto evaluated = 0xfffull;
+
+  INFO("Loops of 24: " << loops_of_24);
+  REQUIRE(ghist.value() == evaluated);
+}
+
+TEST_CASE("The global history folds ones onto itself") {
+  global_history ghist{champsim::data::bits{170}};
+
+  auto loops_of_24 = GENERATE(range(0u, 8u));
+
+  for (std::size_t i = 0; i < 12*loops_of_24; ++i) {
+    ghist.push_back(true);
+    ghist.push_back(false);
+  } // 0xaaa
+  auto evaluated = 0ull;
+
+  INFO("Loops of 24: " << loops_of_24);
+  REQUIRE(ghist.value() == evaluated);
+}
+
+TEST_CASE("The global history folds once") {
+  global_history ghist{champsim::data::bits{24}};
+
+  auto takens = GENERATE(range(12u,23u));
+
+  for (std::size_t i = 0; i < takens; ++i) {
+    ghist.push_back(true);
+  }
+  auto evaluated = 0xfffull ^ ((1ull << (takens-12)) - 1);
+
+  REQUIRE(ghist.value() == evaluated);
+}
+
+TEST_CASE("The global history fold works when the fold size fits cleanly into the value size") {
+  constexpr static std::size_t size = 8*64;
+  folded_shift_register<champsim::data::bits{64}> ghist{champsim::data::bits{size}};
+
+  auto takens = GENERATE(range(size,size+8));
+
+  for (std::size_t i = 0; i < takens; ++i) {
+    ghist.push_back(true);
+  }
+  auto evaluated = 0ull;
+
+  REQUIRE(ghist.value() == evaluated);
+}
+
+TEST_CASE("The global history folds twice") {
+  global_history ghist{champsim::data::bits{36}};
+
+  auto takens = GENERATE(range(24u,35u));
+
+  for (std::size_t i = 0; i < takens; ++i) {
+    ghist.push_back(true);
+  }
+  auto evaluated = (1ull << (takens-24)) - 1;
+
+  REQUIRE(ghist.value() == evaluated);
+}


### PR DESCRIPTION
Somewhere along the develop history, I think I broke the hashed perceptron predictor. I believe this patch fixes that problem. I refactored the global history into its own class that folds a shift register. This class is probably worth looking at as an eventual candidate to promote to the MSL. I think it could have good general usage.

The new tests cover the global history, since that's where the bug was, but there still are no tests covering the perceptron behavior. Testing that would require the perceptron to be factored out into a testable unit. If it continues to be broken, I'll look into that.