### PR TITLE
Added downstream stats for cache, fixed cache miss latency calculations to use downstream.

### DIFF
--- a/config/instantiation_file.py
+++ b/config/instantiation_file.py
@@ -55,7 +55,7 @@ core_builder_parts = {
     '_branch_predictor_data': '.branch_predictor<{^branch_predictor_string}>()',
     '_btb_data': '.btb<{^btb_string}>()',
     '_index': '.index({_index})',
-    '^clock_period': '.clock_period(champsim::chrono::picoseconds{{{^clock_period}}})'
+    'frequency': '.clock_period(champsim::chrono::picoseconds{{{^clock_period}}})'
 }
 
 dib_builder_parts = {
@@ -84,7 +84,7 @@ cache_builder_parts = {
     '_prefetcher_data': '.prefetcher<{^prefetcher_string}>()',
     'lower_translate': '.lower_translate(&{^lower_translate_queues})',
     'lower_level': '.lower_level(&{^lower_level_queues})',
-    '^clock_period': '.clock_period(champsim::chrono::picoseconds{{{^clock_period}}})'
+    'frequency': '.clock_period(champsim::chrono::picoseconds{{{^clock_period}}})'
 }
 
 ptw_builder_parts = {
@@ -94,7 +94,7 @@ ptw_builder_parts = {
     'mshr_size': '.mshr_size({mshr_size})',
     'max_read': '.tag_bandwidth(champsim::bandwidth::maximum_type{{{max_read}}})',
     'max_write': '.fill_bandwidth(champsim::bandwidth::maximum_type{{{max_write}}})',
-    '^clock_period': '.clock_period(champsim::chrono::picoseconds{{{^clock_period}}})'
+    'frequency': '.clock_period(champsim::chrono::picoseconds{{{^clock_period}}})'
 }
 
 def vector_string(iterable):
@@ -128,7 +128,7 @@ def get_cpu_builder(cpu, caches, ul_pairs):
     builder_parts = itertools.chain(util.multiline(itertools.chain(
         ('champsim::core_builder{{ champsim::defaults::default_core }}',),
         required_parts,
-        *(util.wrap_list(v) for k,v in core_builder_parts.items() if k in cpu or k in local_params),
+        *(util.wrap_list(v) for k,v in core_builder_parts.items() if k in cpu),
         (v for k,v in dib_builder_parts.items() if k in cpu.get('DIB',{}))
     ), indent=1, line_end=''))
     yield from (part.format(**cpu, **local_params) for part in builder_parts)
@@ -170,10 +170,9 @@ def get_cache_builder(elem, ul_pairs):
     builder_parts = itertools.chain(util.multiline(itertools.chain(
         ('champsim::cache_builder{{ {^defaults} }}',),
         required_parts,
-        (v for k,v in cache_builder_parts.items() if k in elem or k in local_params),
-        (v for k,v in local_cache_builder_parts.items() if (k[0] in elem or k[0] in local_params) and k[1] == elem[k[0]])
+        (v for k,v in cache_builder_parts.items() if k in elem),
+        (v for k,v in local_cache_builder_parts.items() if k[0] in elem and k[1] == elem[k[0]])
     ), indent=1, line_end=''))
-    
     yield from (part.format(**elem, **local_params) for part in builder_parts)
 
 def get_ptw_builder(ptw, ul_pairs):
@@ -204,7 +203,7 @@ def get_ptw_builder(ptw, ul_pairs):
     builder_parts = itertools.chain(util.multiline(itertools.chain(
         ('champsim::ptw_builder{{ champsim::defaults::default_ptw }}',),
         required_parts,
-        (v for k,v in ptw_builder_parts.items() if k in ptw or k in local_params),
+        (v for k,v in ptw_builder_parts.items() if k in ptw),
         (v for keys,v in local_ptw_builder_parts.items() if any(k in ptw for k in keys))
     ), indent=1, line_end=''))
     yield from (part.format(**ptw, **local_params) for part in builder_parts)

--- a/config/instantiation_file.py
+++ b/config/instantiation_file.py
@@ -122,7 +122,6 @@ def get_cpu_builder(cpu, caches, ul_pairs):
         '^l1i_ptr': f'(*std::next(std::begin(caches), {cache_index(cpu.get("L1I"))}))',
         '^l1d_ptr': f'(*std::next(std::begin(caches), {cache_index(cpu.get("L1D"))}))'
     }
-    
     if 'frequency' in cpu:
         local_params['^clock_period'] = int(1000000/cpu['frequency'])
 
@@ -161,7 +160,6 @@ def get_cache_builder(elem, ul_pairs):
         '^prefetcher_string': ', '.join(f'class {k["class"]}' for k in elem.get('_prefetcher_data',[])),
         '^lower_level_queues': f'channels.at({ul_pairs.index((elem.get("lower_level"), elem.get("name")))})'
     }
- 
     if 'frequency' in elem:
         local_params['^clock_period'] = int(1000000/elem['frequency'])
     if 'lower_translate' in elem:
@@ -199,7 +197,6 @@ def get_ptw_builder(ptw, ul_pairs):
         '^upper_levels_string': vector_string(f'&channels.at({ul_pairs.index(v)})' for v in uppers),
         '^lower_level_queues': f'channels.at({ul_pairs.index((ptw.get("lower_level"), ptw.get("name")))})'
     }
-
     if 'frequency' in ptw:
         local_params['^clock_period'] = int(1000000/ptw['frequency'])
 

--- a/config/instantiation_file.py
+++ b/config/instantiation_file.py
@@ -115,7 +115,6 @@ def get_cpu_builder(cpu, caches, ul_pairs):
         return next(filter(lambda x: x[1]['name'] == name, enumerate(caches)))[0]
 
     local_params = {
-        '^clock_period': int(1000000/cpu['frequency']),
         '^branch_predictor_string': ', '.join(f'class {k["class"]}' for k in cpu.get('_branch_predictor_data',[])),
         '^btb_string': ', '.join(f'class {k["class"]}' for k in cpu.get('_btb_data',[])),
         '^fetch_queues': f'channels.at({ul_pairs.index((cpu.get("L1I"), cpu.get("name")))})',
@@ -123,6 +122,8 @@ def get_cpu_builder(cpu, caches, ul_pairs):
         '^l1i_ptr': f'(*std::next(std::begin(caches), {cache_index(cpu.get("L1I"))}))',
         '^l1d_ptr': f'(*std::next(std::begin(caches), {cache_index(cpu.get("L1D"))}))'
     }
+    if('frequency' in cpu):
+        local_params['^clock_period'] = int(1000000/cpu['frequency'])
 
     builder_parts = itertools.chain(util.multiline(itertools.chain(
         ('champsim::core_builder{{ champsim::defaults::default_core }}',),
@@ -152,7 +153,6 @@ def get_cache_builder(elem, ul_pairs):
 
     uppers = (v for v in ul_pairs if v[0] == elem.get('name'))
     local_params = {
-        '^clock_period': int(1000000/elem['frequency']),
         '^defaults': elem.get('_defaults', ''),
         '^upper_levels_string': vector_string(f'&channels.at({ul_pairs.index(v)})' for v in uppers),
         '^prefetch_activate_string': ', '.join('access_type::'+t for t in elem.get('prefetch_activate',[])),
@@ -160,6 +160,8 @@ def get_cache_builder(elem, ul_pairs):
         '^prefetcher_string': ', '.join(f'class {k["class"]}' for k in elem.get('_prefetcher_data',[])),
         '^lower_level_queues': f'channels.at({ul_pairs.index((elem.get("lower_level"), elem.get("name")))})'
     }
+    if('frequency' in elem):
+        local_params['^clock_period'] = int(1000000/elem['frequency'])
     if 'lower_translate' in elem:
         local_params.update({
             '^lower_translate_queues': f'channels.at({ul_pairs.index((elem.get("lower_translate"), elem.get("name")))})'
@@ -193,10 +195,11 @@ def get_ptw_builder(ptw, ul_pairs):
 
     uppers = (v for v in ul_pairs if v[0] == ptw.get('name'))
     local_params = {
-        '^clock_period': int(1000000/ptw['frequency']),
         '^upper_levels_string': vector_string(f'&channels.at({ul_pairs.index(v)})' for v in uppers),
         '^lower_level_queues': f'channels.at({ul_pairs.index((ptw.get("lower_level"), ptw.get("name")))})'
     }
+    if('frequency' in ptw):
+        local_params['^clock_period'] = int(1000000/ptw['frequency'])
 
     builder_parts = itertools.chain(util.multiline(itertools.chain(
         ('champsim::ptw_builder{{ champsim::defaults::default_ptw }}',),

--- a/inc/cache_stats.h
+++ b/inc/cache_stats.h
@@ -20,6 +20,7 @@ struct cache_stats {
 
   champsim::stats::event_counter<std::pair<access_type, std::remove_cv_t<decltype(NUM_CPUS)>>> hits = {};
   champsim::stats::event_counter<std::pair<access_type, std::remove_cv_t<decltype(NUM_CPUS)>>> misses = {};
+  champsim::stats::event_counter<std::pair<access_type, std::remove_cv_t<decltype(NUM_CPUS)>>> downstream_packets = {};
 
   long total_miss_latency_cycles{};
 };

--- a/inc/cache_stats.h
+++ b/inc/cache_stats.h
@@ -20,7 +20,8 @@ struct cache_stats {
 
   champsim::stats::event_counter<std::pair<access_type, std::remove_cv_t<decltype(NUM_CPUS)>>> hits = {};
   champsim::stats::event_counter<std::pair<access_type, std::remove_cv_t<decltype(NUM_CPUS)>>> misses = {};
-  champsim::stats::event_counter<std::pair<access_type, std::remove_cv_t<decltype(NUM_CPUS)>>> downstream_packets = {};
+  champsim::stats::event_counter<std::pair<access_type, std::remove_cv_t<decltype(NUM_CPUS)>>> mshr_merge = {};
+  champsim::stats::event_counter<std::pair<access_type, std::remove_cv_t<decltype(NUM_CPUS)>>> mshr_return = {};
 
   long total_miss_latency_cycles{};
 };

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -115,6 +115,8 @@ CACHE::mshr_type CACHE::mshr_type::merge(mshr_type predecessor, mshr_type succes
                  std::back_inserter(merged_return));
 
   mshr_type retval{(successor.type == access_type::PREFETCH) ? predecessor : successor};
+
+  //set the time enqueued to the predecessor unless its a demand into prefetch, in which case we use the successor
   retval.time_enqueued = ((successor.type != access_type::PREFETCH && predecessor.type == access_type::PREFETCH)) ? successor.time_enqueued : predecessor.time_enqueued;
   retval.instr_depend_on_me = merged_instr;
   retval.to_return = merged_return;
@@ -207,7 +209,6 @@ bool CACHE::handle_fill(const mshr_type& fill_mshr)
     if (!success) {
       return false;
     }
-    sim_stats.downstream_packets.increment(std::pair{writeback_packet.type, writeback_packet.cpu});
   }
 
   champsim::address evicting_address{};
@@ -230,10 +231,13 @@ bool CACHE::handle_fill(const mshr_type& fill_mshr)
     }
 
     *way = fill_block(fill_mshr, metadata_thru);
+    
   }
 
   // COLLECT STATS
-  sim_stats.total_miss_latency_cycles += (current_time - (fill_mshr.time_enqueued + clock_period)) / clock_period;
+  if(fill_mshr.type != access_type::PREFETCH)
+    sim_stats.total_miss_latency_cycles += (current_time - (fill_mshr.time_enqueued + clock_period)) / clock_period;
+  sim_stats.mshr_return.increment(std::pair{fill_mshr.type,fill_mshr.cpu});
 
   response_type response{fill_mshr.address, fill_mshr.v_address, fill_mshr.data_promise->data, metadata_thru, fill_mshr.instr_depend_on_me};
   for (auto* ret : fill_mshr.to_return) {
@@ -340,6 +344,9 @@ bool CACHE::handle_miss(const tag_lookup_type& handle_pkt)
       }
     }
 
+    //COLLECT STATS
+    sim_stats.mshr_merge.increment(std::pair{to_allocate.type,to_allocate.cpu});
+    
     *mshr_entry = mshr_type::merge(*mshr_entry, to_allocate);
   } else {
     if (mshr_full) { // not enough MSHR resource
@@ -352,7 +359,7 @@ bool CACHE::handle_miss(const tag_lookup_type& handle_pkt)
     if (!success) {
       return false;
     }
-    sim_stats.downstream_packets.increment(std::pair{handle_pkt.type, handle_pkt.cpu});
+    
 
     // Allocate an MSHR
     if (mshr_pkt.second.response_requested) {
@@ -864,7 +871,8 @@ void CACHE::end_phase(unsigned finished_cpu)
     std::pair key{type, finished_cpu};
     roi_stats.hits.set(key, sim_stats.hits.value_or(key, 0));
     roi_stats.misses.set(key, sim_stats.misses.value_or(key, 0));
-    roi_stats.downstream_packets.set(key,sim_stats.downstream_packets.value_or(key,0));
+    roi_stats.mshr_merge.set(key,sim_stats.mshr_merge.value_or(key,0));
+    roi_stats.mshr_return.set(key,sim_stats.mshr_return.value_or(key,0));
   }
 
   roi_stats.pf_requested = sim_stats.pf_requested;

--- a/src/json_printer.cc
+++ b/src/json_printer.cc
@@ -43,26 +43,32 @@ void to_json(nlohmann::json& j, const CACHE::stats_type& stats)
 {
   using hits_value_type = typename decltype(stats.hits)::value_type;
   using misses_value_type = typename decltype(stats.misses)::value_type;
-  using downstream_value_type = typename decltype(stats.downstream_packets)::value_type;
+  using mshr_merge_value_type = typename decltype(stats.mshr_merge)::value_type;
+  using mshr_return_value_type = typename decltype(stats.mshr_return)::value_type;
 
   std::map<std::string, nlohmann::json> statsmap;
   statsmap.emplace("prefetch requested", stats.pf_requested);
   statsmap.emplace("prefetch issued", stats.pf_issued);
   statsmap.emplace("useful prefetch", stats.pf_useful);
   statsmap.emplace("useless prefetch", stats.pf_useless);
-  statsmap.emplace("miss latency", std::ceil(stats.total_miss_latency_cycles) / std::ceil(stats.misses.total()));
+
+  uint64_t total_downstream_demands = stats.mshr_return.total();
+  for (std::size_t cpu = 0; cpu < NUM_CPUS; ++cpu) 
+    total_downstream_demands -= stats.mshr_return.value_or(std::pair{access_type::PREFETCH, cpu}, mshr_return_value_type{});
+
+  statsmap.emplace("miss latency", std::ceil(stats.total_miss_latency_cycles) / std::ceil(total_downstream_demands));
   for (const auto type : {access_type::LOAD, access_type::RFO, access_type::PREFETCH, access_type::WRITE, access_type::TRANSLATION}) {
     std::vector<hits_value_type> hits;
     std::vector<misses_value_type> misses;
-    std::vector<downstream_value_type> downstreams;
+    std::vector<mshr_merge_value_type> mshr_merges;
 
     for (std::size_t cpu = 0; cpu < NUM_CPUS; ++cpu) {
       hits.push_back(stats.hits.value_or(std::pair{type, cpu}, hits_value_type{}));
       misses.push_back(stats.misses.value_or(std::pair{type, cpu}, misses_value_type{}));
-      downstreams.push_back(stats.downstream_packets.value_or(std::pair{type, cpu}, misses_value_type{}));
+      mshr_merges.push_back(stats.mshr_merge.value_or(std::pair{type, cpu}, mshr_merge_value_type{}));
     }
 
-    statsmap.emplace(access_type_names.at(champsim::to_underlying(type)), nlohmann::json{{"hit", hits}, {"miss", misses}, {"downstream", downstreams}});
+    statsmap.emplace(access_type_names.at(champsim::to_underlying(type)), nlohmann::json{{"hit", hits}, {"miss", misses}, {"mshr_merge", mshr_merges}});
   }
 
   j = statsmap;

--- a/src/json_printer.cc
+++ b/src/json_printer.cc
@@ -43,6 +43,7 @@ void to_json(nlohmann::json& j, const CACHE::stats_type& stats)
 {
   using hits_value_type = typename decltype(stats.hits)::value_type;
   using misses_value_type = typename decltype(stats.misses)::value_type;
+  using downstream_value_type = typename decltype(stats.downstream_packets)::value_type;
 
   std::map<std::string, nlohmann::json> statsmap;
   statsmap.emplace("prefetch requested", stats.pf_requested);
@@ -53,13 +54,15 @@ void to_json(nlohmann::json& j, const CACHE::stats_type& stats)
   for (const auto type : {access_type::LOAD, access_type::RFO, access_type::PREFETCH, access_type::WRITE, access_type::TRANSLATION}) {
     std::vector<hits_value_type> hits;
     std::vector<misses_value_type> misses;
+    std::vector<downstream_value_type> downstreams;
 
     for (std::size_t cpu = 0; cpu < NUM_CPUS; ++cpu) {
       hits.push_back(stats.hits.value_or(std::pair{type, cpu}, hits_value_type{}));
       misses.push_back(stats.misses.value_or(std::pair{type, cpu}, misses_value_type{}));
+      downstreams.push_back(stats.downstream_packets.value_or(std::pair{type, cpu}, misses_value_type{}));
     }
 
-    statsmap.emplace(access_type_names.at(champsim::to_underlying(type)), nlohmann::json{{"hit", hits}, {"miss", misses}});
+    statsmap.emplace(access_type_names.at(champsim::to_underlying(type)), nlohmann::json{{"hit", hits}, {"miss", misses}, {"downstream", downstreams}});
   }
 
   j = statsmap;

--- a/src/plain_printer.cc
+++ b/src/plain_printer.cc
@@ -69,13 +69,14 @@ std::vector<std::string> champsim::plain_printer::format(CACHE::stats_type stats
 {
   using hits_value_type = typename decltype(stats.hits)::value_type;
   using misses_value_type = typename decltype(stats.misses)::value_type;
-  using downstream_value_type = typename decltype(stats.downstream_packets)::value_type;
+  using mshr_merge_value_type = typename decltype(stats.mshr_merge)::value_type;
+  using mshr_return_value_type = typename decltype(stats.mshr_return)::value_type;
 
   for (const auto type : {access_type::LOAD, access_type::RFO, access_type::PREFETCH, access_type::WRITE, access_type::TRANSLATION}) {
     for (std::size_t cpu = 0; cpu < NUM_CPUS; ++cpu) {
       stats.hits.allocate(std::pair{type, cpu});
       stats.misses.allocate(std::pair{type, cpu});
-      stats.downstream_packets.allocate(std::pair{type,cpu});
+      stats.mshr_merge.allocate(std::pair{type,cpu});
     }
   }
 
@@ -83,26 +84,28 @@ std::vector<std::string> champsim::plain_printer::format(CACHE::stats_type stats
   for (std::size_t cpu = 0; cpu < NUM_CPUS; ++cpu) {
     hits_value_type total_hits = 0;
     misses_value_type total_misses = 0;
-    downstream_value_type total_downstreams = 0;
+    mshr_merge_value_type total_mshr_merge = 0;
     for (const auto type : {access_type::LOAD, access_type::RFO, access_type::PREFETCH, access_type::WRITE, access_type::TRANSLATION}) {
       total_hits += stats.hits.value_or(std::pair{type, cpu}, hits_value_type{});
       total_misses += stats.misses.value_or(std::pair{type, cpu}, misses_value_type{});
-      total_downstreams += stats.downstream_packets.value_or(std::pair{type,cpu}, downstream_value_type{});
+      total_mshr_merge += stats.mshr_merge.value_or(std::pair{type,cpu}, mshr_merge_value_type{});
     }
 
-    fmt::format_string<std::string_view, std::string_view, int, int, int> hitmiss_fmtstr{"{} {:<12s} ACCESS: {:10d} HIT: {:10d} MISS: {:10d} DOWNSTREAM: {:10d}"};
-    lines.push_back(fmt::format(hitmiss_fmtstr, stats.name, "TOTAL", total_hits + total_misses, total_hits, total_misses, total_downstreams));
+    fmt::format_string<std::string_view, std::string_view, int, int, int> hitmiss_fmtstr{"{} {:<12s} ACCESS: {:10d} HIT: {:10d} MISS: {:10d} MSHR_MERGE: {:10d}"};
+    lines.push_back(fmt::format(hitmiss_fmtstr, stats.name, "TOTAL", total_hits + total_misses, total_hits, total_misses, total_mshr_merge));
     for (const auto type : {access_type::LOAD, access_type::RFO, access_type::PREFETCH, access_type::WRITE, access_type::TRANSLATION}) {
       lines.push_back(
           fmt::format(hitmiss_fmtstr, stats.name, access_type_names.at(champsim::to_underlying(type)),
                       stats.hits.value_or(std::pair{type, cpu}, hits_value_type{}) + stats.misses.value_or(std::pair{type, cpu}, misses_value_type{}),
                       stats.hits.value_or(std::pair{type, cpu}, hits_value_type{}), stats.misses.value_or(std::pair{type, cpu}, misses_value_type{}),
-                      stats.downstream_packets.value_or(std::pair{type, cpu}, downstream_value_type{})));
+                      stats.mshr_merge.value_or(std::pair{type, cpu}, mshr_merge_value_type{})));
     }
 
     lines.push_back(fmt::format("{} PREFETCH REQUESTED: {:10} ISSUED: {:10} USEFUL: {:10} USELESS: {:10}", stats.name, stats.pf_requested, stats.pf_issued,
                                 stats.pf_useful, stats.pf_useless));
-    lines.push_back(fmt::format("{} AVERAGE MISS LATENCY: {} cycles", stats.name, ::print_ratio(stats.total_miss_latency_cycles, stats.downstream_packets.total() - stats.downstream_packets.value_or(std::pair{access_type::WRITE,cpu},downstream_value_type{}))));
+
+    uint64_t total_downstream_demands = stats.mshr_return.total() - stats.mshr_return.value_or(std::pair{access_type::PREFETCH, cpu}, mshr_return_value_type{});
+    lines.push_back(fmt::format("{} AVERAGE MISS LATENCY: {} cycles", stats.name, ::print_ratio(stats.total_miss_latency_cycles,total_downstream_demands)));
   }
 
   return lines;

--- a/src/plain_printer.cc
+++ b/src/plain_printer.cc
@@ -69,11 +69,13 @@ std::vector<std::string> champsim::plain_printer::format(CACHE::stats_type stats
 {
   using hits_value_type = typename decltype(stats.hits)::value_type;
   using misses_value_type = typename decltype(stats.misses)::value_type;
+  using downstream_value_type = typename decltype(stats.downstream_packets)::value_type;
 
   for (const auto type : {access_type::LOAD, access_type::RFO, access_type::PREFETCH, access_type::WRITE, access_type::TRANSLATION}) {
     for (std::size_t cpu = 0; cpu < NUM_CPUS; ++cpu) {
       stats.hits.allocate(std::pair{type, cpu});
       stats.misses.allocate(std::pair{type, cpu});
+      stats.downstream_packets.allocate(std::pair{type,cpu});
     }
   }
 
@@ -81,23 +83,26 @@ std::vector<std::string> champsim::plain_printer::format(CACHE::stats_type stats
   for (std::size_t cpu = 0; cpu < NUM_CPUS; ++cpu) {
     hits_value_type total_hits = 0;
     misses_value_type total_misses = 0;
+    downstream_value_type total_downstreams = 0;
     for (const auto type : {access_type::LOAD, access_type::RFO, access_type::PREFETCH, access_type::WRITE, access_type::TRANSLATION}) {
       total_hits += stats.hits.value_or(std::pair{type, cpu}, hits_value_type{});
       total_misses += stats.misses.value_or(std::pair{type, cpu}, misses_value_type{});
+      total_downstreams += stats.downstream_packets.value_or(std::pair{type,cpu}, downstream_value_type{});
     }
 
-    fmt::format_string<std::string_view, std::string_view, int, int, int> hitmiss_fmtstr{"{} {:<12s} ACCESS: {:10d} HIT: {:10d} MISS: {:10d}"};
-    lines.push_back(fmt::format(hitmiss_fmtstr, stats.name, "TOTAL", total_hits + total_misses, total_hits, total_misses));
+    fmt::format_string<std::string_view, std::string_view, int, int, int> hitmiss_fmtstr{"{} {:<12s} ACCESS: {:10d} HIT: {:10d} MISS: {:10d} DOWNSTREAM: {:10d}"};
+    lines.push_back(fmt::format(hitmiss_fmtstr, stats.name, "TOTAL", total_hits + total_misses, total_hits, total_misses, total_downstreams));
     for (const auto type : {access_type::LOAD, access_type::RFO, access_type::PREFETCH, access_type::WRITE, access_type::TRANSLATION}) {
       lines.push_back(
           fmt::format(hitmiss_fmtstr, stats.name, access_type_names.at(champsim::to_underlying(type)),
                       stats.hits.value_or(std::pair{type, cpu}, hits_value_type{}) + stats.misses.value_or(std::pair{type, cpu}, misses_value_type{}),
-                      stats.hits.value_or(std::pair{type, cpu}, hits_value_type{}), stats.misses.value_or(std::pair{type, cpu}, misses_value_type{})));
+                      stats.hits.value_or(std::pair{type, cpu}, hits_value_type{}), stats.misses.value_or(std::pair{type, cpu}, misses_value_type{}),
+                      stats.downstream_packets.value_or(std::pair{type, cpu}, downstream_value_type{})));
     }
 
     lines.push_back(fmt::format("{} PREFETCH REQUESTED: {:10} ISSUED: {:10} USEFUL: {:10} USELESS: {:10}", stats.name, stats.pf_requested, stats.pf_issued,
                                 stats.pf_useful, stats.pf_useless));
-    lines.push_back(fmt::format("{} AVERAGE MISS LATENCY: {} cycles", stats.name, ::print_ratio(stats.total_miss_latency_cycles, stats.misses.total())));
+    lines.push_back(fmt::format("{} AVERAGE MISS LATENCY: {} cycles", stats.name, ::print_ratio(stats.total_miss_latency_cycles, stats.downstream_packets.total() - stats.downstream_packets.value_or(std::pair{access_type::WRITE,cpu},downstream_value_type{}))));
   }
 
   return lines;

--- a/test/cpp/src/402-miss-latency.cc
+++ b/test/cpp/src/402-miss-latency.cc
@@ -81,14 +81,14 @@ SCENARIO("A cache returns a miss after the specified latency") {
         REQUIRE(uut.sim_stats.misses.value_or(std::pair{test.type, test.cpu},0) == initial_misses + 1);
       }
 
-      THEN("The average miss latency increases") {
-        REQUIRE(uut.sim_stats.total_miss_latency_cycles == miss_latency + fill_latency);
+      THEN("The average miss latency increases only on demand fetches") {
+        REQUIRE(uut.sim_stats.total_miss_latency_cycles == (type != access_type::PREFETCH ? miss_latency + fill_latency : 0));
       }
 
-      THEN("The end-of-phase average miss latency increases") {
+      THEN("The end-of-phase average miss latency increases only on demand fetches") {
         uut.end_phase(0);
-        REQUIRE(uut.sim_stats.total_miss_latency_cycles == miss_latency + fill_latency);
-        REQUIRE(uut.roi_stats.total_miss_latency_cycles == miss_latency + fill_latency);
+        REQUIRE(uut.sim_stats.total_miss_latency_cycles == (type != access_type::PREFETCH ? miss_latency + fill_latency : 0));
+        REQUIRE(uut.roi_stats.total_miss_latency_cycles == (type != access_type::PREFETCH ? miss_latency + fill_latency : 0));
       }
     }
   }

--- a/test/cpp/src/425-useless-prefetch.cc
+++ b/test/cpp/src/425-useless-prefetch.cc
@@ -37,6 +37,7 @@ SCENARIO("A cache increments the useless prefetch count when it evicts an unhit 
 
     WHEN("A packet is sent") {
       const champsim::address seed_addr{0xdeadbeef};
+      long old_miss_cycles = uut.sim_stats.total_miss_latency_cycles;
       auto seed_result = uut.prefetch_line(seed_addr, true, 0);
 
       for (auto i = 0; i < 2*(miss_latency+hit_latency); ++i)
@@ -46,6 +47,10 @@ SCENARIO("A cache increments the useless prefetch count when it evicts an unhit 
       THEN("The issue is received") {
         CHECK(seed_result);
         CHECK_THAT(mock_ll.addresses, Catch::Matchers::RangeEquals(std::vector({seed_addr})));
+      }
+
+      THEN("The average miss latency does not change") {
+          REQUIRE(uut.sim_stats.total_miss_latency_cycles == old_miss_cycles);
       }
 
       AND_WHEN("A packet with a different address is sent") {

--- a/test/cpp/src/431-merge-prefetch.cc
+++ b/test/cpp/src/431-merge-prefetch.cc
@@ -102,6 +102,19 @@ SCENARIO("A prefetch MSHR that gets hit is promoted") {
         //CHECK(testbed.uut.MSHR.front().instr_id == 1);
         CHECK_THAT(testbed.uut.MSHR.front().to_return, Catch::Matchers::SizeIs(2));
       }
+
+      AND_WHEN("The MSHR is closed") {
+        champsim::channel::response_type response{testbed.uut.MSHR.front().address, testbed.uut.MSHR.front().v_address, testbed.uut.MSHR.front().data_promise->data, 0, testbed.uut.MSHR.front().instr_depend_on_me};
+
+        testbed.uut.lower_level->returned.push_back(response);
+        for (uint64_t i = 0; i < 8*(testbed.hit_latency); ++i)
+          for (auto elem : testbed.elements)
+            elem->_operate();
+        
+        THEN("The average miss latency is reduced") {
+          REQUIRE(std::llabs(testbed.uut.sim_stats.total_miss_latency_cycles) < testbed.hit_latency);
+        }
+      }
     }
   }
 }

--- a/test/cpp/src/498-cache-plain-printer.cc
+++ b/test/cpp/src/498-cache-plain-printer.cc
@@ -8,12 +8,12 @@ TEST_CASE("An empty cache stat block prints all zeros") {
   given.name = "test_cache";
 
   std::vector<std::string> expected{
-    "test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0",
+    "test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
     "test_cache PREFETCH REQUESTED:          0 ISSUED:          0 USEFUL:          0 USELESS:          0",
     "test_cache AVERAGE MISS LATENCY: - cycles"
   };
@@ -24,11 +24,11 @@ TEST_CASE("An empty cache stat block prints all zeros") {
 TEST_CASE("Hits increment the hit and access counts") {
   auto num_hits = 255;
   auto [line_index, hit_type, expected_line] = GENERATE(as<std::tuple<std::size_t, access_type, std::string>>{},
-      std::tuple{1, access_type::LOAD, "test_cache LOAD         ACCESS:        255 HIT:        255 MISS:          0"},
-      std::tuple{2, access_type::RFO, "test_cache RFO          ACCESS:        255 HIT:        255 MISS:          0"},
-      std::tuple{3, access_type::PREFETCH, "test_cache PREFETCH     ACCESS:        255 HIT:        255 MISS:          0"},
-      std::tuple{4, access_type::WRITE, "test_cache WRITE        ACCESS:        255 HIT:        255 MISS:          0"},
-      std::tuple{5, access_type::TRANSLATION, "test_cache TRANSLATION  ACCESS:        255 HIT:        255 MISS:          0"}
+      std::tuple{1, access_type::LOAD, "test_cache LOAD         ACCESS:        255 HIT:        255 MISS:          0 DOWNSTREAM:          0"},
+      std::tuple{2, access_type::RFO, "test_cache RFO          ACCESS:        255 HIT:        255 MISS:          0 DOWNSTREAM:          0"},
+      std::tuple{3, access_type::PREFETCH, "test_cache PREFETCH     ACCESS:        255 HIT:        255 MISS:          0 DOWNSTREAM:          0"},
+      std::tuple{4, access_type::WRITE, "test_cache WRITE        ACCESS:        255 HIT:        255 MISS:          0 DOWNSTREAM:          0"},
+      std::tuple{5, access_type::TRANSLATION, "test_cache TRANSLATION  ACCESS:        255 HIT:        255 MISS:          0 DOWNSTREAM:          0"}
   );
 
   cache_stats given{};
@@ -36,12 +36,12 @@ TEST_CASE("Hits increment the hit and access counts") {
   given.hits.set({hit_type, 0}, num_hits);
 
   std::vector<std::string> expected{
-    "test_cache TOTAL        ACCESS:        255 HIT:        255 MISS:          0",
-    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0",
+    "test_cache TOTAL        ACCESS:        255 HIT:        255 MISS:          0 DOWNSTREAM:          0",
+    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
     "test_cache PREFETCH REQUESTED:          0 ISSUED:          0 USEFUL:          0 USELESS:          0",
     "test_cache AVERAGE MISS LATENCY: - cycles"
   };
@@ -53,11 +53,11 @@ TEST_CASE("Hits increment the hit and access counts") {
 TEST_CASE("Misses increment the miss and access counts") {
   auto num_misses = 255;
   auto [line_index, miss_type, expected_line] = GENERATE(as<std::tuple<std::size_t, access_type, std::string>>{},
-      std::tuple{1, access_type::LOAD, "test_cache LOAD         ACCESS:        255 HIT:          0 MISS:        255"},
-      std::tuple{2, access_type::RFO, "test_cache RFO          ACCESS:        255 HIT:          0 MISS:        255"},
-      std::tuple{3, access_type::PREFETCH, "test_cache PREFETCH     ACCESS:        255 HIT:          0 MISS:        255"},
-      std::tuple{4, access_type::WRITE, "test_cache WRITE        ACCESS:        255 HIT:          0 MISS:        255"},
-      std::tuple{5, access_type::TRANSLATION, "test_cache TRANSLATION  ACCESS:        255 HIT:          0 MISS:        255"}
+      std::tuple{1, access_type::LOAD, "test_cache LOAD         ACCESS:        255 HIT:          0 MISS:        255 DOWNSTREAM:          0"},
+      std::tuple{2, access_type::RFO, "test_cache RFO          ACCESS:        255 HIT:          0 MISS:        255 DOWNSTREAM:          0"},
+      std::tuple{3, access_type::PREFETCH, "test_cache PREFETCH     ACCESS:        255 HIT:          0 MISS:        255 DOWNSTREAM:          0"},
+      std::tuple{4, access_type::WRITE, "test_cache WRITE        ACCESS:        255 HIT:          0 MISS:        255 DOWNSTREAM:          0"},
+      std::tuple{5, access_type::TRANSLATION, "test_cache TRANSLATION  ACCESS:        255 HIT:          0 MISS:        255 DOWNSTREAM:          0"}
   );
 
   cache_stats given{};
@@ -65,46 +65,47 @@ TEST_CASE("Misses increment the miss and access counts") {
   given.misses.set({miss_type, 0}, num_misses);
 
   std::vector<std::string> expected{
-    "test_cache TOTAL        ACCESS:        255 HIT:          0 MISS:        255",
-    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0",
+    "test_cache TOTAL        ACCESS:        255 HIT:          0 MISS:        255 DOWNSTREAM:          0",
+    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
     "test_cache PREFETCH REQUESTED:          0 ISSUED:          0 USEFUL:          0 USELESS:          0",
-    "test_cache AVERAGE MISS LATENCY: 0 cycles"
+    "test_cache AVERAGE MISS LATENCY: - cycles"
   };
   expected.at(line_index) = expected_line;
 
   REQUIRE_THAT(champsim::plain_printer::format(given), Catch::Matchers::RangeEquals(expected));
 }
 
-TEST_CASE("Misses increment the AMAT") {
-  auto num_misses = 255;
-  auto miss_latency = GENERATE(1,2,6);
+TEST_CASE("Downstreams increment the AMAT") {
+  auto num_downstream = 255;
+  auto downstream_latency = GENERATE(1,2,6);
   auto [line_index, miss_type, expected_line] = GENERATE(as<std::tuple<std::size_t, access_type, std::string>>{},
-      std::tuple{1, access_type::LOAD, "test_cache LOAD         ACCESS:        255 HIT:          0 MISS:        255"},
-      std::tuple{2, access_type::RFO, "test_cache RFO          ACCESS:        255 HIT:          0 MISS:        255"},
-      std::tuple{3, access_type::PREFETCH, "test_cache PREFETCH     ACCESS:        255 HIT:          0 MISS:        255"},
-      std::tuple{4, access_type::WRITE, "test_cache WRITE        ACCESS:        255 HIT:          0 MISS:        255"},
-      std::tuple{5, access_type::TRANSLATION, "test_cache TRANSLATION  ACCESS:        255 HIT:          0 MISS:        255"}
+      std::tuple{1, access_type::LOAD, "test_cache LOAD         ACCESS:        255 HIT:          0 MISS:        255 DOWNSTREAM:        255"},
+      std::tuple{2, access_type::RFO, "test_cache RFO          ACCESS:        255 HIT:          0 MISS:        255 DOWNSTREAM:        255"},
+      std::tuple{3, access_type::PREFETCH, "test_cache PREFETCH     ACCESS:        255 HIT:          0 MISS:        255 DOWNSTREAM:        255"},
+      //std::tuple{4, access_type::WRITE, "test_cache WRITE        ACCESS:        255 HIT:          0 MISS:        255 DOWNSTREAM:        255"},
+      std::tuple{5, access_type::TRANSLATION, "test_cache TRANSLATION  ACCESS:        255 HIT:          0 MISS:        255 DOWNSTREAM:        255"}
   );
 
   cache_stats given{};
   given.name = "test_cache";
-  given.misses.set({miss_type, 0}, num_misses);
-  given.total_miss_latency_cycles = miss_latency*num_misses;
+  given.downstream_packets.set({miss_type, 0}, num_downstream);
+  given.misses.set({miss_type,0}, num_downstream);
+  given.total_miss_latency_cycles = downstream_latency*num_downstream;
 
   std::vector<std::string> expected{
-    "test_cache TOTAL        ACCESS:        255 HIT:          0 MISS:        255",
-    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0",
+    "test_cache TOTAL        ACCESS:        255 HIT:          0 MISS:        255 DOWNSTREAM:        255",
+    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
     "test_cache PREFETCH REQUESTED:          0 ISSUED:          0 USEFUL:          0 USELESS:          0",
   };
-  expected.push_back("test_cache AVERAGE MISS LATENCY: " + std::to_string(miss_latency) + " cycles");
+  expected.push_back("test_cache AVERAGE MISS LATENCY: " + std::to_string(downstream_latency) + " cycles");
   expected.at(line_index) = expected_line;
 
   REQUIRE_THAT(champsim::plain_printer::format(given), Catch::Matchers::RangeEquals(expected));
@@ -116,12 +117,12 @@ TEST_CASE("Prefetch requests increase the count") {
   given.pf_requested = 1;
 
   std::vector<std::string> expected{
-    "test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0",
+    "test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
     "test_cache PREFETCH REQUESTED:          1 ISSUED:          0 USEFUL:          0 USELESS:          0",
     "test_cache AVERAGE MISS LATENCY: - cycles"
   };
@@ -135,12 +136,12 @@ TEST_CASE("Prefetch issues increase the count") {
   given.pf_issued = 1;
 
   std::vector<std::string> expected{
-    "test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0",
+    "test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
     "test_cache PREFETCH REQUESTED:          0 ISSUED:          1 USEFUL:          0 USELESS:          0",
     "test_cache AVERAGE MISS LATENCY: - cycles"
   };
@@ -154,12 +155,12 @@ TEST_CASE("Prefetch useful increases the count") {
   given.pf_useful = 1;
 
   std::vector<std::string> expected{
-    "test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0",
+    "test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
     "test_cache PREFETCH REQUESTED:          0 ISSUED:          0 USEFUL:          1 USELESS:          0",
     "test_cache AVERAGE MISS LATENCY: - cycles"
   };
@@ -173,12 +174,12 @@ TEST_CASE("Prefetch useless increases the count") {
   given.pf_useless = 1;
 
   std::vector<std::string> expected{
-    "test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0",
-    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0",
+    "test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
     "test_cache PREFETCH REQUESTED:          0 ISSUED:          0 USEFUL:          0 USELESS:          1",
     "test_cache AVERAGE MISS LATENCY: - cycles"
   };

--- a/test/cpp/src/498-cache-plain-printer.cc
+++ b/test/cpp/src/498-cache-plain-printer.cc
@@ -8,12 +8,12 @@ TEST_CASE("An empty cache stat block prints all zeros") {
   given.name = "test_cache";
 
   std::vector<std::string> expected{
-    "test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
     "test_cache PREFETCH REQUESTED:          0 ISSUED:          0 USEFUL:          0 USELESS:          0",
     "test_cache AVERAGE MISS LATENCY: - cycles"
   };
@@ -24,11 +24,11 @@ TEST_CASE("An empty cache stat block prints all zeros") {
 TEST_CASE("Hits increment the hit and access counts") {
   auto num_hits = 255;
   auto [line_index, hit_type, expected_line] = GENERATE(as<std::tuple<std::size_t, access_type, std::string>>{},
-      std::tuple{1, access_type::LOAD, "test_cache LOAD         ACCESS:        255 HIT:        255 MISS:          0 DOWNSTREAM:          0"},
-      std::tuple{2, access_type::RFO, "test_cache RFO          ACCESS:        255 HIT:        255 MISS:          0 DOWNSTREAM:          0"},
-      std::tuple{3, access_type::PREFETCH, "test_cache PREFETCH     ACCESS:        255 HIT:        255 MISS:          0 DOWNSTREAM:          0"},
-      std::tuple{4, access_type::WRITE, "test_cache WRITE        ACCESS:        255 HIT:        255 MISS:          0 DOWNSTREAM:          0"},
-      std::tuple{5, access_type::TRANSLATION, "test_cache TRANSLATION  ACCESS:        255 HIT:        255 MISS:          0 DOWNSTREAM:          0"}
+      std::tuple{1, access_type::LOAD, "test_cache LOAD         ACCESS:        255 HIT:        255 MISS:          0 MSHR_MERGE:          0"},
+      std::tuple{2, access_type::RFO, "test_cache RFO          ACCESS:        255 HIT:        255 MISS:          0 MSHR_MERGE:          0"},
+      std::tuple{3, access_type::PREFETCH, "test_cache PREFETCH     ACCESS:        255 HIT:        255 MISS:          0 MSHR_MERGE:          0"},
+      std::tuple{4, access_type::WRITE, "test_cache WRITE        ACCESS:        255 HIT:        255 MISS:          0 MSHR_MERGE:          0"},
+      std::tuple{5, access_type::TRANSLATION, "test_cache TRANSLATION  ACCESS:        255 HIT:        255 MISS:          0 MSHR_MERGE:          0"}
   );
 
   cache_stats given{};
@@ -36,12 +36,12 @@ TEST_CASE("Hits increment the hit and access counts") {
   given.hits.set({hit_type, 0}, num_hits);
 
   std::vector<std::string> expected{
-    "test_cache TOTAL        ACCESS:        255 HIT:        255 MISS:          0 DOWNSTREAM:          0",
-    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache TOTAL        ACCESS:        255 HIT:        255 MISS:          0 MSHR_MERGE:          0",
+    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
     "test_cache PREFETCH REQUESTED:          0 ISSUED:          0 USEFUL:          0 USELESS:          0",
     "test_cache AVERAGE MISS LATENCY: - cycles"
   };
@@ -53,11 +53,11 @@ TEST_CASE("Hits increment the hit and access counts") {
 TEST_CASE("Misses increment the miss and access counts") {
   auto num_misses = 255;
   auto [line_index, miss_type, expected_line] = GENERATE(as<std::tuple<std::size_t, access_type, std::string>>{},
-      std::tuple{1, access_type::LOAD, "test_cache LOAD         ACCESS:        255 HIT:          0 MISS:        255 DOWNSTREAM:          0"},
-      std::tuple{2, access_type::RFO, "test_cache RFO          ACCESS:        255 HIT:          0 MISS:        255 DOWNSTREAM:          0"},
-      std::tuple{3, access_type::PREFETCH, "test_cache PREFETCH     ACCESS:        255 HIT:          0 MISS:        255 DOWNSTREAM:          0"},
-      std::tuple{4, access_type::WRITE, "test_cache WRITE        ACCESS:        255 HIT:          0 MISS:        255 DOWNSTREAM:          0"},
-      std::tuple{5, access_type::TRANSLATION, "test_cache TRANSLATION  ACCESS:        255 HIT:          0 MISS:        255 DOWNSTREAM:          0"}
+      std::tuple{1, access_type::LOAD, "test_cache LOAD         ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:          0"},
+      std::tuple{2, access_type::RFO, "test_cache RFO          ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:          0"},
+      std::tuple{3, access_type::PREFETCH, "test_cache PREFETCH     ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:          0"},
+      std::tuple{4, access_type::WRITE, "test_cache WRITE        ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:          0"},
+      std::tuple{5, access_type::TRANSLATION, "test_cache TRANSLATION  ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:          0"}
   );
 
   cache_stats given{};
@@ -65,12 +65,12 @@ TEST_CASE("Misses increment the miss and access counts") {
   given.misses.set({miss_type, 0}, num_misses);
 
   std::vector<std::string> expected{
-    "test_cache TOTAL        ACCESS:        255 HIT:          0 MISS:        255 DOWNSTREAM:          0",
-    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache TOTAL        ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:          0",
+    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
     "test_cache PREFETCH REQUESTED:          0 ISSUED:          0 USEFUL:          0 USELESS:          0",
     "test_cache AVERAGE MISS LATENCY: - cycles"
   };
@@ -79,33 +79,35 @@ TEST_CASE("Misses increment the miss and access counts") {
   REQUIRE_THAT(champsim::plain_printer::format(given), Catch::Matchers::RangeEquals(expected));
 }
 
-TEST_CASE("Downstreams increment the AMAT") {
-  auto num_downstream = 255;
-  auto downstream_latency = GENERATE(1,2,6);
+TEST_CASE("Returning MSHRs increment the AMAT") {
+  auto num_mshr_returned = 128;
+  auto num_mshr_merged = 127;
+  auto mshr_return_latency = GENERATE(1,2,6);
   auto [line_index, miss_type, expected_line] = GENERATE(as<std::tuple<std::size_t, access_type, std::string>>{},
-      std::tuple{1, access_type::LOAD, "test_cache LOAD         ACCESS:        255 HIT:          0 MISS:        255 DOWNSTREAM:        255"},
-      std::tuple{2, access_type::RFO, "test_cache RFO          ACCESS:        255 HIT:          0 MISS:        255 DOWNSTREAM:        255"},
-      std::tuple{3, access_type::PREFETCH, "test_cache PREFETCH     ACCESS:        255 HIT:          0 MISS:        255 DOWNSTREAM:        255"},
-      //std::tuple{4, access_type::WRITE, "test_cache WRITE        ACCESS:        255 HIT:          0 MISS:        255 DOWNSTREAM:        255"},
-      std::tuple{5, access_type::TRANSLATION, "test_cache TRANSLATION  ACCESS:        255 HIT:          0 MISS:        255 DOWNSTREAM:        255"}
+      std::tuple{1, access_type::LOAD, "test_cache LOAD         ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:        127"},
+      std::tuple{2, access_type::RFO, "test_cache RFO          ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:        127"},
+      //std::tuple{3, access_type::PREFETCH, "test_cache PREFETCH     ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:        127"},
+      std::tuple{4, access_type::WRITE, "test_cache WRITE        ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:        127"},
+      std::tuple{5, access_type::TRANSLATION, "test_cache TRANSLATION  ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:        127"}
   );
 
   cache_stats given{};
   given.name = "test_cache";
-  given.downstream_packets.set({miss_type, 0}, num_downstream);
-  given.misses.set({miss_type,0}, num_downstream);
-  given.total_miss_latency_cycles = downstream_latency*num_downstream;
+  given.mshr_return.set({miss_type, 0}, num_mshr_returned);
+  given.mshr_merge.set({miss_type, 0}, num_mshr_merged);
+  given.misses.set({miss_type,0}, num_mshr_merged + num_mshr_returned);
+  given.total_miss_latency_cycles = mshr_return_latency*num_mshr_returned;
 
   std::vector<std::string> expected{
-    "test_cache TOTAL        ACCESS:        255 HIT:          0 MISS:        255 DOWNSTREAM:        255",
-    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache TOTAL        ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:        127",
+    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
     "test_cache PREFETCH REQUESTED:          0 ISSUED:          0 USEFUL:          0 USELESS:          0",
   };
-  expected.push_back("test_cache AVERAGE MISS LATENCY: " + std::to_string(downstream_latency) + " cycles");
+  expected.push_back("test_cache AVERAGE MISS LATENCY: " + std::to_string(mshr_return_latency) + " cycles");
   expected.at(line_index) = expected_line;
 
   REQUIRE_THAT(champsim::plain_printer::format(given), Catch::Matchers::RangeEquals(expected));
@@ -117,12 +119,12 @@ TEST_CASE("Prefetch requests increase the count") {
   given.pf_requested = 1;
 
   std::vector<std::string> expected{
-    "test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
     "test_cache PREFETCH REQUESTED:          1 ISSUED:          0 USEFUL:          0 USELESS:          0",
     "test_cache AVERAGE MISS LATENCY: - cycles"
   };
@@ -136,12 +138,12 @@ TEST_CASE("Prefetch issues increase the count") {
   given.pf_issued = 1;
 
   std::vector<std::string> expected{
-    "test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
     "test_cache PREFETCH REQUESTED:          0 ISSUED:          1 USEFUL:          0 USELESS:          0",
     "test_cache AVERAGE MISS LATENCY: - cycles"
   };
@@ -155,12 +157,12 @@ TEST_CASE("Prefetch useful increases the count") {
   given.pf_useful = 1;
 
   std::vector<std::string> expected{
-    "test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
     "test_cache PREFETCH REQUESTED:          0 ISSUED:          0 USEFUL:          1 USELESS:          0",
     "test_cache AVERAGE MISS LATENCY: - cycles"
   };
@@ -174,12 +176,12 @@ TEST_CASE("Prefetch useless increases the count") {
   given.pf_useless = 1;
 
   std::vector<std::string> expected{
-    "test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
-    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 DOWNSTREAM:          0",
+    "test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
     "test_cache PREFETCH REQUESTED:          0 ISSUED:          0 USEFUL:          0 USELESS:          1",
     "test_cache AVERAGE MISS LATENCY: - cycles"
   };


### PR DESCRIPTION
Three things this pr covers:
1. Added downstream stats to the cache. This shows how many of each type of packet went downstream from said cache. This should always be <= misses, but does not count misses that hit in the mshr. It should match up with accesses to the downstream cache/dram.
2. Cache miss latency is now calculated as the total time each MSHR was open divided by the number of downstream packets (excluding writes) from that cache. If a demand merges into a prefetch, then right now it updates the open time to the demand. I am not sure if this should be done or not. I can imagine that many prefetches never get a demand merge, so this change doesn't seem too meaningful, unless we only count demands when calculating the miss latency.
3. instantiation_file.py had a bug where clock_period would not be set for operables. This was due to clock period not being a defined field within the cache, cpu, and ptw by the user. I made some modifications that should fix that issue.
resolves #535 