### PR TITLE
Fixed bug where loads with register dependencies would issue early

### DIFF
--- a/inc/ooo_cpu.h
+++ b/inc/ooo_cpu.h
@@ -65,7 +65,7 @@ public:
 struct LSQ_ENTRY : champsim::program_ordered<LSQ_ENTRY> {
   champsim::address virtual_address{};
   champsim::address ip{};
-  champsim::chrono::clock::time_point ready_time{};
+  champsim::chrono::clock::time_point ready_time{champsim::chrono::clock::time_point::max()};
 
   std::array<uint8_t, 2> asid = {std::numeric_limits<uint8_t>::max(), std::numeric_limits<uint8_t>::max()};
   bool fetch_issued = false;

--- a/test/cpp/src/250-load-scheduling.cc
+++ b/test/cpp/src/250-load-scheduling.cc
@@ -1,0 +1,64 @@
+#include <catch.hpp>
+#include "mocks.hpp"
+#include "ooo_cpu.h"
+#include "instr.h"
+
+SCENARIO("The core issues loads only after its registers are finished") {
+  GIVEN("A DISPATCH_BUFFER with a register RAW and memory source") {
+    do_nothing_MRC mock_L1I, mock_L1D;
+    O3_CPU uut{champsim::core_builder{}
+      .fetch_queues(&mock_L1I.queues)
+      .data_queues(&mock_L1D.queues)
+      .dispatch_width(champsim::bandwidth::maximum_type{2})
+      .rob_size(2)
+      .lq_size(1)
+    };
+
+    auto producer = champsim::test::instruction_with_ip(champsim::address{2000});
+    producer.destination_registers.push_back(1);
+    producer.instr_id = 1;
+    auto consumer = champsim::test::instruction_with_ip_and_source_memory(champsim::address{2004}, champsim::address{0xcafe0000});
+    consumer.source_registers.push_back(1);
+    consumer.instr_id = 2;
+
+    uut.DISPATCH_BUFFER.push_back(producer);
+    uut.DISPATCH_BUFFER.push_back(consumer);
+    for (auto &instr : uut.DISPATCH_BUFFER)
+      instr.ready_time = champsim::chrono::clock::time_point{};
+
+    //auto old_cycle = uut.current_cycle();
+
+    WHEN("The instructions are promoted to the ROB and given a cycle") {
+      for (int i = 0; i < 2; ++i) {
+        for (auto op : std::array<champsim::operable*,3>{{&uut, &mock_L1I, &mock_L1D}})
+          op->_operate();
+      }
+
+      THEN("The ROB has two entries") {
+        REQUIRE(std::size(uut.ROB) == 2);
+      }
+
+      THEN("The load queue has one entry that has not been issued") {
+        REQUIRE(std::count_if(std::begin(uut.LQ), std::end(uut.LQ), [](auto x){ return x.has_value(); }) == 1);
+        REQUIRE(uut.LQ.at(0)->fetch_issued == false);
+        REQUIRE(mock_L1D.packet_count() == 0);
+      }
+
+      AND_WHEN("The consumer is executed") {
+        while (!uut.ROB.back().executed) {
+          for (auto op : std::array<champsim::operable*,3>{{&uut, &mock_L1I, &mock_L1D}})
+            op->_operate();
+        }
+        for (auto op : std::array<champsim::operable*,3>{{&uut, &mock_L1I, &mock_L1D}})
+          op->_operate();
+
+        THEN("The load queue entry is issued") {
+          REQUIRE(uut.LQ.at(0)->fetch_issued == true);
+          REQUIRE(mock_L1D.packet_count() == 1);
+        }
+      }
+    }
+  }
+}
+
+


### PR DESCRIPTION
Resolves #476 

The `ready_time` member of `LSQ_ENTRY` was initialized to the minimum value, so LQ entries would be immediately ready to issue unless they forwarded from an SQ. This ignored any register dependencies between prior instructions which may be address registers. This patch resolves the issue by initializing to the maximum value instead. The ready time is updated when the instruction is executed.