### PR TITLE
fixed btb return stack for large virtual addresses

### DIFF
--- a/btb/basic_btb/return_stack.cc
+++ b/btb/basic_btb/return_stack.cc
@@ -26,7 +26,7 @@ void return_stack::calibrate_call_size(champsim::address branch_target)
     auto call_ip = stack.back();
     stack.pop_back();
 
-    auto estimated_call_instr_size = champsim::offset(call_ip, branch_target);
+    auto estimated_call_instr_size = call_ip > branch_target ?  champsim::uoffset(branch_target, call_ip) : champsim::uoffset(call_ip, branch_target);
     if (estimated_call_instr_size <= 10) {
       call_size_trackers[call_ip.slice_lower<champsim::data::bits{champsim::msl::lg2(num_call_size_trackers)}>().to<std::size_t>()] = estimated_call_instr_size;
     }

--- a/btb/basic_btb/return_stack.cc
+++ b/btb/basic_btb/return_stack.cc
@@ -26,6 +26,12 @@ void return_stack::calibrate_call_size(champsim::address branch_target)
     auto call_ip = stack.back();
     stack.pop_back();
 
+    static int num_times_returned_backwards = 0;
+    if (call_ip > branch_target && num_times_returned_backwards < 10) {
+        ++num_times_returned_backwards;
+        fmt::print("[BTB] WARNING: target of return is a lower address than the corresponding call. This is usually a problem with your trace.\n");
+    }
+    
     auto estimated_call_instr_size = call_ip > branch_target ?  champsim::uoffset(branch_target, call_ip) : champsim::uoffset(call_ip, branch_target);
     if (estimated_call_instr_size <= 10) {
       call_size_trackers[call_ip.slice_lower<champsim::data::bits{champsim::msl::lg2(num_call_size_trackers)}>().to<std::size_t>()] = estimated_call_instr_size;


### PR DESCRIPTION
When running some of our cvp traces, we would get errors since the virtual addresses were too large to use a signed offset.
Since we just want the absolute value, I inserted a ternary operator here to call uoffset(x,y) if x < y and uoffset(y,x) if x > y.

The actual differences between the two are very small, it's just that the inputs were incredibly large.