### PR TITLE
Changed plain-printer to indicate origin cpu of cache stats.

### DIFF
--- a/inc/cache_stats.h
+++ b/inc/cache_stats.h
@@ -12,7 +12,6 @@
 struct cache_stats {
   std::string name;
   // prefetch stats
-  std::size_t cpu;
   uint64_t pf_requested = 0;
   uint64_t pf_issued = 0;
   uint64_t pf_useful = 0;

--- a/inc/cache_stats.h
+++ b/inc/cache_stats.h
@@ -12,6 +12,7 @@
 struct cache_stats {
   std::string name;
   // prefetch stats
+  std::size_t cpu;
   uint64_t pf_requested = 0;
   uint64_t pf_issued = 0;
   uint64_t pf_useful = 0;

--- a/inc/event_counter.h
+++ b/inc/event_counter.h
@@ -82,6 +82,11 @@ public:
 
   auto total() const { return std::accumulate(std::begin(values), std::end(values), value_type{}); }
 
+  std::vector<key_type> get_keys() const
+  {
+    return keys;
+  }
+
   event_counter<key_type>& operator+=(const event_counter<key_type>& rhs)
   {
     std::transform(std::begin(values), std::end(values), std::cbegin(keys), std::begin(values),

--- a/inc/event_counter.h
+++ b/inc/event_counter.h
@@ -44,6 +44,14 @@ public:
     }
   }
 
+  void set_default(key_type key, value_type value = {}) {
+    auto [key_iter, value_iter] = get_iter(key);
+    if (key_iter == std::end(keys) || *key_iter != key) {
+      keys.insert(key_iter, key);
+      values.insert(value_iter, value);
+    }
+  }
+
   void deallocate(key_type key)
   {
     auto [key_iter, value_iter] = get_iter(key);
@@ -82,10 +90,7 @@ public:
 
   auto total() const { return std::accumulate(std::begin(values), std::end(values), value_type{}); }
 
-  std::vector<key_type> get_keys() const
-  {
-    return keys;
-  }
+  std::vector<key_type> get_keys() const { return keys; }
 
   event_counter<key_type>& operator+=(const event_counter<key_type>& rhs)
   {

--- a/inc/event_counter.h
+++ b/inc/event_counter.h
@@ -44,14 +44,6 @@ public:
     }
   }
 
-  void set_default(key_type key, value_type value = {}) {
-    auto [key_iter, value_iter] = get_iter(key);
-    if (key_iter == std::end(keys) || *key_iter != key) {
-      keys.insert(key_iter, key);
-      values.insert(value_iter, value);
-    }
-  }
-
   void deallocate(key_type key)
   {
     auto [key_iter, value_iter] = get_iter(key);

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -849,9 +849,7 @@ void CACHE::begin_phase()
   stats_type new_sim_stats;
 
   new_roi_stats.name = NAME;
-  new_roi_stats.cpu = cpu;
   new_sim_stats.name = NAME;
-  new_sim_stats.cpu = cpu;
 
   roi_stats = new_roi_stats;
   sim_stats = new_sim_stats;
@@ -866,6 +864,7 @@ void CACHE::begin_phase()
 
 void CACHE::end_phase(unsigned finished_cpu)
 {
+  finished_cpu = finished_cpu;
   roi_stats.total_miss_latency_cycles = sim_stats.total_miss_latency_cycles;
 
   roi_stats.hits = sim_stats.hits;
@@ -878,7 +877,6 @@ void CACHE::end_phase(unsigned finished_cpu)
   roi_stats.pf_useful = sim_stats.pf_useful;
   roi_stats.pf_useless = sim_stats.pf_useless;
   roi_stats.pf_fill = sim_stats.pf_fill;
-  roi_stats.cpu = cpu;
 
   for (auto* ul : upper_levels) {
     ul->roi_stats.RQ_ACCESS = ul->sim_stats.RQ_ACCESS;

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -849,7 +849,9 @@ void CACHE::begin_phase()
   stats_type new_sim_stats;
 
   new_roi_stats.name = NAME;
+  new_roi_stats.cpu = cpu;
   new_sim_stats.name = NAME;
+  new_sim_stats.cpu = cpu;
 
   roi_stats = new_roi_stats;
   sim_stats = new_sim_stats;
@@ -866,19 +868,17 @@ void CACHE::end_phase(unsigned finished_cpu)
 {
   roi_stats.total_miss_latency_cycles = sim_stats.total_miss_latency_cycles;
 
-  for (auto type : {access_type::LOAD, access_type::RFO, access_type::PREFETCH, access_type::WRITE, access_type::TRANSLATION}) {
-    std::pair key{type, finished_cpu};
-    roi_stats.hits.set(key, sim_stats.hits.value_or(key, 0));
-    roi_stats.misses.set(key, sim_stats.misses.value_or(key, 0));
-    roi_stats.mshr_merge.set(key, sim_stats.mshr_merge.value_or(key, 0));
-    roi_stats.mshr_return.set(key, sim_stats.mshr_return.value_or(key, 0));
-  }
+  roi_stats.hits = sim_stats.hits;
+  roi_stats.misses = sim_stats.misses;
+  roi_stats.mshr_merge = sim_stats.mshr_merge;
+  roi_stats.mshr_return = sim_stats.mshr_return;
 
   roi_stats.pf_requested = sim_stats.pf_requested;
   roi_stats.pf_issued = sim_stats.pf_issued;
   roi_stats.pf_useful = sim_stats.pf_useful;
   roi_stats.pf_useless = sim_stats.pf_useless;
   roi_stats.pf_fill = sim_stats.pf_fill;
+  roi_stats.cpu = cpu;
 
   for (auto* ul : upper_levels) {
     ul->roi_stats.RQ_ACCESS = ul->sim_stats.RQ_ACCESS;

--- a/src/plain_printer.cc
+++ b/src/plain_printer.cc
@@ -72,25 +72,35 @@ std::vector<std::string> champsim::plain_printer::format(CACHE::stats_type stats
   using mshr_merge_value_type = typename decltype(stats.mshr_merge)::value_type;
   using mshr_return_value_type = typename decltype(stats.mshr_return)::value_type;
 
-  std::size_t num_cpus = NUM_CPUS;
-  //check keys to ensure this is the highest cpu
+  std::vector<std::size_t> cpus;
+
+  //build a vector of all existing cpus
   auto stat_keys = {stats.hits.get_keys(), stats.misses.get_keys(), stats.mshr_merge.get_keys(), stats.mshr_return.get_keys()};
-  for (auto keys : stat_keys) {
-    auto max_cpu_stat = std::max_element(keys.begin(), keys.end(), [](const auto& lhs, const auto& rhs) { return lhs.second < rhs.second; });
-    if(max_cpu_stat != keys.end() && max_cpu_stat->second + 1 > num_cpus)
-      num_cpus = max_cpu_stat->second + 1;
+  for (auto keys : stat_keys)
+    for (auto key : keys)
+      if(std::find_if(cpus.begin(), cpus.end(), [key=key](const auto val) {return key.second == val;}) == cpus.end())
+        cpus.push_back(key.second);
+        
+  //ensure stats were collected for active cpu, print warning otherwise
+  //always display stats for active cpu
+  if(std::find_if(cpus.begin(), cpus.end(), [key=stats.cpu](const auto val) {return key == val;}) == cpus.end())
+  {
+    cpus.push_back(stats.cpu);
+    fmt::print("[PLAIN PRINTER] WARNING: cpu{} stats were not collected for {}\n",stats.cpu,stats.name);
   }
+  
+  std::sort(cpus.begin(),cpus.end());
 
   for (const auto type : {access_type::LOAD, access_type::RFO, access_type::PREFETCH, access_type::WRITE, access_type::TRANSLATION}) {
-    for (std::size_t cpu = 0; cpu < num_cpus; ++cpu) {
-      stats.hits.allocate(std::pair{type, cpu});
-      stats.misses.allocate(std::pair{type, cpu});
-      stats.mshr_merge.allocate(std::pair{type, cpu});
+    for (auto cpu : cpus) {
+      stats.hits.set_default(std::pair{type, cpu});
+      stats.misses.set_default(std::pair{type, cpu});
+      stats.mshr_merge.set_default(std::pair{type, cpu});
     }
   }
 
   std::vector<std::string> lines{};
-  for (std::size_t cpu = 0; cpu < num_cpus; ++cpu) {
+  for (auto cpu : cpus) {
     hits_value_type total_hits = 0;
     misses_value_type total_misses = 0;
     mshr_merge_value_type total_mshr_merge = 0;

--- a/src/plain_printer.cc
+++ b/src/plain_printer.cc
@@ -85,28 +85,30 @@ std::vector<std::string> champsim::plain_printer::format(CACHE::stats_type stats
     hits_value_type total_hits = 0;
     misses_value_type total_misses = 0;
     mshr_merge_value_type total_mshr_merge = 0;
+    mshr_return_value_type total_mshr_return = 0;
     for (const auto type : {access_type::LOAD, access_type::RFO, access_type::PREFETCH, access_type::WRITE, access_type::TRANSLATION}) {
       total_hits += stats.hits.value_or(std::pair{type, cpu}, hits_value_type{});
       total_misses += stats.misses.value_or(std::pair{type, cpu}, misses_value_type{});
       total_mshr_merge += stats.mshr_merge.value_or(std::pair{type, cpu}, mshr_merge_value_type{});
+      total_mshr_return += stats.mshr_return.value_or(std::pair{type, cpu}, mshr_merge_value_type{});
     }
 
     fmt::format_string<std::string_view, std::string_view, int, int, int> hitmiss_fmtstr{
-        "{} {:<12s} ACCESS: {:10d} HIT: {:10d} MISS: {:10d} MSHR_MERGE: {:10d}"};
-    lines.push_back(fmt::format(hitmiss_fmtstr, stats.name, "TOTAL", total_hits + total_misses, total_hits, total_misses, total_mshr_merge));
+        "cpu{}->{} {:<12s} ACCESS: {:10d} HIT: {:10d} MISS: {:10d} MSHR_MERGE: {:10d}"};
+    lines.push_back(fmt::format(hitmiss_fmtstr, cpu, stats.name, "TOTAL", total_hits + total_misses, total_hits, total_misses, total_mshr_merge));
     for (const auto type : {access_type::LOAD, access_type::RFO, access_type::PREFETCH, access_type::WRITE, access_type::TRANSLATION}) {
       lines.push_back(
-          fmt::format(hitmiss_fmtstr, stats.name, access_type_names.at(champsim::to_underlying(type)),
+          fmt::format(hitmiss_fmtstr, cpu, stats.name, access_type_names.at(champsim::to_underlying(type)),
                       stats.hits.value_or(std::pair{type, cpu}, hits_value_type{}) + stats.misses.value_or(std::pair{type, cpu}, misses_value_type{}),
                       stats.hits.value_or(std::pair{type, cpu}, hits_value_type{}), stats.misses.value_or(std::pair{type, cpu}, misses_value_type{}),
                       stats.mshr_merge.value_or(std::pair{type, cpu}, mshr_merge_value_type{})));
     }
 
-    lines.push_back(fmt::format("{} PREFETCH REQUESTED: {:10} ISSUED: {:10} USEFUL: {:10} USELESS: {:10}", stats.name, stats.pf_requested, stats.pf_issued,
+    lines.push_back(fmt::format("cpu{}->{} PREFETCH REQUESTED: {:10} ISSUED: {:10} USEFUL: {:10} USELESS: {:10}", cpu, stats.name, stats.pf_requested, stats.pf_issued,
                                 stats.pf_useful, stats.pf_useless));
 
-    uint64_t total_downstream_demands = stats.mshr_return.total() - stats.mshr_return.value_or(std::pair{access_type::PREFETCH, cpu}, mshr_return_value_type{});
-    lines.push_back(fmt::format("{} AVERAGE MISS LATENCY: {} cycles", stats.name, ::print_ratio(stats.total_miss_latency_cycles, total_downstream_demands)));
+    uint64_t total_downstream_demands = total_mshr_return - stats.mshr_return.value_or(std::pair{access_type::PREFETCH, cpu}, mshr_return_value_type{});
+    lines.push_back(fmt::format("cpu{}->{} AVERAGE MISS LATENCY: {} cycles", cpu, stats.name, ::print_ratio(stats.total_miss_latency_cycles, total_downstream_demands)));
   }
 
   return lines;

--- a/test/cpp/src/498-cache-plain-printer.cc
+++ b/test/cpp/src/498-cache-plain-printer.cc
@@ -3,20 +3,11 @@
 #include "stats_printer.h"
 #include "cache_stats.h"
 
-TEST_CASE("An empty cache stat block prints all zeros") {
+TEST_CASE("An empty cache stat block prints nothing") {
   cache_stats given{};
   given.name = "test_cache";
 
-  std::vector<std::string> expected{
-    "cpu0->test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "cpu0->test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "cpu0->test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "cpu0->test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "cpu0->test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "cpu0->test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "cpu0->test_cache PREFETCH REQUESTED:          0 ISSUED:          0 USEFUL:          0 USELESS:          0",
-    "cpu0->test_cache AVERAGE MISS LATENCY: - cycles"
-  };
+  std::vector<std::string> expected{};
 
   REQUIRE_THAT(champsim::plain_printer::format(given), Catch::Matchers::RangeEquals(expected));
 }
@@ -117,6 +108,7 @@ TEST_CASE("Prefetch requests increase the count") {
   cache_stats given{};
   given.name = "test_cache";
   given.pf_requested = 1;
+  given.mshr_return.set({access_type::PREFETCH,0},1);
 
   std::vector<std::string> expected{
     "cpu0->test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
@@ -136,6 +128,7 @@ TEST_CASE("Prefetch issues increase the count") {
   cache_stats given{};
   given.name = "test_cache";
   given.pf_issued = 1;
+  given.mshr_return.set({access_type::PREFETCH,0},1);
 
   std::vector<std::string> expected{
     "cpu0->test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
@@ -155,6 +148,7 @@ TEST_CASE("Prefetch useful increases the count") {
   cache_stats given{};
   given.name = "test_cache";
   given.pf_useful = 1;
+  given.mshr_return.set({access_type::PREFETCH,0},1);
 
   std::vector<std::string> expected{
     "cpu0->test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
@@ -174,6 +168,7 @@ TEST_CASE("Prefetch useless increases the count") {
   cache_stats given{};
   given.name = "test_cache";
   given.pf_useless = 1;
+  given.mshr_return.set({access_type::PREFETCH,0},1);
 
   std::vector<std::string> expected{
     "cpu0->test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",

--- a/test/cpp/src/498-cache-plain-printer.cc
+++ b/test/cpp/src/498-cache-plain-printer.cc
@@ -8,14 +8,14 @@ TEST_CASE("An empty cache stat block prints all zeros") {
   given.name = "test_cache";
 
   std::vector<std::string> expected{
-    "test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache PREFETCH REQUESTED:          0 ISSUED:          0 USEFUL:          0 USELESS:          0",
-    "test_cache AVERAGE MISS LATENCY: - cycles"
+    "cpu0->test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache PREFETCH REQUESTED:          0 ISSUED:          0 USEFUL:          0 USELESS:          0",
+    "cpu0->test_cache AVERAGE MISS LATENCY: - cycles"
   };
 
   REQUIRE_THAT(champsim::plain_printer::format(given), Catch::Matchers::RangeEquals(expected));
@@ -24,11 +24,11 @@ TEST_CASE("An empty cache stat block prints all zeros") {
 TEST_CASE("Hits increment the hit and access counts") {
   auto num_hits = 255;
   auto [line_index, hit_type, expected_line] = GENERATE(as<std::tuple<std::size_t, access_type, std::string>>{},
-      std::tuple{1, access_type::LOAD, "test_cache LOAD         ACCESS:        255 HIT:        255 MISS:          0 MSHR_MERGE:          0"},
-      std::tuple{2, access_type::RFO, "test_cache RFO          ACCESS:        255 HIT:        255 MISS:          0 MSHR_MERGE:          0"},
-      std::tuple{3, access_type::PREFETCH, "test_cache PREFETCH     ACCESS:        255 HIT:        255 MISS:          0 MSHR_MERGE:          0"},
-      std::tuple{4, access_type::WRITE, "test_cache WRITE        ACCESS:        255 HIT:        255 MISS:          0 MSHR_MERGE:          0"},
-      std::tuple{5, access_type::TRANSLATION, "test_cache TRANSLATION  ACCESS:        255 HIT:        255 MISS:          0 MSHR_MERGE:          0"}
+      std::tuple{1, access_type::LOAD, "cpu0->test_cache LOAD         ACCESS:        255 HIT:        255 MISS:          0 MSHR_MERGE:          0"},
+      std::tuple{2, access_type::RFO, "cpu0->test_cache RFO          ACCESS:        255 HIT:        255 MISS:          0 MSHR_MERGE:          0"},
+      std::tuple{3, access_type::PREFETCH, "cpu0->test_cache PREFETCH     ACCESS:        255 HIT:        255 MISS:          0 MSHR_MERGE:          0"},
+      std::tuple{4, access_type::WRITE, "cpu0->test_cache WRITE        ACCESS:        255 HIT:        255 MISS:          0 MSHR_MERGE:          0"},
+      std::tuple{5, access_type::TRANSLATION, "cpu0->test_cache TRANSLATION  ACCESS:        255 HIT:        255 MISS:          0 MSHR_MERGE:          0"}
   );
 
   cache_stats given{};
@@ -36,14 +36,14 @@ TEST_CASE("Hits increment the hit and access counts") {
   given.hits.set({hit_type, 0}, num_hits);
 
   std::vector<std::string> expected{
-    "test_cache TOTAL        ACCESS:        255 HIT:        255 MISS:          0 MSHR_MERGE:          0",
-    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache PREFETCH REQUESTED:          0 ISSUED:          0 USEFUL:          0 USELESS:          0",
-    "test_cache AVERAGE MISS LATENCY: - cycles"
+    "cpu0->test_cache TOTAL        ACCESS:        255 HIT:        255 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache PREFETCH REQUESTED:          0 ISSUED:          0 USEFUL:          0 USELESS:          0",
+    "cpu0->test_cache AVERAGE MISS LATENCY: - cycles"
   };
   expected.at(line_index) = expected_line;
 
@@ -53,11 +53,11 @@ TEST_CASE("Hits increment the hit and access counts") {
 TEST_CASE("Misses increment the miss and access counts") {
   auto num_misses = 255;
   auto [line_index, miss_type, expected_line] = GENERATE(as<std::tuple<std::size_t, access_type, std::string>>{},
-      std::tuple{1, access_type::LOAD, "test_cache LOAD         ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:          0"},
-      std::tuple{2, access_type::RFO, "test_cache RFO          ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:          0"},
-      std::tuple{3, access_type::PREFETCH, "test_cache PREFETCH     ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:          0"},
-      std::tuple{4, access_type::WRITE, "test_cache WRITE        ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:          0"},
-      std::tuple{5, access_type::TRANSLATION, "test_cache TRANSLATION  ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:          0"}
+      std::tuple{1, access_type::LOAD, "cpu0->test_cache LOAD         ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:          0"},
+      std::tuple{2, access_type::RFO, "cpu0->test_cache RFO          ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:          0"},
+      std::tuple{3, access_type::PREFETCH, "cpu0->test_cache PREFETCH     ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:          0"},
+      std::tuple{4, access_type::WRITE, "cpu0->test_cache WRITE        ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:          0"},
+      std::tuple{5, access_type::TRANSLATION, "cpu0->test_cache TRANSLATION  ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:          0"}
   );
 
   cache_stats given{};
@@ -65,14 +65,14 @@ TEST_CASE("Misses increment the miss and access counts") {
   given.misses.set({miss_type, 0}, num_misses);
 
   std::vector<std::string> expected{
-    "test_cache TOTAL        ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:          0",
-    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache PREFETCH REQUESTED:          0 ISSUED:          0 USEFUL:          0 USELESS:          0",
-    "test_cache AVERAGE MISS LATENCY: - cycles"
+    "cpu0->test_cache TOTAL        ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:          0",
+    "cpu0->test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache PREFETCH REQUESTED:          0 ISSUED:          0 USEFUL:          0 USELESS:          0",
+    "cpu0->test_cache AVERAGE MISS LATENCY: - cycles"
   };
   expected.at(line_index) = expected_line;
 
@@ -84,11 +84,11 @@ TEST_CASE("Returning MSHRs increment the AMAT") {
   auto num_mshr_merged = 127;
   auto mshr_return_latency = GENERATE(1,2,6);
   auto [line_index, miss_type, expected_line] = GENERATE(as<std::tuple<std::size_t, access_type, std::string>>{},
-      std::tuple{1, access_type::LOAD, "test_cache LOAD         ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:        127"},
-      std::tuple{2, access_type::RFO, "test_cache RFO          ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:        127"},
+      std::tuple{1, access_type::LOAD, "cpu0->test_cache LOAD         ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:        127"},
+      std::tuple{2, access_type::RFO, "cpu0->test_cache RFO          ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:        127"},
       //std::tuple{3, access_type::PREFETCH, "test_cache PREFETCH     ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:        127"},
-      std::tuple{4, access_type::WRITE, "test_cache WRITE        ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:        127"},
-      std::tuple{5, access_type::TRANSLATION, "test_cache TRANSLATION  ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:        127"}
+      std::tuple{4, access_type::WRITE, "cpu0->test_cache WRITE        ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:        127"},
+      std::tuple{5, access_type::TRANSLATION, "cpu0->test_cache TRANSLATION  ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:        127"}
   );
 
   cache_stats given{};
@@ -99,15 +99,15 @@ TEST_CASE("Returning MSHRs increment the AMAT") {
   given.total_miss_latency_cycles = mshr_return_latency*num_mshr_returned;
 
   std::vector<std::string> expected{
-    "test_cache TOTAL        ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:        127",
-    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache PREFETCH REQUESTED:          0 ISSUED:          0 USEFUL:          0 USELESS:          0",
+    "cpu0->test_cache TOTAL        ACCESS:        255 HIT:          0 MISS:        255 MSHR_MERGE:        127",
+    "cpu0->test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache PREFETCH REQUESTED:          0 ISSUED:          0 USEFUL:          0 USELESS:          0",
   };
-  expected.push_back("test_cache AVERAGE MISS LATENCY: " + std::to_string(mshr_return_latency) + " cycles");
+  expected.push_back("cpu0->test_cache AVERAGE MISS LATENCY: " + std::to_string(mshr_return_latency) + " cycles");
   expected.at(line_index) = expected_line;
 
   REQUIRE_THAT(champsim::plain_printer::format(given), Catch::Matchers::RangeEquals(expected));
@@ -119,14 +119,14 @@ TEST_CASE("Prefetch requests increase the count") {
   given.pf_requested = 1;
 
   std::vector<std::string> expected{
-    "test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache PREFETCH REQUESTED:          1 ISSUED:          0 USEFUL:          0 USELESS:          0",
-    "test_cache AVERAGE MISS LATENCY: - cycles"
+    "cpu0->test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache PREFETCH REQUESTED:          1 ISSUED:          0 USEFUL:          0 USELESS:          0",
+    "cpu0->test_cache AVERAGE MISS LATENCY: - cycles"
   };
 
   REQUIRE_THAT(champsim::plain_printer::format(given), Catch::Matchers::RangeEquals(expected));
@@ -138,14 +138,14 @@ TEST_CASE("Prefetch issues increase the count") {
   given.pf_issued = 1;
 
   std::vector<std::string> expected{
-    "test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache PREFETCH REQUESTED:          0 ISSUED:          1 USEFUL:          0 USELESS:          0",
-    "test_cache AVERAGE MISS LATENCY: - cycles"
+    "cpu0->test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache PREFETCH REQUESTED:          0 ISSUED:          1 USEFUL:          0 USELESS:          0",
+    "cpu0->test_cache AVERAGE MISS LATENCY: - cycles"
   };
 
   REQUIRE_THAT(champsim::plain_printer::format(given), Catch::Matchers::RangeEquals(expected));
@@ -157,14 +157,14 @@ TEST_CASE("Prefetch useful increases the count") {
   given.pf_useful = 1;
 
   std::vector<std::string> expected{
-    "test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache PREFETCH REQUESTED:          0 ISSUED:          0 USEFUL:          1 USELESS:          0",
-    "test_cache AVERAGE MISS LATENCY: - cycles"
+    "cpu0->test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache PREFETCH REQUESTED:          0 ISSUED:          0 USEFUL:          1 USELESS:          0",
+    "cpu0->test_cache AVERAGE MISS LATENCY: - cycles"
   };
 
   REQUIRE_THAT(champsim::plain_printer::format(given), Catch::Matchers::RangeEquals(expected));
@@ -176,14 +176,14 @@ TEST_CASE("Prefetch useless increases the count") {
   given.pf_useless = 1;
 
   std::vector<std::string> expected{
-    "test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
-    "test_cache PREFETCH REQUESTED:          0 ISSUED:          0 USEFUL:          0 USELESS:          1",
-    "test_cache AVERAGE MISS LATENCY: - cycles"
+    "cpu0->test_cache TOTAL        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache LOAD         ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache RFO          ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache PREFETCH     ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache WRITE        ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache TRANSLATION  ACCESS:          0 HIT:          0 MISS:          0 MSHR_MERGE:          0",
+    "cpu0->test_cache PREFETCH REQUESTED:          0 ISSUED:          0 USEFUL:          0 USELESS:          1",
+    "cpu0->test_cache AVERAGE MISS LATENCY: - cycles"
   };
 
   REQUIRE_THAT(champsim::plain_printer::format(given), Catch::Matchers::RangeEquals(expected));


### PR DESCRIPTION
There have been questions about what the cache stats from the plain printer are indicating for multi-core runs.
This change indicates the origin core that the cache stats are being split by. The json files already do this, but the plain printer does not, so this brings it into sync.