### PR TITLE
Added modern dram mappings to memory controller.

### DIFF
--- a/inc/dram_controller.h
+++ b/inc/dram_controller.h
@@ -60,6 +60,7 @@ struct DRAM_ADDRESS_MAPPING {
   unsigned long get_bank(champsim::address address) const;
   unsigned long get_row(champsim::address address) const;
   unsigned long get_column(champsim::address address) const;
+  unsigned long swizzel_bits(champsim::address address, unsigned long segment_size, unsigned long segment_offset, unsigned long field, unsigned long field_bits) const;
 
   bool is_collision(champsim::address a, champsim::address b) const;
 

--- a/inc/dram_controller.h
+++ b/inc/dram_controller.h
@@ -60,7 +60,23 @@ struct DRAM_ADDRESS_MAPPING {
   unsigned long get_bank(champsim::address address) const;
   unsigned long get_row(champsim::address address) const;
   unsigned long get_column(champsim::address address) const;
-  unsigned long swizzel_bits(champsim::address address, unsigned long segment_size, unsigned long segment_offset, unsigned long field, unsigned long field_bits) const;
+
+   /**
+   * Perform the hashing operations for indexing our channels, banks, and bankgroups.
+   * This is done to increase parallelism when serving requests at the DRAM level.
+   *
+   * :param address: The physical address at which the hashing operation is occurring.
+   * :param segment_size: The number of row bits extracted during each iteration. (# of row bits / segment_size) == # of XOR operations
+   * :param segment_offset: The bit offset within the segment that the XOR operation will occur at. The bits taken from the segment will be [segment_offset + field_bits : segment_offset]
+   * 
+   * :param field: The input index that is being permuted by the operation.
+   * :param field_bits: The length of the index in bits.
+   * 
+   * Each iteration of the operation takes the selected bits of the segment and XORs them with the entirety of the field
+   * which should be equal or greater than length (in the case of the last iteration). This continues until no bits remain
+   * within the row that have not been XOR'd with the field.
+   */
+  unsigned long swizzle_bits(champsim::address address, unsigned long segment_size, unsigned long segment_offset, unsigned long field, unsigned long field_bits) const;
 
   bool is_collision(champsim::address a, champsim::address b) const;
 

--- a/inc/dram_controller.h
+++ b/inc/dram_controller.h
@@ -76,7 +76,7 @@ struct DRAM_ADDRESS_MAPPING {
    * which should be equal or greater than length (in the case of the last iteration). This continues until no bits remain
    * within the row that have not been XOR'd with the field.
    */
-  unsigned long swizzle_bits(champsim::address address, unsigned long segment_size, unsigned long segment_offset, unsigned long field, unsigned long field_bits) const;
+  unsigned long swizzle_bits(champsim::address address, unsigned long segment_size, champsim::data::bits segment_offset, unsigned long field, unsigned long field_bits) const;
 
   bool is_collision(champsim::address a, champsim::address b) const;
 

--- a/src/dram_controller.cc
+++ b/src/dram_controller.cc
@@ -552,7 +552,7 @@ bool MEMORY_CONTROLLER::add_wq(const request_type& packet)
   return false;
 }
 
-unsigned long DRAM_ADDRESS_MAPPING::swizzel_bits(champsim::address address, unsigned long segment_size, unsigned long segment_offset, unsigned long field, unsigned long field_bits) const {
+unsigned long DRAM_ADDRESS_MAPPING::swizzle_bits(champsim::address address, unsigned long segment_size, unsigned long segment_offset, unsigned long field, unsigned long field_bits) const {
   champsim::address row = champsim::address{get_row(address)};
   unsigned long permute_field = field;
 
@@ -569,7 +569,7 @@ unsigned long DRAM_ADDRESS_MAPPING::get_channel(champsim::address address) const
   unsigned long channel = std::get<SLICER_CHANNEL_IDX>(address_slicer(address)).to<unsigned long>();
   //channel bits should be xor'd with each row bit
   unsigned long c_bits = champsim::size(get<SLICER_CHANNEL_IDX>(address_slicer));
-  return(swizzel_bits(address,1,0,channel,c_bits));
+  return(swizzle_bits(address,1,0,channel,c_bits));
 }
 unsigned long DRAM_ADDRESS_MAPPING::get_rank(champsim::address address) const { return std::get<SLICER_RANK_IDX>(address_slicer(address)).to<unsigned long>(); }
 unsigned long DRAM_ADDRESS_MAPPING::get_bankgroup(champsim::address address) const
@@ -578,7 +578,7 @@ unsigned long DRAM_ADDRESS_MAPPING::get_bankgroup(champsim::address address) con
 
   unsigned long bg_bits = champsim::size(get<SLICER_BANKGROUP_IDX>(address_slicer));
   unsigned long bk_bits = champsim::size(get<SLICER_BANK_IDX>(address_slicer));
-  return(swizzel_bits(address,bg_bits + bk_bits,0,bankgroup,bg_bits));
+  return(swizzle_bits(address,bg_bits + bk_bits,0,bankgroup,bg_bits));
 }
 unsigned long DRAM_ADDRESS_MAPPING::get_bank(champsim::address address) const 
 { 
@@ -588,7 +588,7 @@ unsigned long DRAM_ADDRESS_MAPPING::get_bank(champsim::address address) const
   unsigned long bk_bits = champsim::size(get<SLICER_BANK_IDX>(address_slicer));
   //bank bits should be xor'd with select row bits
 
-  return(swizzel_bits(address,bg_bits + bk_bits,bg_bits,bank,bk_bits));
+  return(swizzle_bits(address,bg_bits + bk_bits,bg_bits,bank,bk_bits));
 }
 unsigned long DRAM_ADDRESS_MAPPING::get_row(champsim::address address) const { return std::get<SLICER_ROW_IDX>(address_slicer(address)).to<unsigned long>(); }
 unsigned long DRAM_ADDRESS_MAPPING::get_column(champsim::address address) const { return std::get<SLICER_COLUMN_IDX>(address_slicer(address)).to<unsigned long>(); }

--- a/test/cpp/src/701-dram-scheduler.cc
+++ b/test/cpp/src/701-dram-scheduler.cc
@@ -82,6 +82,7 @@ SCENARIO("A series of reads arrive at the memory controller and are reordered") 
         std::vector<uint64_t> row_access =     {0,1,0, 1,0,1,   0,1,0,  1,0,1,    0,1,0,    1,0,1,    0,1,0};
         std::vector<uint64_t> col_access =     {1,2,3, 4,5,6,   7,8,9,  10,11,12, 13,14,15, 16,17,18, 19,20,21};
         std::vector<uint64_t> bak_access =     {0,0,0, 1,1,1,   2,2,2,  3,3,3,    4,4,4,    5,5,5,    6,6,6};
+        std::vector<uint64_t> bakg_access =    {0,1,0, 1,0,1,   0,1,0,  1,0,1,    0,1,0,    1,0,1,    0,1,0};
         std::vector<uint64_t> arriv_time =     {3,4,2, 0,1,5,   6,7,8,  9,10,11,  12,13,14, 15,16,17, 20,18,19};
         //we can expect the previous listed accesses to be reordered as such, as long as bank accesses are sufficiently lengthy
         //such that we can allocate requests to 6 additional banks before the first bank is done. The timing for the memory controller
@@ -143,7 +144,7 @@ SCENARIO("A series of reads arrive at the memory controller and are reordered") 
             offset += champsim::lg2(chan_size*pref_size);
             champsim::address_slice channel_slice{champsim::dynamic_extent{champsim::data::bits{champsim::lg2(DRAM_CHANNELS) + offset}, champsim::data::bits{offset}}, 0};
             offset += champsim::lg2(DRAM_CHANNELS);
-            champsim::address_slice bankgroup_slice{champsim::dynamic_extent{champsim::data::bits{champsim::lg2(DRAM_BANKGROUPS) + offset}, champsim::data::bits{offset}}, 0};
+            champsim::address_slice bankgroup_slice{champsim::dynamic_extent{champsim::data::bits{champsim::lg2(DRAM_BANKGROUPS) + offset}, champsim::data::bits{offset}}, bakg_access[i]};
             offset += champsim::lg2(DRAM_BANKGROUPS);
             champsim::address_slice bank_slice{champsim::dynamic_extent{champsim::data::bits{champsim::lg2(DRAM_BANKS) + offset}, champsim::data::bits{offset}}, bak_access[i]};
             offset += champsim::lg2(DRAM_BANKS);

--- a/test/cpp/src/751-channel-bit-select.cc
+++ b/test/cpp/src/751-channel-bit-select.cc
@@ -82,3 +82,76 @@ TEST_CASE("A DRAM channel can identify the bits of a bankgroup") {
   INFO(fmt::format("address: {}", addr));
   REQUIRE(uut.get_bankgroup(addr) == segment_to_find);
 }
+
+TEST_CASE("A permutation of channels is provided per row") {
+  auto row = GENERATE(as<unsigned long>{}, 1,3,7,15,23,117,257,1023,1635,2778,4092);
+  auto channels = GENERATE(as<std::size_t>{}, 1,2,4);
+  auto rows = GENERATE(as<std::size_t>{}, 1024,4096);
+  auto columns = GENERATE(as<std::size_t>{}, 128,256);
+  auto ranks = GENERATE(as<std::size_t>{}, 2,8);
+  auto bankgroups = GENERATE(as<std::size_t>{}, 2,8);
+  auto banks = GENERATE(as<std::size_t>{}, 2,8);
+  auto prefetch_size = GENERATE(as<std::size_t>{}, 8, 16);
+  auto uut = DRAM_ADDRESS_MAPPING(champsim::data::bytes{8}, prefetch_size, channels, bankgroups, banks, columns, ranks, rows);
+
+  //set row address
+  champsim::address row_addr{row << (3 + champsim::lg2(columns) + champsim::lg2(ranks) + champsim::lg2(banks) + champsim::lg2(bankgroups) + champsim::lg2(channels))};
+
+  std::vector<unsigned long> decoded_channels(channels,0);
+
+  for(unsigned int c = 0; c < channels; c++) {
+  //set bank_address
+    champsim::address addr = champsim::address{row_addr.to<unsigned long>() + (c << (3 + champsim::lg2(prefetch_size)))};
+    decoded_channels[uut.get_channel(addr)]++;
+  }
+  REQUIRE_THAT(decoded_channels,Catch::Matchers::Equals(std::vector<unsigned long>(channels,1)));
+
+}
+
+TEST_CASE("A permutation of banks is provided per row") {
+  auto row = GENERATE(as<unsigned long>{}, 1,3,7,15,23,117,257,1023,1635,2778,4092);
+  auto rows = GENERATE(as<std::size_t>{}, 1024,4096);
+  auto columns = GENERATE(as<std::size_t>{}, 128,256);
+  auto ranks = GENERATE(as<std::size_t>{}, 2,8);
+  auto bankgroups = GENERATE(as<std::size_t>{}, 2,8);
+  auto banks = GENERATE(as<std::size_t>{}, 2,8);
+  auto prefetch_size = GENERATE(as<std::size_t>{}, 8, 16);
+  auto uut = DRAM_ADDRESS_MAPPING(champsim::data::bytes{8}, prefetch_size, 1, bankgroups, banks, columns, ranks, rows);
+
+  //set row address
+  champsim::address row_addr{row << (3 + champsim::lg2(columns) + champsim::lg2(ranks) + champsim::lg2(banks) + champsim::lg2(bankgroups))};
+
+  std::vector<unsigned long> decoded_banks(banks,0);
+
+  for(unsigned int b = 0; b < banks; b++) {
+  //set bank_address
+    champsim::address addr = champsim::address{row_addr.to<unsigned long>() + (b << (3 + champsim::lg2(prefetch_size) + champsim::lg2(bankgroups)))};
+    decoded_banks[uut.get_bank(addr)]++;
+  }
+  REQUIRE_THAT(decoded_banks,Catch::Matchers::Equals(std::vector<unsigned long>(banks,1)));
+
+}
+
+TEST_CASE("A permutation of bankgroups is provided per row") {
+  auto row = GENERATE(as<unsigned long>{}, 1,3,7,15,23,117,257,1023,1635,2778,4092);
+  auto rows = GENERATE(as<std::size_t>{}, 1024,4096);
+  auto columns = GENERATE(as<std::size_t>{}, 128,256);
+  auto ranks = GENERATE(as<std::size_t>{}, 2,8);
+  auto bankgroups = GENERATE(as<std::size_t>{}, 2,8);
+  auto banks = GENERATE(as<std::size_t>{}, 2,8);
+  auto prefetch_size = GENERATE(as<std::size_t>{}, 8, 16);
+  auto uut = DRAM_ADDRESS_MAPPING(champsim::data::bytes{8}, prefetch_size, 1, bankgroups, banks, columns, ranks, rows);
+
+  //set row address
+  champsim::address row_addr{row << (3 + champsim::lg2(columns) + champsim::lg2(ranks) + champsim::lg2(banks) + champsim::lg2(bankgroups))};
+
+  std::vector<unsigned long> decoded_bankgroups(bankgroups,0);
+
+  for(unsigned int b = 0; b < bankgroups; b++) {
+  //set bank_address
+    champsim::address addr = champsim::address{row_addr.to<unsigned long>() + (b << (3 + champsim::lg2(prefetch_size)))};
+    decoded_bankgroups[uut.get_bankgroup(addr)]++;
+  }
+  REQUIRE_THAT(decoded_bankgroups,Catch::Matchers::Equals(std::vector<unsigned long>(bankgroups,1)));
+
+}

--- a/test/cpp/src/751-channel-bit-select.cc
+++ b/test/cpp/src/751-channel-bit-select.cc
@@ -84,9 +84,9 @@ TEST_CASE("A DRAM channel can identify the bits of a bankgroup") {
 }
 
 TEST_CASE("A permutation of channels is provided per row") {
-  auto row = GENERATE(as<unsigned long>{}, 1,3,7,15,23,117,257,1023,1635,2778,4092);
+  auto row = GENERATE(as<unsigned long>{}, 1,3,7,15,23,117,257,1023,1635,2778,4092,8423,15266,45555,65432);
   auto channels = GENERATE(as<std::size_t>{}, 1,2,4);
-  auto rows = GENERATE(as<std::size_t>{}, 1024,4096);
+  auto rows = GENERATE(as<std::size_t>{}, 65536,131072);
   auto columns = GENERATE(as<std::size_t>{}, 128,256);
   auto ranks = GENERATE(as<std::size_t>{}, 2,8);
   auto bankgroups = GENERATE(as<std::size_t>{}, 2,8);
@@ -109,8 +109,8 @@ TEST_CASE("A permutation of channels is provided per row") {
 }
 
 TEST_CASE("A permutation of banks is provided per row") {
-  auto row = GENERATE(as<unsigned long>{}, 1,3,7,15,23,117,257,1023,1635,2778,4092);
-  auto rows = GENERATE(as<std::size_t>{}, 1024,4096);
+  auto row = GENERATE(as<unsigned long>{}, 1,3,7,15,23,117,257,1023,1635,2778,4092,8423,15266,45555,65432);
+  auto rows = GENERATE(as<std::size_t>{}, 65536,131072);
   auto columns = GENERATE(as<std::size_t>{}, 128,256);
   auto ranks = GENERATE(as<std::size_t>{}, 2,8);
   auto bankgroups = GENERATE(as<std::size_t>{}, 2,8);
@@ -133,8 +133,8 @@ TEST_CASE("A permutation of banks is provided per row") {
 }
 
 TEST_CASE("A permutation of bankgroups is provided per row") {
-  auto row = GENERATE(as<unsigned long>{}, 1,3,7,15,23,117,257,1023,1635,2778,4092);
-  auto rows = GENERATE(as<std::size_t>{}, 1024,4096);
+  auto row = GENERATE(as<unsigned long>{}, 1,3,7,15,23,117,257,1023,1635,2778,4092,8423,15266,45555,65432);
+  auto rows = GENERATE(as<std::size_t>{}, 65536,131072);
   auto columns = GENERATE(as<std::size_t>{}, 128,256);
   auto ranks = GENERATE(as<std::size_t>{}, 2,8);
   auto bankgroups = GENERATE(as<std::size_t>{}, 2,8);


### PR DESCRIPTION
Modernized dram mappings have been added to the memory controller.
Because our model allows for arbitrary values for # of rows,banks, etc..., we cannot directly copy mappings from real machines.

This mapping is heavily based on the re'd zen4 mappings.

Each channel bit is xor'd with all row bits.

Bankgroup and bank bits are xor'd all at once, as follows.
[bank bits][bank group bits]
  ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^
[row bits [bg bits + bk_bits:0]]
  ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^
[row bits [(bg_bits + bk_bits)*(i+1)][(bg_bits + bk_bits)*i]]
 ....
 ....
 Until we are out of row bits to xor with.

New tests were added to test this, and ensure that no aliasing occurs in these mappings.