### PR TITLE
Added component class, added parameter dump

### DIFF
--- a/config/instantiation_file.py
+++ b/config/instantiation_file.py
@@ -414,6 +414,18 @@ def get_instantiation_lines(cores, caches, ptws, pmem, vmem, build_id):
     ), rtype='std::vector<std::reference_wrapper<champsim::operable>>')
     yield ''
 
+    yield from cxx.function(f'{classname}::component_view', (
+        'std::vector<std::reference_wrapper<champsim::component>> retval{};',
+        'auto make_ref = [](auto& x){ return std::ref<champsim::component>(x); };',
+        'std::transform(std::begin(cores), std::end(cores), std::back_inserter(retval), make_ref);',
+        'std::transform(std::begin(caches), std::end(caches), std::back_inserter(retval), make_ref);',
+        'std::transform(std::begin(ptws), std::end(ptws), std::back_inserter(retval), make_ref);',
+        'retval.push_back(std::ref<champsim::component>(DRAM));',
+        'retval.push_back(std::ref<champsim::component>(vmem));',
+        'return retval;'
+    ), rtype='std::vector<std::reference_wrapper<champsim::component>>')
+    yield ''
+
     yield from cxx.function(f'{classname}::dram_view', [f'return {pmem["name"]};'], rtype='MEMORY_CONTROLLER&')
     yield ''
 
@@ -441,7 +453,8 @@ def get_instantiation_header(num_cpus, env, build_id):
         'std::vector<std::reference_wrapper<CACHE>> cache_view() final;',
         'std::vector<std::reference_wrapper<PageTableWalker>> ptw_view() final;',
         'MEMORY_CONTROLLER& dram_view() final;',
-        'std::vector<std::reference_wrapper<operable>> operable_view() final;'
+        'std::vector<std::reference_wrapper<operable>> operable_view() final;',
+        'std::vector<std::reference_wrapper<component>> component_view() final;'
     )
     struct_name = f'champsim::configured::generated_environment<0x{build_id}> final'
     yield from cxx.struct(struct_name, struct_body, superclass='champsim::environment')

--- a/inc/cache.h
+++ b/inc/cache.h
@@ -46,8 +46,9 @@
 #include "operable.h"
 #include "util/to_underlying.h" // for to_underlying
 #include "waitable.h"
+#include "component.h"
 
-class CACHE : public champsim::operable
+class CACHE : public champsim::operable, public champsim::component
 {
   enum [[deprecated(
       "Prefetchers may not specify arbitrary fill levels. Use CACHE::prefetch_line(pf_addr, fill_this_level, prefetch_metadata) instead.")]] FILL_LEVEL{

--- a/inc/cache.h
+++ b/inc/cache.h
@@ -219,6 +219,7 @@ public:
   prefetch_line(uint64_t ip, uint64_t base_addr, uint64_t pf_addr, bool fill_this_level, uint32_t prefetch_metadata);
 
   void print_deadlock() final;
+  void print_dump() final;
 
 #include "module_decl.inc"
 

--- a/inc/cache.h
+++ b/inc/cache.h
@@ -223,7 +223,7 @@ public:
 
 #include "module_decl.inc"
 
-  struct prefetcher_module_concept {
+  struct prefetcher_module_concept : public component {
     virtual ~prefetcher_module_concept() = default;
 
     virtual void bind(CACHE* cache) = 0;
@@ -238,7 +238,7 @@ public:
     virtual void impl_prefetcher_branch_operate(champsim::address ip, uint8_t branch_type, champsim::address branch_target) = 0;
   };
 
-  struct replacement_module_concept {
+  struct replacement_module_concept : public component {
     virtual ~replacement_module_concept() = default;
 
     virtual void bind(CACHE* cache) = 0;

--- a/inc/component.h
+++ b/inc/component.h
@@ -17,6 +17,10 @@
 #ifndef COMPONENT_H
 #define COMPONENT_H
 
+#include <string_view>
+#include <vector>
+#include <fmt/ranges.h>
+
 namespace champsim
 {
 class component
@@ -30,6 +34,18 @@ public:
   virtual void print_deadlock() {}                  // LCOV_EXCL_LINE
   virtual void print_dump() {}
 
+  constexpr static std::string_view param_fmtstr{"{} {} {:35} {:>1}\n"};
+  constexpr static std::string_view params_fmtstr{"{} {} {:35} [{:>1}]\n"};
+
+  template<typename T>
+  void print_parameter(std::string type_name, std::string instance_name, std::string parameter_name, T parameter) {
+    fmt::print(param_fmtstr,type_name,instance_name,parameter_name,parameter);
+  }
+
+  template<typename T>
+  void print_parameters(std::string type_name, std::string instance_name, std::string parameter_name, std::vector<T> parameters) {
+    fmt::print(params_fmtstr,type_name,instance_name,parameter_name,fmt::join(parameters,", "));
+  }
 };
 
 } // namespace champsim

--- a/inc/component.h
+++ b/inc/component.h
@@ -14,29 +14,22 @@
  * limitations under the License.
  */
 
-#ifndef OPERABLE_H
-#define OPERABLE_H
-
-#include "chrono.h"
+#ifndef COMPONENT_H
+#define COMPONENT_H
 
 namespace champsim
 {
-class operable
+class component
 {
 public:
-  champsim::chrono::picoseconds clock_period{};
-  champsim::chrono::clock::time_point current_time{};
-  
-  operable();
-  virtual ~operable() = default;
-  explicit operable(champsim::chrono::picoseconds clock_period);
+  bool warmup = true;
 
-  long _operate();
-  long operate_on(const champsim::chrono::clock& clock);
+  virtual void initialize() {} // LCOV_EXCL_LINE
+  virtual void begin_phase() {}                     // LCOV_EXCL_LINE
+  virtual void end_phase(unsigned /*cpu index*/) {} // LCOV_EXCL_LINE
+  virtual void print_deadlock() {}                  // LCOV_EXCL_LINE
+  virtual void print_dump() {}
 
-  virtual long operate() = 0;                 // LCOV_EXCL_LINE
-
-  [[deprecated]] uint64_t current_cycle() const;
 };
 
 } // namespace champsim

--- a/inc/dram_controller.h
+++ b/inc/dram_controller.h
@@ -162,6 +162,7 @@ struct DRAM_CHANNEL final : public champsim::operable, public champsim::componen
   void begin_phase() final;
   void end_phase(unsigned cpu) final;
   void print_deadlock() final;
+  void print_dump() final;
 
   std::size_t bank_request_capacity() const;
   std::size_t bankgroup_request_capacity() const;
@@ -198,6 +199,7 @@ public:
   void begin_phase() final;
   void end_phase(unsigned cpu) final;
   void print_deadlock() final;
+  void print_dump() final;
 
   [[nodiscard]] champsim::data::bytes size() const;
 };

--- a/inc/dram_controller.h
+++ b/inc/dram_controller.h
@@ -33,6 +33,7 @@
 #include "dram_stats.h"
 #include "extent_set.h"
 #include "operable.h"
+#include "component.h"
 
 struct DRAM_ADDRESS_MAPPING {
   constexpr static std::size_t SLICER_OFFSET_IDX = 0;
@@ -71,7 +72,7 @@ struct DRAM_ADDRESS_MAPPING {
   std::size_t channels() const;
 };
 
-struct DRAM_CHANNEL final : public champsim::operable {
+struct DRAM_CHANNEL final : public champsim::operable, public champsim::component {
   using response_type = typename champsim::channel::response_type;
 
   const DRAM_ADDRESS_MAPPING address_mapping;
@@ -167,7 +168,7 @@ struct DRAM_CHANNEL final : public champsim::operable {
   [[nodiscard]] champsim::data::bytes density() const;
 };
 
-class MEMORY_CONTROLLER : public champsim::operable
+class MEMORY_CONTROLLER : public champsim::operable, public champsim::component
 {
   using channel_type = champsim::channel;
   using request_type = typename channel_type::request_type;

--- a/inc/environment.h
+++ b/inc/environment.h
@@ -24,6 +24,7 @@
 #include "dram_controller.h"
 #include "ooo_cpu.h"
 #include "operable.h"
+#include "component.h"
 #include "ptw.h"
 
 namespace champsim
@@ -34,6 +35,7 @@ struct environment {
   virtual std::vector<std::reference_wrapper<PageTableWalker>> ptw_view() = 0;
   virtual MEMORY_CONTROLLER& dram_view() = 0;
   virtual std::vector<std::reference_wrapper<operable>> operable_view() = 0;
+  virtual std::vector<std::reference_wrapper<component>> component_view() = 0;
 };
 
 namespace configured

--- a/inc/modules.h
+++ b/inc/modules.h
@@ -25,6 +25,7 @@
 #include "address.h"
 #include "block.h"
 #include "champsim.h"
+#include "component.h"
 
 class CACHE;
 class O3_CPU;
@@ -43,7 +44,7 @@ struct bound_to {
   void bind(T* bind_arg) { intern_ = bind_arg; }
 };
 
-struct branch_predictor : public bound_to<O3_CPU> {
+struct branch_predictor : public bound_to<O3_CPU>, public component {
   explicit branch_predictor(O3_CPU* cpu) : bound_to<O3_CPU>(cpu) {}
 
   template <typename T, typename... Args>
@@ -71,7 +72,7 @@ struct branch_predictor : public bound_to<O3_CPU> {
   constexpr static bool has_predict_branch = decltype(predict_branch_member_impl<T, Args...>(0))::value;
 };
 
-struct btb : public bound_to<O3_CPU> {
+struct btb : public bound_to<O3_CPU>, public component {
   explicit btb(O3_CPU* cpu) : bound_to<O3_CPU>(cpu) {}
 
   template <typename T, typename... Args>
@@ -99,7 +100,7 @@ struct btb : public bound_to<O3_CPU> {
   constexpr static bool has_btb_prediction = decltype(predict_branch_member_impl<T, Args...>(0))::value;
 };
 
-struct prefetcher : public bound_to<CACHE> {
+struct prefetcher : public bound_to<CACHE>, public component {
   explicit prefetcher(CACHE* cache) : bound_to<CACHE>(cache) {}
   bool prefetch_line(champsim::address pf_addr, bool fill_this_level, uint32_t prefetch_metadata) const;
   [[deprecated]] bool prefetch_line(uint64_t pf_addr, bool fill_this_level, uint32_t prefetch_metadata) const;
@@ -153,7 +154,7 @@ struct prefetcher : public bound_to<CACHE> {
   constexpr static bool has_branch_operate = decltype(branch_operate_member_impl<T, Args...>(0))::value;
 };
 
-struct replacement : public bound_to<CACHE> {
+struct replacement : public bound_to<CACHE>, public component {
   explicit replacement(CACHE* cache) : bound_to<CACHE>(cache) {}
 
   template <typename T, typename... Args>

--- a/inc/ooo_cpu.h
+++ b/inc/ooo_cpu.h
@@ -35,6 +35,7 @@
 
 #include "bandwidth.h"
 #include "champsim.h"
+#include "component.h"
 #include "channel.h"
 #include "core_builder.h"
 #include "core_stats.h"
@@ -80,7 +81,7 @@ struct LSQ_ENTRY : champsim::program_ordered<LSQ_ENTRY> {
 };
 
 // cpu
-class O3_CPU : public champsim::operable
+class O3_CPU : public champsim::operable, public champsim::component
 {
 public:
   uint32_t cpu = 0;

--- a/inc/ooo_cpu.h
+++ b/inc/ooo_cpu.h
@@ -185,6 +185,7 @@ public:
   [[nodiscard]] auto sim_cycle() const { return (current_time.time_since_epoch() / clock_period) - sim_stats.begin_cycles; }
 
   void print_deadlock() final;
+  void print_dump() final;
 
 #include "module_decl.inc"
 

--- a/inc/ptw.h
+++ b/inc/ptw.h
@@ -27,12 +27,13 @@
 #include "bandwidth.h"
 #include "channel.h"
 #include "operable.h"
+#include "component.h"
 #include "ptw_builder.h"
 #include "util/lru_table.h"
 #include "waitable.h"
 
 class VirtualMemory;
-class PageTableWalker : public champsim::operable
+class PageTableWalker : public champsim::operable, public champsim::component
 {
   struct pscl_entry {
     champsim::address vaddr;

--- a/inc/ptw.h
+++ b/inc/ptw.h
@@ -98,6 +98,7 @@ public:
 
   void begin_phase() final;
   void print_deadlock() final;
+  void print_dump() final;
 };
 
 #endif

--- a/inc/vmem.h
+++ b/inc/vmem.h
@@ -119,6 +119,8 @@ public:
    * :returns: A pair of the page table page address and the latency to be applied to the operation.
    */
   std::pair<champsim::address, champsim::chrono::clock::duration> get_pte_pa(uint32_t cpu_num, champsim::page_number vaddr, std::size_t level);
+
+  void print_dump() final;
 };
 
 #endif

--- a/inc/vmem.h
+++ b/inc/vmem.h
@@ -26,12 +26,13 @@
 #include "address.h"
 #include "champsim.h"
 #include "chrono.h"
+#include "component.h"
 
 class MEMORY_CONTROLLER;
 
 using pte_entry = champsim::data::size<long long, std::ratio<8>>;
 
-class VirtualMemory
+class VirtualMemory: public champsim::component
 {
 private:
   std::map<std::pair<uint32_t, champsim::page_number>, champsim::page_number> vpage_to_ppage_map;

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -935,4 +935,51 @@ void CACHE::print_deadlock()
     champsim::range_print_deadlock(ul->PQ, NAME + "_PQ", q_writer, q_entry_pack);
   }
 }
+
+void CACHE::print_dump() {
+  fmt::print("CACHE {} {:35} {:>0}\n",NAME,"cache.clock_period",clock_period.count());
+  fmt::print("CACHE {} {:35} {:>0}\n",NAME,"cache.sets",NUM_SET);
+  fmt::print("CACHE {} {:35} {:>0}\n",NAME,"cache.ways",NUM_WAY);
+
+  fmt::print("CACHE {} {:35} [",NAME,"cache.rq_size");
+  auto rq_sizes = get_rq_size();
+  long unsigned printed = 0;
+  for(auto s = rq_sizes.begin(); s != rq_sizes.end(); s++) {
+    fmt::print("{:>0}",*s);
+    printed++;
+    if(printed < std::size(rq_sizes))
+      fmt::print(",");
+  }
+  fmt::print("]\n");
+
+  fmt::print("CACHE {} {:35} [",NAME,"cache.wq_size");
+  auto wq_sizes = get_wq_size();
+  printed = 0;
+  for(auto s = wq_sizes.begin(); s != wq_sizes.end(); s++) {
+    fmt::print("{:>0}",*s);
+    printed++;
+    if(printed < std::size(wq_sizes))
+      fmt::print(",");
+  }
+  fmt::print("]\n");
+
+  fmt::print("CACHE {} {:35} {:>0}\n",NAME,"cache.pq_size",PQ_SIZE);
+  fmt::print("CACHE {} {:35} {:>0}\n",NAME,"cache.mshr_size",MSHR_SIZE);
+  fmt::print("CACHE {} {:35} {:>0}\n",NAME,"cache.hit_latency",HIT_LATENCY / clock_period);
+  fmt::print("CACHE {} {:35} {:>0}\n",NAME,"cache.fill_latency",FILL_LATENCY / clock_period);
+  fmt::print("CACHE {} {:35} {:>0}\n",NAME,"cache.max_tag_check",(std::size_t)MAX_TAG);
+  fmt::print("CACHE {} {:35} {:>0}\n",NAME,"cache.max_fill",(std::size_t)(MAX_FILL));
+  fmt::print("CACHE {} {:35} {:>0}\n",NAME,"cache.prefetch_as_load",prefetch_as_load);
+  fmt::print("CACHE {} {:35} {:>0}\n",NAME,"cache.virtual_prefetch",virtual_prefetch);
+  fmt::print("CACHE {} {:35} [",NAME,"cache.prefetch_activate");
+
+  printed = 0;
+  for(auto s = pref_activate_mask.begin(); s != pref_activate_mask.end(); s++) {
+    fmt::print("{:>1}",access_type_names.at(champsim::to_underlying(*s)));
+    printed++;
+    if(printed < std::size(pref_activate_mask))
+      fmt::print(",");
+  }
+  fmt::print("]\n");
+}
 // LCOV_EXCL_STOP

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -89,6 +89,9 @@ auto CACHE::operator=(CACHE&& other) -> CACHE&
   pref_module_pimpl->bind(this);
   repl_module_pimpl->bind(this);
 
+  pref_module_pimpl->warmup = this->warmup;
+  repl_module_pimpl->warmup = this->warmup;
+
   return *this;
 }
 
@@ -792,7 +795,7 @@ std::vector<double> CACHE::get_wq_occupancy_ratio() const { return ::occupancy_r
 
 std::vector<double> CACHE::get_pq_occupancy_ratio() const { return ::occupancy_ratio_vec(get_pq_occupancy(), get_pq_size()); }
 
-void CACHE::impl_prefetcher_initialize() const { pref_module_pimpl->impl_prefetcher_initialize(); }
+void CACHE::impl_prefetcher_initialize() const { pref_module_pimpl->impl_prefetcher_initialize(); pref_module_pimpl->initialize();}
 
 uint32_t CACHE::impl_prefetcher_cache_operate(champsim::address addr, champsim::address ip, bool cache_hit, bool useful_prefetch, access_type type,
                                               uint32_t metadata_in) const
@@ -815,7 +818,7 @@ void CACHE::impl_prefetcher_branch_operate(champsim::address ip, uint8_t branch_
   pref_module_pimpl->impl_prefetcher_branch_operate(ip, branch_type, branch_target);
 }
 
-void CACHE::impl_initialize_replacement() const { repl_module_pimpl->impl_initialize_replacement(); }
+void CACHE::impl_initialize_replacement() const { repl_module_pimpl->impl_initialize_replacement(); repl_module_pimpl->initialize();}
 
 long CACHE::impl_find_victim(uint32_t triggering_cpu, uint64_t instr_id, long set, const BLOCK* current_set, champsim::address ip, champsim::address full_addr,
                              access_type type) const
@@ -860,6 +863,10 @@ void CACHE::begin_phase()
     ul->roi_stats = ul_new_roi_stats;
     ul->sim_stats = ul_new_sim_stats;
   }
+  pref_module_pimpl->warmup = warmup;
+  repl_module_pimpl->warmup = warmup;
+  pref_module_pimpl->begin_phase();
+  repl_module_pimpl->begin_phase();
 }
 
 void CACHE::end_phase(unsigned finished_cpu)
@@ -895,6 +902,8 @@ void CACHE::end_phase(unsigned finished_cpu)
     ul->roi_stats.WQ_TO_CACHE = ul->sim_stats.WQ_TO_CACHE;
     ul->roi_stats.WQ_FORWARD = ul->sim_stats.WQ_FORWARD;
   }
+  pref_module_pimpl->end_phase(finished_cpu);
+  repl_module_pimpl->end_phase(finished_cpu);
 }
 
 template <typename T>
@@ -932,52 +941,33 @@ void CACHE::print_deadlock()
     champsim::range_print_deadlock(ul->WQ, NAME + "_WQ", q_writer, q_entry_pack);
     champsim::range_print_deadlock(ul->PQ, NAME + "_PQ", q_writer, q_entry_pack);
   }
+  pref_module_pimpl->print_deadlock();
+  repl_module_pimpl->print_deadlock();
 }
 
 void CACHE::print_dump() {
-  fmt::print("CACHE {} {:35} {:>0}\n",NAME,"cache.clock_period",clock_period.count());
-  fmt::print("CACHE {} {:35} {:>0}\n",NAME,"cache.sets",NUM_SET);
-  fmt::print("CACHE {} {:35} {:>0}\n",NAME,"cache.ways",NUM_WAY);
 
-  fmt::print("CACHE {} {:35} [",NAME,"cache.rq_size");
-  auto rq_sizes = get_rq_size();
-  long unsigned printed = 0;
-  for(auto s = rq_sizes.begin(); s != rq_sizes.end(); s++) {
-    fmt::print("{:>0}",*s);
-    printed++;
-    if(printed < std::size(rq_sizes))
-      fmt::print(",");
-  }
-  fmt::print("]\n");
+  print_parameter("CACHE",NAME,"cache.clock_period",clock_period.count());
+  print_parameter("CACHE",NAME,"cache.sets",NUM_SET);
+  print_parameter("CACHE",NAME,"cache.ways",NUM_WAY);
+  print_parameters("CACHE",NAME,"cache.rq_size",get_rq_size());
+  print_parameters("CACHE",NAME,"cache.wq_size",get_wq_size());
 
-  fmt::print("CACHE {} {:35} [",NAME,"cache.wq_size");
-  auto wq_sizes = get_wq_size();
-  printed = 0;
-  for(auto s = wq_sizes.begin(); s != wq_sizes.end(); s++) {
-    fmt::print("{:>0}",*s);
-    printed++;
-    if(printed < std::size(wq_sizes))
-      fmt::print(",");
-  }
-  fmt::print("]\n");
+  print_parameter("CACHE",NAME,"cache.pq_size",PQ_SIZE);
+  print_parameter("CACHE",NAME,"cache.mshr_size",MSHR_SIZE);
+  print_parameter("CACHE",NAME,"cache.hit_latency",HIT_LATENCY / clock_period);
+  print_parameter("CACHE",NAME,"cache.fill_latency",FILL_LATENCY / clock_period);
+  print_parameter("CACHE",NAME,"cache.max_tag_check",(std::size_t)MAX_TAG);
+  print_parameter("CACHE",NAME,"cache.max_fill",(std::size_t)(MAX_FILL));
+  print_parameter("CACHE",NAME,"cache.prefetch_as_load",prefetch_as_load);
+  print_parameter("CACHE",NAME,"cache.virtual_prefetch",virtual_prefetch);
 
-  fmt::print("CACHE {} {:35} {:>0}\n",NAME,"cache.pq_size",PQ_SIZE);
-  fmt::print("CACHE {} {:35} {:>0}\n",NAME,"cache.mshr_size",MSHR_SIZE);
-  fmt::print("CACHE {} {:35} {:>0}\n",NAME,"cache.hit_latency",HIT_LATENCY / clock_period);
-  fmt::print("CACHE {} {:35} {:>0}\n",NAME,"cache.fill_latency",FILL_LATENCY / clock_period);
-  fmt::print("CACHE {} {:35} {:>0}\n",NAME,"cache.max_tag_check",(std::size_t)MAX_TAG);
-  fmt::print("CACHE {} {:35} {:>0}\n",NAME,"cache.max_fill",(std::size_t)(MAX_FILL));
-  fmt::print("CACHE {} {:35} {:>0}\n",NAME,"cache.prefetch_as_load",prefetch_as_load);
-  fmt::print("CACHE {} {:35} {:>0}\n",NAME,"cache.virtual_prefetch",virtual_prefetch);
-  fmt::print("CACHE {} {:35} [",NAME,"cache.prefetch_activate");
-
-  printed = 0;
-  for(auto s = pref_activate_mask.begin(); s != pref_activate_mask.end(); s++) {
-    fmt::print("{:>1}",access_type_names.at(champsim::to_underlying(*s)));
-    printed++;
-    if(printed < std::size(pref_activate_mask))
-      fmt::print(",");
-  }
-  fmt::print("]\n");
+  std::vector<std::string_view> prefetch_activators;
+  std::transform(std::begin(pref_activate_mask), std::end(pref_activate_mask), std::back_inserter(prefetch_activators), [](auto const t) { return access_type_names.at(champsim::to_underlying(t)); });
+  print_parameters("CACHE",NAME,"cache.prefetch_activate",prefetch_activators);
+  print_parameter("CACHE",NAME,"cache.prefetcher","");
+  pref_module_pimpl->print_dump();
+  print_parameter("CACHE",NAME,"cache.replacement","");
+  repl_module_pimpl->print_dump();
 }
 // LCOV_EXCL_STOP

--- a/src/champsim.cc
+++ b/src/champsim.cc
@@ -62,13 +62,15 @@ long do_cycle(environment& env, std::vector<tracereader>& traces, std::vector<st
 
 phase_stats do_phase(const phase_info& phase, environment& env, std::vector<tracereader>& traces, champsim::chrono::clock& global_clock)
 {
+  auto components = env.component_view();
   auto operables = env.operable_view();
+
   auto [phase_name, is_warmup, length, trace_index, trace_names] = phase;
 
   // Initialize phase
-  for (champsim::operable& op : operables) {
-    op.warmup = is_warmup;
-    op.begin_phase();
+  for (champsim::component& comp : components) {
+    comp.warmup = is_warmup;
+    comp.begin_phase();
   }
 
   const auto time_quantum = std::accumulate(std::cbegin(operables), std::cend(operables), champsim::chrono::clock::duration::max(),
@@ -122,7 +124,7 @@ phase_stats do_phase(const phase_info& phase, environment& env, std::vector<trac
     }
 
     if (stalled_cycle >= DEADLOCK_CYCLE || livelock_trigger) {
-      std::for_each(std::begin(operables), std::end(operables), [](champsim::operable& c) { c.print_deadlock(); });
+      std::for_each(std::begin(components), std::end(components), [](champsim::component& c) { c.print_deadlock(); });
       abort();
     }
 
@@ -139,8 +141,8 @@ phase_stats do_phase(const phase_info& phase, environment& env, std::vector<trac
 
     for (O3_CPU& cpu : env.cpu_view()) {
       if (next_phase_complete[cpu.cpu] != phase_complete[cpu.cpu]) {
-        for (champsim::operable& op : operables) {
-          op.end_phase(cpu.cpu);
+        for (champsim::component& comp : components) {
+          comp.end_phase(cpu.cpu);
         }
 
         fmt::print("{} finished CPU {} instructions: {} cycles: {} cumulative IPC: {:.4g} (Simulation time: {:%H hr %M min %S sec})\n", phase_name, cpu.cpu,
@@ -183,8 +185,8 @@ phase_stats do_phase(const phase_info& phase, environment& env, std::vector<trac
 // simulation entry point
 std::vector<phase_stats> main(environment& env, std::vector<phase_info>& phases, std::vector<tracereader>& traces)
 {
-  for (champsim::operable& op : env.operable_view()) {
-    op.initialize();
+  for (champsim::component& comp : env.component_view()) {
+    comp.initialize();
   }
 
   champsim::chrono::clock global_clock;

--- a/src/dram_controller.cc
+++ b/src/dram_controller.cc
@@ -594,16 +594,16 @@ void MEMORY_CONTROLLER::print_deadlock()
 }
 void MEMORY_CONTROLLER::print_dump()
 {
-  fmt::print("MEMORY CONTROLLER {:35} {:>0}\n","DRAM.data_bus_period",data_bus_period.count());
-  fmt::print("MEMORY CONTROLLER {:35} {:>0}\n","DRAM.memory_controller_period",clock_period.count());
-  fmt::print("MEMORY CONTROLLER {:35} {:>0}\n","DRAM.channels",address_mapping.channels());
-  fmt::print("MEMORY CONTROLLER {:35} {:>0}\n","DRAM.ranks",address_mapping.ranks());
-  fmt::print("MEMORY CONTROLLER {:35} {:>0}\n","DRAM.bankgroups",address_mapping.bankgroups());
-  fmt::print("MEMORY CONTROLLER {:35} {:>0}\n","DRAM.banks",address_mapping.banks());
-  fmt::print("MEMORY CONTROLLER {:35} {:>0}\n","DRAM.rows",address_mapping.rows());
-  fmt::print("MEMORY CONTROLLER {:35} {:>0}\n","DRAM.columns",address_mapping.columns());
-  fmt::print("MEMORY CONTROLLER {:35} {:>0}\n","DRAM.channel_width",channel_width.count());
-  fmt::print("MEMORY CONTROLLER {:35} {:>0}\n","DRAM.prefetch_size",address_mapping.prefetch_size);
+  print_parameter("MEMORY CONTROLLER", "DRAM","DRAM.data_bus_period",data_bus_period.count());
+  print_parameter("MEMORY CONTROLLER", "DRAM","DRAM.memory_controller_period",clock_period.count());
+  print_parameter("MEMORY CONTROLLER", "DRAM","DRAM.channels",address_mapping.channels());
+  print_parameter("MEMORY CONTROLLER", "DRAM","DRAM.ranks",address_mapping.ranks());
+  print_parameter("MEMORY CONTROLLER", "DRAM","DRAM.bankgroups",address_mapping.bankgroups());
+  print_parameter("MEMORY CONTROLLER", "DRAM","DRAM.banks",address_mapping.banks());
+  print_parameter("MEMORY CONTROLLER", "DRAM","DRAM.rows",address_mapping.rows());
+  print_parameter("MEMORY CONTROLLER", "DRAM","DRAM.columns",address_mapping.columns());
+  print_parameter("MEMORY CONTROLLER", "DRAM","DRAM.channel_width",channel_width.count());
+  print_parameter("MEMORY CONTROLLER", "DRAM","DRAM.prefetch_size",address_mapping.prefetch_size);
   int j = 0;
   for (auto& chan : channels) {
     fmt::print("DRAM Channel {}\n", j++);
@@ -623,23 +623,23 @@ void DRAM_CHANNEL::print_deadlock()
 }
 void DRAM_CHANNEL::print_dump()
 {
-  fmt::print("\t{:35} {:>0}\n","channel.data_bus_period",data_bus_period.count());
-  fmt::print("\t{:35} {:>0}\n","channel.memory_controller_period",clock_period.count());
-  fmt::print("\t{:35} {:>0}\n","channel.channels",address_mapping.channels());
-  fmt::print("\t{:35} {:>0}\n","channel.ranks",address_mapping.ranks());
-  fmt::print("\t{:35} {:>0}\n","channel.bankgroups",address_mapping.bankgroups());
-  fmt::print("\t{:35} {:>0}\n","channel.banks",address_mapping.banks());
-  fmt::print("\t{:35} {:>0}\n","channel.rows",address_mapping.rows());
-  fmt::print("\t{:35} {:>0}\n","channel.columns",address_mapping.columns());
-  fmt::print("\t{:35} {:>0}\n","channel.channel_width",channel_width.count());
-  fmt::print("\t{:35} {:>0}\n","channel.prefetch_size",address_mapping.prefetch_size);
-  fmt::print("\t{:35} {:>0}\n","channel.wq_size",std::size(WQ));
-  fmt::print("\t{:35} {:>0}\n","channel.rq_size",std::size(RQ));
-  fmt::print("\t{:35} {:>0}\n","channel.tCAS",tCAS / clock_period);
-  fmt::print("\t{:35} {:>0}\n","channel.tRCD",tRCD / clock_period);
-  fmt::print("\t{:35} {:>0}\n","channel.tRP",tRP / clock_period);
-  fmt::print("\t{:35} {:>0}\n","channel.tRAS",tRAS / clock_period);
-  fmt::print("\t{:35} {:>0}\n","channel.tREF",tREF / clock_period);
-  fmt::print("\t{:35} {:>0}\n","channel.tRFC",tRFC / clock_period);
+  print_parameter("\tDRAM_CHANNEL","channel","channel.data_bus_period",data_bus_period.count());
+  print_parameter("\tDRAM_CHANNEL","channel","channel.memory_controller_period",clock_period.count());
+  print_parameter("\tDRAM_CHANNEL","channel","channel.channels",address_mapping.channels());
+  print_parameter("\tDRAM_CHANNEL","channel","channel.ranks",address_mapping.ranks());
+  print_parameter("\tDRAM_CHANNEL","channel","channel.bankgroups",address_mapping.bankgroups());
+  print_parameter("\tDRAM_CHANNEL","channel","channel.banks",address_mapping.banks());
+  print_parameter("\tDRAM_CHANNEL","channel","channel.rows",address_mapping.rows());
+  print_parameter("\tDRAM_CHANNEL","channel","channel.columns",address_mapping.columns());
+  print_parameter("\tDRAM_CHANNEL","channel","channel.channel_width",channel_width.count());
+  print_parameter("\tDRAM_CHANNEL","channel","channel.prefetch_size",address_mapping.prefetch_size);
+  print_parameter("\tDRAM_CHANNEL","channel","channel.wq_size",std::size(WQ));
+  print_parameter("\tDRAM_CHANNEL","channel","channel.rq_size",std::size(RQ));
+  print_parameter("\tDRAM_CHANNEL","channel","channel.tCAS",tCAS / clock_period);
+  print_parameter("\tDRAM_CHANNEL","channel","channel.tRCD",tRCD / clock_period);
+  print_parameter("\tDRAM_CHANNEL","channel","channel.tRP",tRP / clock_period);
+  print_parameter("\tDRAM_CHANNEL","channel","channel.tRAS",tRAS / clock_period);
+  print_parameter("\tDRAM_CHANNEL","channel","channel.tREF",tREF / clock_period);
+  print_parameter("\tDRAM_CHANNEL","channel","channel.tRFC",tRFC / clock_period);
 }
 // LCOV_EXCL_STOP

--- a/src/dram_controller.cc
+++ b/src/dram_controller.cc
@@ -592,6 +592,24 @@ void MEMORY_CONTROLLER::print_deadlock()
     chan.print_deadlock();
   }
 }
+void MEMORY_CONTROLLER::print_dump()
+{
+  fmt::print("MEMORY CONTROLLER {:35} {:>0}\n","DRAM.data_bus_period",data_bus_period.count());
+  fmt::print("MEMORY CONTROLLER {:35} {:>0}\n","DRAM.memory_controller_period",clock_period.count());
+  fmt::print("MEMORY CONTROLLER {:35} {:>0}\n","DRAM.channels",address_mapping.channels());
+  fmt::print("MEMORY CONTROLLER {:35} {:>0}\n","DRAM.ranks",address_mapping.ranks());
+  fmt::print("MEMORY CONTROLLER {:35} {:>0}\n","DRAM.bankgroups",address_mapping.bankgroups());
+  fmt::print("MEMORY CONTROLLER {:35} {:>0}\n","DRAM.banks",address_mapping.banks());
+  fmt::print("MEMORY CONTROLLER {:35} {:>0}\n","DRAM.rows",address_mapping.rows());
+  fmt::print("MEMORY CONTROLLER {:35} {:>0}\n","DRAM.columns",address_mapping.columns());
+  fmt::print("MEMORY CONTROLLER {:35} {:>0}\n","DRAM.channel_width",channel_width.count());
+  fmt::print("MEMORY CONTROLLER {:35} {:>0}\n","DRAM.prefetch_size",address_mapping.prefetch_size);
+  int j = 0;
+  for (auto& chan : channels) {
+    fmt::print("DRAM Channel {}\n", j++);
+    chan.print_dump();
+  }
+}
 
 void DRAM_CHANNEL::print_deadlock()
 {
@@ -602,5 +620,26 @@ void DRAM_CHANNEL::print_deadlock()
 
   champsim::range_print_deadlock(RQ, "RQ", q_writer, q_entry_pack);
   champsim::range_print_deadlock(WQ, "WQ", q_writer, q_entry_pack);
+}
+void DRAM_CHANNEL::print_dump()
+{
+  fmt::print("\t{:35} {:>0}\n","channel.data_bus_period",data_bus_period.count());
+  fmt::print("\t{:35} {:>0}\n","channel.memory_controller_period",clock_period.count());
+  fmt::print("\t{:35} {:>0}\n","channel.channels",address_mapping.channels());
+  fmt::print("\t{:35} {:>0}\n","channel.ranks",address_mapping.ranks());
+  fmt::print("\t{:35} {:>0}\n","channel.bankgroups",address_mapping.bankgroups());
+  fmt::print("\t{:35} {:>0}\n","channel.banks",address_mapping.banks());
+  fmt::print("\t{:35} {:>0}\n","channel.rows",address_mapping.rows());
+  fmt::print("\t{:35} {:>0}\n","channel.columns",address_mapping.columns());
+  fmt::print("\t{:35} {:>0}\n","channel.channel_width",channel_width.count());
+  fmt::print("\t{:35} {:>0}\n","channel.prefetch_size",address_mapping.prefetch_size);
+  fmt::print("\t{:35} {:>0}\n","channel.wq_size",std::size(WQ));
+  fmt::print("\t{:35} {:>0}\n","channel.rq_size",std::size(RQ));
+  fmt::print("\t{:35} {:>0}\n","channel.tCAS",tCAS / clock_period);
+  fmt::print("\t{:35} {:>0}\n","channel.tRCD",tRCD / clock_period);
+  fmt::print("\t{:35} {:>0}\n","channel.tRP",tRP / clock_period);
+  fmt::print("\t{:35} {:>0}\n","channel.tRAS",tRAS / clock_period);
+  fmt::print("\t{:35} {:>0}\n","channel.tREF",tREF / clock_period);
+  fmt::print("\t{:35} {:>0}\n","channel.tRFC",tRFC / clock_period);
 }
 // LCOV_EXCL_STOP

--- a/src/main.cc
+++ b/src/main.cc
@@ -74,6 +74,7 @@ int main(int argc, char** argv) // NOLINT(bugprone-exception-escape)
     for (champsim::component& comp: gen_environment.component_view()) {
       comp.print_dump();
     }
+    exit(0);
   };
 
   app.add_flag("-c,--cloudsuite", knob_cloudsuite, "Read all traces using the cloudsuite format");

--- a/src/main.cc
+++ b/src/main.cc
@@ -70,8 +70,15 @@ int main(int argc, char** argv) // NOLINT(bugprone-exception-escape)
     }
   };
 
+  auto set_dump_callback = [&](auto) {
+    for (champsim::component& comp: gen_environment.component_view()) {
+      comp.print_dump();
+    }
+  };
+
   app.add_flag("-c,--cloudsuite", knob_cloudsuite, "Read all traces using the cloudsuite format");
   app.add_flag("--hide-heartbeat", set_heartbeat_callback, "Hide the heartbeat output");
+  app.add_flag("--dump", set_dump_callback, "Dump ChampSim's internal configuration");
   auto* warmup_instr_option = app.add_option("-w,--warmup-instructions", warmup_instructions, "The number of instructions in the warmup phase");
   auto* deprec_warmup_instr_option =
       app.add_option("--warmup_instructions", warmup_instructions, "[deprecated] use --warmup-instructions instead")->excludes(warmup_instr_option);

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -799,6 +799,23 @@ void O3_CPU::print_deadlock()
   champsim::range_print_deadlock(SQ, "cpu" + std::to_string(cpu) + "_SQ", sq_fmt, sq_pack);
 }
 // LCOV_EXCL_STOP
+void O3_CPU::print_dump() {
+  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.clock_period",clock_period.count());
+  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.ifetch_buffer_size",IFETCH_BUFFER_SIZE);
+  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.decode_buffer_size",DECODE_BUFFER_SIZE);
+  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.dispatch_buffer_size",DISPATCH_BUFFER_SIZE);
+  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.register_file_size",REGISTER_FILE_SIZE);
+  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.rob_size",ROB_SIZE);
+  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.lq_width",(std::size_t)LQ_WIDTH);
+  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.sq_width",(std::size_t)SQ_WIDTH);
+  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.retire_width",(std::size_t)RETIRE_WIDTH);
+  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.mispredict_penalty",BRANCH_MISPREDICT_PENALTY / clock_period);
+  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.scheduler_size",(std::size_t)SCHEDULER_SIZE);
+  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.decode_latency",DECODE_LATENCY / clock_period);
+  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.dispatch_latency",DISPATCH_LATENCY / clock_period);
+  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.schedule_latency",SCHEDULING_LATENCY / clock_period);
+  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.execute_latency",EXEC_LATENCY / clock_period);
+}
 
 LSQ_ENTRY::LSQ_ENTRY(champsim::address addr, champsim::program_ordered<LSQ_ENTRY>::id_type id, champsim::address local_ip, std::array<uint8_t, 2> local_asid)
     : champsim::program_ordered<LSQ_ENTRY>{id}, virtual_address(addr), ip(local_ip), asid(local_asid)

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -800,21 +800,21 @@ void O3_CPU::print_deadlock()
 }
 // LCOV_EXCL_STOP
 void O3_CPU::print_dump() {
-  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.clock_period",clock_period.count());
-  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.ifetch_buffer_size",IFETCH_BUFFER_SIZE);
-  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.decode_buffer_size",DECODE_BUFFER_SIZE);
-  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.dispatch_buffer_size",DISPATCH_BUFFER_SIZE);
-  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.register_file_size",REGISTER_FILE_SIZE);
-  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.rob_size",ROB_SIZE);
-  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.lq_width",(std::size_t)LQ_WIDTH);
-  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.sq_width",(std::size_t)SQ_WIDTH);
-  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.retire_width",(std::size_t)RETIRE_WIDTH);
-  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.mispredict_penalty",BRANCH_MISPREDICT_PENALTY / clock_period);
-  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.scheduler_size",(std::size_t)SCHEDULER_SIZE);
-  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.decode_latency",DECODE_LATENCY / clock_period);
-  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.dispatch_latency",DISPATCH_LATENCY / clock_period);
-  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.schedule_latency",SCHEDULING_LATENCY / clock_period);
-  fmt::print("O3 CPU{} {:35} {:>0}\n",cpu,"core.execute_latency",EXEC_LATENCY / clock_period);
+  print_parameter("O3_CPU",std::to_string(cpu),"core.clock_period",clock_period.count());
+  print_parameter("O3_CPU",std::to_string(cpu),"core.ifetch_buffer_size",IFETCH_BUFFER_SIZE);
+  print_parameter("O3_CPU",std::to_string(cpu),"core.decode_buffer_size",DECODE_BUFFER_SIZE);
+  print_parameter("O3_CPU",std::to_string(cpu),"core.dispatch_buffer_size",DISPATCH_BUFFER_SIZE);
+  print_parameter("O3_CPU",std::to_string(cpu),"core.register_file_size",REGISTER_FILE_SIZE);
+  print_parameter("O3_CPU",std::to_string(cpu),"core.rob_size",ROB_SIZE);
+  print_parameter("O3_CPU",std::to_string(cpu),"core.lq_width",(std::size_t)LQ_WIDTH);
+  print_parameter("O3_CPU",std::to_string(cpu),"core.sq_width",(std::size_t)SQ_WIDTH);
+  print_parameter("O3_CPU",std::to_string(cpu),"core.retire_width",(std::size_t)RETIRE_WIDTH);
+  print_parameter("O3_CPU",std::to_string(cpu),"core.mispredict_penalty",BRANCH_MISPREDICT_PENALTY / clock_period);
+  print_parameter("O3_CPU",std::to_string(cpu),"core.scheduler_size",(std::size_t)SCHEDULER_SIZE);
+  print_parameter("O3_CPU",std::to_string(cpu),"core.decode_latency",DECODE_LATENCY / clock_period);
+  print_parameter("O3_CPU",std::to_string(cpu),"core.dispatch_latency",DISPATCH_LATENCY / clock_period);
+  print_parameter("O3_CPU",std::to_string(cpu),"core.schedule_latency",SCHEDULING_LATENCY / clock_period);
+  print_parameter("O3_CPU",std::to_string(cpu),"core.execute_latency",EXEC_LATENCY / clock_period);
 }
 
 LSQ_ENTRY::LSQ_ENTRY(champsim::address addr, champsim::program_ordered<LSQ_ENTRY>::id_type id, champsim::address local_ip, std::array<uint8_t, 2> local_asid)

--- a/src/ptw.cc
+++ b/src/ptw.cc
@@ -240,3 +240,11 @@ void PageTableWalker::print_deadlock()
   });
 }
 // LCOV_EXCL_STOP
+void PageTableWalker::print_dump() {
+  fmt::print("PTW {} {:35} {:>0}\n",NAME,"ptw.clock_period",clock_period.count());
+  fmt::print("PTW {} {:35} {:>0}\n",NAME,"ptw.max_fill",(std::size_t)MAX_FILL);
+  fmt::print("PTW {} {:35} {:>0}\n",NAME,"ptw.max_read",(std::size_t)MAX_READ);
+  fmt::print("PTW {} {:35} {:>0}\n",NAME,"ptw.hit_latency",HIT_LATENCY / clock_period);
+  fmt::print("PTW {} {:35} {:>0}\n",NAME,"ptw.mshr_size",MSHR_SIZE);
+  fmt::print("PTW {} {:35} {:>0}\n",NAME,"ptw.pscl_levels",std::size(pscl) + 1);
+}

--- a/src/ptw.cc
+++ b/src/ptw.cc
@@ -241,10 +241,10 @@ void PageTableWalker::print_deadlock()
 }
 // LCOV_EXCL_STOP
 void PageTableWalker::print_dump() {
-  fmt::print("PTW {} {:35} {:>0}\n",NAME,"ptw.clock_period",clock_period.count());
-  fmt::print("PTW {} {:35} {:>0}\n",NAME,"ptw.max_fill",(std::size_t)MAX_FILL);
-  fmt::print("PTW {} {:35} {:>0}\n",NAME,"ptw.max_read",(std::size_t)MAX_READ);
-  fmt::print("PTW {} {:35} {:>0}\n",NAME,"ptw.hit_latency",HIT_LATENCY / clock_period);
-  fmt::print("PTW {} {:35} {:>0}\n",NAME,"ptw.mshr_size",MSHR_SIZE);
-  fmt::print("PTW {} {:35} {:>0}\n",NAME,"ptw.pscl_levels",std::size(pscl) + 1);
+  print_parameter("PTW",NAME,"ptw.clock_period",clock_period.count());
+  print_parameter("PTW",NAME,"ptw.max_fill",(std::size_t)MAX_FILL);
+  print_parameter("PTW",NAME,"ptw.max_read",(std::size_t)MAX_READ);
+  print_parameter("PTW",NAME,"ptw.hit_latency",HIT_LATENCY / clock_period);
+  print_parameter("PTW",NAME,"ptw.mshr_size",MSHR_SIZE);
+  print_parameter("PTW",NAME,"ptw.pscl_levels",std::size(pscl) + 1);
 }

--- a/src/vmem.cc
+++ b/src/vmem.cc
@@ -154,3 +154,13 @@ std::pair<champsim::address, champsim::chrono::clock::duration> VirtualMemory::g
 
   return {paddr, penalty};
 }
+
+void VirtualMemory::print_dump() {
+  fmt::print("VMEM {:25s} {:>0}\n","vmem.pte_page_size",pte_page_size.count()*8);
+  fmt::print("VMEM {:25s} {:>0}\n","vmem.pt_levels", pt_levels);
+  fmt::print("VMEM {:25s} {:>0}\n","vmem.minor_fault_penalty", minor_fault_penalty.count());
+  if(randomization_seed.has_value())
+    fmt::print("VMEM {:25s} {:>0}\n","vmem.randomization",randomization_seed.value());
+  else
+    fmt::print("VMEM {:25s} {:>1}\n","vmem.randomization","false");
+}

--- a/src/vmem.cc
+++ b/src/vmem.cc
@@ -156,11 +156,11 @@ std::pair<champsim::address, champsim::chrono::clock::duration> VirtualMemory::g
 }
 
 void VirtualMemory::print_dump() {
-  fmt::print("VMEM {:25s} {:>0}\n","vmem.pte_page_size",pte_page_size.count()*8);
-  fmt::print("VMEM {:25s} {:>0}\n","vmem.pt_levels", pt_levels);
-  fmt::print("VMEM {:25s} {:>0}\n","vmem.minor_fault_penalty", minor_fault_penalty.count());
+  print_parameter("VMEM","VMEM","vmem.pte_page_size",pte_page_size.count()*8);
+  print_parameter("VMEM","VMEM","vmem.pt_levels", pt_levels);
+  print_parameter("VMEM","VMEM","vmem.minor_fault_penalty", minor_fault_penalty.count());
   if(randomization_seed.has_value())
-    fmt::print("VMEM {:25s} {:>0}\n","vmem.randomization",randomization_seed.value());
+    print_parameter("VMEM","VMEM","vmem.randomization",randomization_seed.value());
   else
-    fmt::print("VMEM {:25s} {:>1}\n","vmem.randomization","false");
+    print_parameter("VMEM","VMEM","vmem.randomization","false");
 }

--- a/test/cpp/src/401-hit-latency.cc
+++ b/test/cpp/src/401-hit-latency.cc
@@ -25,10 +25,11 @@ SCENARIO("A cache returns a hit after the specified latency") {
       .prefetch_activate(access_type::LOAD, access_type::RFO, access_type::PREFETCH, access_type::WRITE, access_type::TRANSLATION)
     };
 
-    std::array<champsim::operable*, 3> elements{{&uut, &mock_ll, &mock_ul}};
+    std::array<champsim::operable*, 3> operables{{&uut, &mock_ll, &mock_ul}};
+    std::array<champsim::component*, 3> components{{&uut, &mock_ll, &mock_ul}};
 
     // Initialize the prefetching and replacement
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();
@@ -52,7 +53,7 @@ SCENARIO("A cache returns a hit after the specified latency") {
 
       // Run the uut for a bunch of cycles to clear it out of the RQ and fill the cache
       for (auto i = 0; i < 100; ++i)
-        for (auto elem : elements)
+        for (auto elem : operables)
           elem->_operate();
 
       AND_WHEN("A packet with the same address is sent") {
@@ -67,7 +68,7 @@ SCENARIO("A cache returns a hit after the specified latency") {
         }
 
         for (uint64_t i = 0; i < 2*hit_latency; ++i)
-          for (auto elem : elements)
+          for (auto elem : operables)
             elem->_operate();
 
         THEN("It takes exactly the specified cycles to return") {

--- a/test/cpp/src/402-miss-latency.cc
+++ b/test/cpp/src/402-miss-latency.cc
@@ -27,9 +27,10 @@ SCENARIO("A cache returns a miss after the specified latency") {
       .prefetch_activate(access_type::LOAD, access_type::RFO, access_type::PREFETCH, access_type::WRITE, access_type::TRANSLATION)
     };
 
-    std::array<champsim::operable*, 3> elements{{&uut, &mock_ll, &mock_ul}};
+    std::array<champsim::operable*, 3> operables{{&uut, &mock_ll, &mock_ul}};
+    std::array<champsim::component*, 3> components{{&uut, &mock_ll, &mock_ul}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();
@@ -59,7 +60,7 @@ SCENARIO("A cache returns a miss after the specified latency") {
 
       // Run the uut for long enough to miss
       for (uint64_t i = 0; i < hit_latency+1; ++i)
-        for (auto elem : elements)
+        for (auto elem : operables)
           elem->_operate();
 
       THEN("The MSHR occupancy increases") {
@@ -70,7 +71,7 @@ SCENARIO("A cache returns a miss after the specified latency") {
 
       // Run the uut for long enough to fill the cache
       for (uint64_t i = 0; i < 2*(miss_latency+fill_latency); ++i)
-        for (auto elem : elements)
+        for (auto elem : operables)
           elem->_operate();
 
       THEN("It takes exactly the specified cycles to return") {
@@ -120,9 +121,10 @@ SCENARIO("A cache completes a fill after the specified latency") {
 
     CACHE uut{builder};
 
-    std::array<champsim::operable*, 3> elements{{&uut, &mock_ll, &mock_ul}};
+    std::array<champsim::operable*, 3> operables{{&uut, &mock_ll, &mock_ul}};
+    std::array<champsim::component*, 3> components{{&uut, &mock_ll, &mock_ul}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();
@@ -147,7 +149,7 @@ SCENARIO("A cache completes a fill after the specified latency") {
 
       // Run the uut for a bunch of cycles to clear it out of the WQ and fill the cache
       for (uint64_t i = 0; i < 2*(miss_latency+hit_latency+fill_latency); ++i)
-        for (auto elem : elements)
+        for (auto elem : operables)
           elem->_operate();
 
       THEN("It takes exactly the specified cycles to return") {
@@ -194,9 +196,10 @@ SCENARIO("The MSHR bandwidth limits the number of outstanding misses") {
         .mshr_size(1)
     };
 
-    std::array<champsim::operable*, 4> elements{{&mock_ll, &uut, &mock_ul_seed, &mock_ul_test}};
+    std::array<champsim::operable*, 4> operables{{&mock_ll, &uut, &mock_ul_seed, &mock_ul_test}};
+    std::array<champsim::component*, 4> components{{&mock_ll, &uut, &mock_ul_seed, &mock_ul_test}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();
@@ -212,7 +215,7 @@ SCENARIO("The MSHR bandwidth limits the number of outstanding misses") {
     auto test_a_result = mock_ul_seed.issue(test_a);
 
     for (uint64_t i = 0; i < 100; ++i)
-      for (auto elem : elements)
+      for (auto elem : operables)
         elem->_operate();
 
     THEN("The issue is received") {
@@ -237,7 +240,7 @@ SCENARIO("The MSHR bandwidth limits the number of outstanding misses") {
 
       auto first_packet_delay = 10;
       for (auto i = 0; i < first_packet_delay; ++i)
-        for (auto elem : elements)
+        for (auto elem : operables)
           elem->_operate();
 
       THEN("The test packet was not forwarded to the lower level") {
@@ -261,9 +264,10 @@ SCENARIO("A lower-level queue refusal limits the number of outstanding misses") 
       .lower_level(&refusal_channel)
     };
 
-    std::array<champsim::operable*, 2> elements{{&uut, &mock_ul}};
+    std::array<champsim::operable*, 2> operables{{&uut, &mock_ul}};
+    std::array<champsim::component*, 2> components{{&uut, &mock_ul}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();
@@ -282,7 +286,7 @@ SCENARIO("A lower-level queue refusal limits the number of outstanding misses") 
       auto test_a_result = mock_ul.issue(test_a);
 
       for (uint64_t i = 0; i < 100; ++i)
-        for (auto elem : elements)
+        for (auto elem : operables)
           elem->_operate();
 
       THEN("The issue is received") {
@@ -291,7 +295,7 @@ SCENARIO("A lower-level queue refusal limits the number of outstanding misses") 
 
       auto first_packet_delay = 10;
       for (auto i = 0; i < first_packet_delay; ++i)
-        for (auto elem : elements)
+        for (auto elem : operables)
           elem->_operate();
 
       THEN("The number of misses did not increase") {

--- a/test/cpp/src/403-read-bandwidth.cc
+++ b/test/cpp/src/403-read-bandwidth.cc
@@ -23,9 +23,10 @@ TEMPLATE_TEST_CASE("The read queue respects the tag bandwidth", "", to_rq_MRP, t
       .fill_bandwidth(champsim::bandwidth::maximum_type{10})
     };
 
-    std::array<champsim::operable*, 3> elements{{&uut, &mock_ll, &mock_ul}};
+    std::array<champsim::operable*, 3> operables{{&uut, &mock_ll, &mock_ul}};
+    std::array<champsim::component*, 3> components{{&uut, &mock_ll, &mock_ul}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();
@@ -52,7 +53,7 @@ TEMPLATE_TEST_CASE("The read queue respects the tag bandwidth", "", to_rq_MRP, t
 
     // Run the uut for a bunch of cycles to clear it out of the RQ and fill the cache
     for (auto i = 0; i < 100; ++i)
-      for (auto elem : elements)
+      for (auto elem : operables)
         elem->_operate();
 
     WHEN("The same packets are sent") {
@@ -66,7 +67,7 @@ TEMPLATE_TEST_CASE("The read queue respects the tag bandwidth", "", to_rq_MRP, t
       }
 
       for (auto i = 0; i < 100; ++i)
-        for (auto elem : elements)
+        for (auto elem : operables)
           elem->_operate();
 
       auto cycle = (size-1)/tag_bandwidth;

--- a/test/cpp/src/404-fill-bandwidth.cc
+++ b/test/cpp/src/404-fill-bandwidth.cc
@@ -23,9 +23,10 @@ SCENARIO("The MSHR respects the fill bandwidth") {
       .fill_bandwidth(champsim::bandwidth::maximum_type{fill_bandwidth})
     };
 
-    std::array<champsim::operable*, 3> elements{{&uut, &mock_ll, &mock_ul}};
+    std::array<champsim::operable*, 3> operables{{&uut, &mock_ll, &mock_ul}};
+    std::array<champsim::component*, 3> components{{&uut, &mock_ll, &mock_ul}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();
@@ -53,7 +54,7 @@ SCENARIO("The MSHR respects the fill bandwidth") {
 
       // Give the cache enough time to miss
       for (auto i = 0; i < 100; ++i)
-        for (auto elem : elements)
+        for (auto elem : operables)
           elem->_operate();
 
       for (const auto &pkt : seeds)
@@ -61,7 +62,7 @@ SCENARIO("The MSHR respects the fill bandwidth") {
 
       // Give the cache enough time to fill
       for (auto i = 0; i < 100; ++i)
-        for (auto elem : elements)
+        for (auto elem : operables)
           elem->_operate();
 
       auto cycle = (size-1)/fill_bandwidth;
@@ -94,10 +95,11 @@ SCENARIO("Writebacks respect the fill bandwidth") {
       .fill_bandwidth(champsim::bandwidth::maximum_type{fill_bandwidth})
     };
 
-    std::array<champsim::operable*, 3> elements{{&uut, &mock_ll, &mock_ul}};
+    std::array<champsim::operable*, 3> operables{{&uut, &mock_ll, &mock_ul}};
+    std::array<champsim::component*, 3> components{{&uut, &mock_ll, &mock_ul}};
 
     // Initialize the prefetching and replacement
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();
@@ -126,7 +128,7 @@ SCENARIO("Writebacks respect the fill bandwidth") {
 
       // Run the uut for a bunch of cycles to clear it out of the RQ and fill the cache
       for (auto i = 0; i < 100; ++i)
-        for (auto elem : elements)
+        for (auto elem : operables)
           elem->_operate();
 
       auto cycle = (size-1)/fill_bandwidth;

--- a/test/cpp/src/405-fill-eviction.cc
+++ b/test/cpp/src/405-fill-eviction.cc
@@ -21,8 +21,9 @@ SCENARIO("A cache evicts a block when required") {
     };
 
     std::array<champsim::operable*, 4> elements{{&uut, &mock_ll, &mock_ul_seed, &mock_ul_test}};
+    std::array<champsim::component*, 4> components{{&uut, &mock_ll, &mock_ul_seed, &mock_ul_test}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();

--- a/test/cpp/src/406-mshr-merge.cc
+++ b/test/cpp/src/406-mshr-merge.cc
@@ -47,8 +47,9 @@ SCENARIO("A cache merges two requests in the MSHR") {
     };
 
     std::array<champsim::operable*, 4> elements{{&mock_ll, &uut, &mock_ul_seed, &mock_ul_test}};
+    std::array<champsim::component*, 4> components{{&mock_ll, &uut, &mock_ul_seed, &mock_ul_test}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();

--- a/test/cpp/src/407-writeback-dirty.cc
+++ b/test/cpp/src/407-writeback-dirty.cc
@@ -21,8 +21,9 @@ SCENARIO("Blocks that have been written are marked dirty") {
     };
 
     std::array<champsim::operable*, 4> elements{{&uut, &mock_ll, &mock_ul_seed, &mock_ul_test}};
+    std::array<champsim::component*, 4> components{{&uut, &mock_ll, &mock_ul_seed, &mock_ul_test}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();

--- a/test/cpp/src/408-set-independence.cc
+++ b/test/cpp/src/408-set-independence.cc
@@ -36,10 +36,9 @@ struct test_fixture
     .tag_bandwidth(champsim::bandwidth::maximum_type{way})
     .fill_bandwidth(champsim::bandwidth::maximum_type{way})
   ) {
-    std::array<champsim::operable*, 3> elements{{&uut, &mock_ll, &mock_ul}};
-
+    std::array<champsim::component*, 3> components{{&uut, &mock_ll, &mock_ul}};
     // Initialize the prefetching and replacement
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();

--- a/test/cpp/src/411-queue-translation-hit.cc
+++ b/test/cpp/src/411-queue-translation-hit.cc
@@ -19,8 +19,9 @@ TEMPLATE_TEST_CASE("Caches issue translations", "", to_wq_MRP, to_rq_MRP, to_pq_
     };
 
     std::array<champsim::operable*, 4> elements{{&uut, &mock_ll, &mock_ul, &mock_translator}};
+    std::array<champsim::component*, 4> components{{&uut, &mock_ll, &mock_ul, &mock_translator}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();
@@ -75,8 +76,9 @@ TEMPLATE_TEST_CASE("Translations work even if the addresses happen to be the sam
     };
 
     std::array<champsim::operable*, 4> elements{{&uut, &mock_ll, &mock_ul, &mock_translator}};
+    std::array<champsim::component*, 4> components{{&uut, &mock_ll, &mock_ul, &mock_translator}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();

--- a/test/cpp/src/412-queue-translation-miss.cc
+++ b/test/cpp/src/412-queue-translation-miss.cc
@@ -20,8 +20,9 @@ TEMPLATE_TEST_CASE("Caches detect translation misses", "", to_wq_MRP, to_rq_MRP,
     };
 
     std::array<champsim::operable*, 4> elements{{&uut, &mock_ll, &mock_ul, &mock_translator}};
+    std::array<champsim::component*, 4> components{{&uut, &mock_ll, &mock_ul, &mock_translator}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();

--- a/test/cpp/src/413-hit-under-miss.cc
+++ b/test/cpp/src/413-hit-under-miss.cc
@@ -21,8 +21,9 @@ TEMPLATE_TEST_CASE("Translation misses do not inhibit other packets from being i
     };
 
     std::array<champsim::operable*, 4> elements{{&uut, &mock_ll, &mock_translator, &mock_ul}};
+    std::array<champsim::component*, 4> components{{&uut, &mock_ll, &mock_translator, &mock_ul}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();

--- a/test/cpp/src/414-tag-check-bound.cc
+++ b/test/cpp/src/414-tag-check-bound.cc
@@ -18,8 +18,9 @@ TEST_CASE("Tag checks do not break when translation misses back up") {
   };
 
   std::array<champsim::operable*, 4> elements{{&uut, &mock_ll, &mock_ul, &mock_translator}};
+  std::array<champsim::component*, 4> components{{&uut, &mock_ll, &mock_ul, &mock_translator}};
 
-  for (auto elem : elements) {
+  for (auto elem : components) {
     elem->initialize();
     elem->warmup = false;
     elem->begin_phase();
@@ -76,8 +77,9 @@ TEST_CASE("Backed up translation misses do not prevent translated packets from a
   };
 
   std::array<champsim::operable*, 4> elements{{&uut, &mock_ll, &seed_ul, &mock_ul}};
+  std::array<champsim::component*, 4> components{{&uut, &mock_ll, &seed_ul, &mock_ul}};
 
-  for (auto elem : elements) {
+  for (auto elem : components) {
     elem->initialize();
     elem->warmup = false;
     elem->begin_phase();

--- a/test/cpp/src/415-translation-collision.cc
+++ b/test/cpp/src/415-translation-collision.cc
@@ -20,8 +20,9 @@ SCENARIO("A cache keeps the address for packets that don't need translation") {
     };
 
     std::array<champsim::operable*, 4> elements{{&uut, &mock_ll, &mock_ul, &mock_translator}};
+    std::array<champsim::component*, 4> components{{&uut, &mock_ll, &mock_ul, &mock_translator}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();

--- a/test/cpp/src/420-issue-prefetch.cc
+++ b/test/cpp/src/420-issue-prefetch.cc
@@ -43,8 +43,9 @@ SCENARIO("A prefetch can be issued") {
     };
 
     std::array<champsim::operable*, 3> elements{{&mock_ll, &mock_ul, &uut}};
+    std::array<champsim::component*, 3> components{{&mock_ll, &mock_ul, &uut}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();

--- a/test/cpp/src/421-prefetch-fill-level.cc
+++ b/test/cpp/src/421-prefetch-fill-level.cc
@@ -20,8 +20,9 @@ SCENARIO("A prefetch can be issued that creates an MSHR") {
     };
 
     std::array<champsim::operable*, 2> elements{{&mock_ll, &uut}};
+    std::array<champsim::component*, 2> components{{&mock_ll, &uut}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();
@@ -62,8 +63,9 @@ SCENARIO("A prefetch can be issued without creating an MSHR") {
     };
 
     std::array<champsim::operable*, 2> elements{{&mock_ll, &uut}};
+    std::array<champsim::component*, 2> components{{&mock_ll, &uut}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();
@@ -101,8 +103,9 @@ SCENARIO("A prefetch fill the first level") {
     };
 
     std::array<champsim::operable*, 3> elements{{&uut, &mock_ll, &mock_ut}};
+    std::array<champsim::component*, 3> components{{&uut, &mock_ll, &mock_ut}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();
@@ -167,8 +170,9 @@ SCENARIO("A prefetch not fill the first level and fill the second level") {
     };
 
     std::array<champsim::operable*, 5> elements{{&uut, &mock_ll, &uul, &mock_ut, &mock_ul}};
+    std::array<champsim::component*, 5> components{{&uut, &mock_ll, &uul, &mock_ut, &mock_ul}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();

--- a/test/cpp/src/422-prefetch-hit.cc
+++ b/test/cpp/src/422-prefetch-hit.cc
@@ -18,8 +18,9 @@ SCENARIO("A prefetch can hit the cache") {
     };
 
     std::array<champsim::operable*, 3> elements{{&mock_ll, &mock_ul, &uut}};
+    std::array<champsim::component*, 3> components{{&mock_ll, &mock_ul, &uut}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();
@@ -67,8 +68,9 @@ SCENARIO("A prefetch not intended to fill this level that would hit the cache is
     };
 
     std::array<champsim::operable*, 3> elements{{&mock_ll, &mock_ul, &uut}};
+    std::array<champsim::component*, 3> components{{&mock_ll, &mock_ul, &uut}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();

--- a/test/cpp/src/423-prefetcher-activate.cc
+++ b/test/cpp/src/423-prefetcher-activate.cc
@@ -40,8 +40,9 @@ SCENARIO("A prefetch does not trigger itself") {
     };
 
     std::array<champsim::operable*, 2> elements{{&mock_ll, &uut}};
+    std::array<champsim::component*, 2> components{{&mock_ll, &uut}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();
@@ -85,8 +86,9 @@ SCENARIO("The prefetcher is triggered if the packet matches the activate field")
     };
 
     std::array<champsim::operable*, 3> elements{{&mock_ll, &mock_ul, &uut}};
+    std::array<champsim::component*, 3> components{{&mock_ll, &mock_ul, &uut}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();
@@ -142,8 +144,9 @@ SCENARIO("The prefetcher is not triggered if the packet does not match the activ
     CACHE uut{builder};
 
     std::array<champsim::operable*, 3> elements{{&mock_ll, &mock_ul, &uut}};
+    std::array<champsim::component*, 3> components{{&mock_ll, &mock_ul, &uut}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();

--- a/test/cpp/src/424-duplicate-prefetch.cc
+++ b/test/cpp/src/424-duplicate-prefetch.cc
@@ -18,8 +18,9 @@ SCENARIO("Duplicate prefetches do not count each other as useful") {
     };
 
     std::array<champsim::operable*, 3> elements{{&mock_ll, &mock_ul, &uut}};
+    std::array<champsim::component*, 3> components{{&mock_ll, &mock_ul, &uut}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();

--- a/test/cpp/src/425-useless-prefetch.cc
+++ b/test/cpp/src/425-useless-prefetch.cc
@@ -23,8 +23,9 @@ SCENARIO("A cache increments the useless prefetch count when it evicts an unhit 
     };
 
     std::array<champsim::operable*, 4> elements{{&uut, &mock_ll, &mock_ul_seed, &mock_ul_test}};
+    std::array<champsim::component*, 4> components{{&uut, &mock_ll, &mock_ul_seed, &mock_ul_test}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();

--- a/test/cpp/src/426-internal-pq-size.cc
+++ b/test/cpp/src/426-internal-pq-size.cc
@@ -13,9 +13,9 @@ SCENARIO("The prefetch queue size limits the number of prefetches that can be is
       .pq_size((unsigned)pq_size)
     };
 
-    std::array<champsim::operable*, 2> elements{{&mock_ll, &uut}};
+    std::array<champsim::component*, 2> components{{&mock_ll, &uut}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();

--- a/test/cpp/src/430-prefetcher-interface.cc
+++ b/test/cpp/src/430-prefetcher-interface.cc
@@ -60,8 +60,9 @@ SCENARIO("The prefetcher interface prefers one that uses champsim::address") {
     };
 
     std::array<champsim::operable*, 3> elements{{&mock_ll, &mock_ul, &uut}};
+    std::array<champsim::component*, 3> components{{&mock_ll, &mock_ul, &uut}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();

--- a/test/cpp/src/431-merge-prefetch.cc
+++ b/test/cpp/src/431-merge-prefetch.cc
@@ -19,6 +19,7 @@ struct merge_testbed
   uint32_t pkt_id = 0;
 
   std::array<champsim::operable*, 4> elements{{&mock_ll, &uut, &seed_ul, &test_ul}};
+  std::array<champsim::component*, 4> components{{&mock_ll, &uut, &seed_ul, &test_ul}};
 
   template <typename MRP>
   void issue_type(MRP& ul, access_type type, uint64_t delay = hit_latency+1)
@@ -40,7 +41,7 @@ struct merge_testbed
 
   explicit merge_testbed(access_type type)
   {
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();

--- a/test/cpp/src/432-prefetch-metadata.cc
+++ b/test/cpp/src/432-prefetch-metadata.cc
@@ -67,8 +67,9 @@ SCENARIO("Prefetch metadata from an issued prefetch is seen in the lower level")
     };
 
     std::array<champsim::operable*, 3> elements{{&mock_ll, &lower, &upper}};
+    std::array<champsim::component*, 3> components{{&mock_ll, &lower, &upper}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();
@@ -123,8 +124,9 @@ SCENARIO("Prefetch metadata from an filled block is seen in the upper level") {
     };
 
     std::array<champsim::operable*, 4> elements{{&mock_ll, &lower, &upper, &mock_ul}};
+    std::array<champsim::component*, 4> components{{&mock_ll, &lower, &upper, &mock_ul}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();

--- a/test/cpp/src/441-replacement-bypass.cc
+++ b/test/cpp/src/441-replacement-bypass.cc
@@ -37,8 +37,9 @@ SCENARIO("The replacement policy can bypass") {
     };
 
     std::array<champsim::operable*, 4> elements{{&mock_ll, &uut, &mock_ul_seed, &mock_ul_test}};
+    std::array<champsim::component*, 4> components{{&mock_ll, &uut, &mock_ul_seed, &mock_ul_test}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();

--- a/test/cpp/src/442-replacement-interface.cc
+++ b/test/cpp/src/442-replacement-interface.cc
@@ -58,8 +58,9 @@ SCENARIO("The replacement policy is triggered on a miss, not on a fill") {
     };
 
     std::array<champsim::operable*, 3> elements{{&mock_ll, &mock_ul, &uut}};
+    std::array<champsim::component*, 3> components{{&mock_ll, &mock_ul, &uut}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();
@@ -133,8 +134,9 @@ SCENARIO("The replacement policy is triggered on a hit") {
     };
 
     std::array<champsim::operable*, 3> elements{{&mock_ll, &mock_ul, &uut}};
+    std::array<champsim::component*, 3> components{{&mock_ll, &mock_ul, &uut}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();
@@ -204,8 +206,9 @@ SCENARIO("The replacement policy notes the correct eviction information") {
     };
 
     std::array<champsim::operable*, 4> elements{{&mock_ll, &mock_ul_seed, &mock_ul_test, &uut}};
+    std::array<champsim::component*, 4> components{{&mock_ll, &mock_ul_seed, &mock_ul_test, &uut}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();

--- a/test/cpp/src/443-replacement-interface-selection.cc
+++ b/test/cpp/src/443-replacement-interface-selection.cc
@@ -87,8 +87,9 @@ SCENARIO("The simulator selects the address-based victim finder in replacement p
     };
 
     std::array<champsim::operable*, 3> elements{{&mock_ll, &mock_ul, &uut}};
+    std::array<champsim::component*, 3> components{{&mock_ll, &mock_ul, &uut}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();
@@ -165,8 +166,9 @@ SCENARIO("The simulator selects the address-based update function in replacement
     };
 
     std::array<champsim::operable*, 3> elements{{&mock_ll, &mock_ul, &uut}};
+    std::array<champsim::component*, 3> components{{&mock_ll, &mock_ul, &uut}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();
@@ -230,8 +232,9 @@ SCENARIO("The simulator selects the cache fill function if it is available") {
     };
 
     std::array<champsim::operable*, 3> elements{{&mock_ll, &mock_ul, &uut}};
+    std::array<champsim::component*, 3> components{{&mock_ll, &mock_ul, &uut}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();

--- a/test/cpp/src/451-next-line-behavior.cc
+++ b/test/cpp/src/451-next-line-behavior.cc
@@ -18,8 +18,9 @@ SCENARIO("The next line prefetcher issues prefetches") {
     };
 
     std::array<champsim::operable*, 3> elements{{&mock_ll, &mock_ul, &uut}};
+    std::array<champsim::component*, 3> components{{&mock_ll, &mock_ul, &uut}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();
@@ -64,8 +65,9 @@ SCENARIO("The next line prefetcher issues prefetches in a moved-constructed cach
     CACHE uut{std::move(move_source)};
 
     std::array<champsim::operable*, 3> elements{{&mock_ll, &mock_ul, &uut}};
+    std::array<champsim::component*, 3> components{{&mock_ll, &mock_ul, &uut}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();

--- a/test/cpp/src/452-ip-stride-behavior.cc
+++ b/test/cpp/src/452-ip-stride-behavior.cc
@@ -21,8 +21,9 @@ SCENARIO("The ip_stride prefetcher issues prefetches when the IP matches") {
     };
 
     std::array<champsim::operable*, 3> elements{{&mock_ll, &mock_ul, &uut}};
+    std::array<champsim::component*, 3> components{{&mock_ll, &mock_ul, &uut}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();

--- a/test/cpp/src/453-va-ampm-lite-behavior.cc
+++ b/test/cpp/src/453-va-ampm-lite-behavior.cc
@@ -22,8 +22,9 @@ SCENARIO("The va_ampm_lite prefetcher issues prefetches when addresses stride in
     };
 
     std::array<champsim::operable*, 4> elements{{&mock_ll, &mock_lt, &mock_ul, &uut}};
+    std::array<champsim::component*, 4> components{{&mock_ll, &mock_lt, &mock_ul, &uut}};
 
-    for (auto elem : elements) {
+    for (auto elem : components) {
       elem->initialize();
       elem->warmup = false;
       elem->begin_phase();

--- a/test/cpp/src/mocks.hpp
+++ b/test/cpp/src/mocks.hpp
@@ -13,7 +13,7 @@
 /*
  * A MemoryRequestConsumer that simply returns all packets on the next cycle
  */
-class do_nothing_MRC : public champsim::operable
+class do_nothing_MRC : public champsim::operable, public champsim::component
 {
   struct packet : champsim::channel::request_type
   {
@@ -69,7 +69,7 @@ class do_nothing_MRC : public champsim::operable
 /*
  * A MemoryRequestConsumer that returns only a particular address
  */
-class filter_MRC : public champsim::operable
+class filter_MRC : public champsim::operable, public champsim::component
 {
   struct packet : champsim::channel::request_type
   {
@@ -123,7 +123,7 @@ class filter_MRC : public champsim::operable
 /*
  * A MemoryRequestConsumer that releases blocks when instructed to
  */
-class release_MRC : public champsim::operable
+class release_MRC : public champsim::operable, public champsim::component
 {
   std::deque<champsim::channel::request_type> packets;
   std::size_t mpacket_count = 0;
@@ -190,7 +190,7 @@ struct counting_MRP
   }
 };
 
-struct queue_issue_MRP : public champsim::operable
+struct queue_issue_MRP : public champsim::operable, public champsim::component
 {
   using request_type = typename champsim::channel::request_type;
   using response_type = typename champsim::channel::response_type;


### PR DESCRIPTION
Passing the argument _--dump_ when running ChampSim will now dump the internal configuration of ChampSim's components and then quit.

The component class was added to help differentiate two classes of interfaces within ChampSim.
The component class exposes interfaces to the runtime, while the operable class exposes interfaces to the clock bus.
Most ChampSim operables inherit from both, while certain components like VMEM only inherit from one.