### PR TITLE
fix: deprecated options in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Storage for these traces is kindly provided by Daniel Jimenez (Texas A&M Univers
 
 Execute the binary directly.
 ```
-$ bin/champsim --warmup_instructions 200000000 --simulation_instructions 500000000 ~/path/to/traces/600.perlbench_s-210B.champsimtrace.xz
+$ bin/champsim --warmup-instructions 200000000 --simulation-instructions 500000000 ~/path/to/traces/600.perlbench_s-210B.champsimtrace.xz
 ```
 
 The number of warmup and simulation instructions given will be the number of instructions retired. Note that the statistics printed at the end of the simulation include only the simulation phase.
@@ -73,7 +73,7 @@ Note that the example prefetcher is an L2 prefetcher. You might design a prefetc
 ```
 $ ./config.sh <configuration file>
 $ make
-$ bin/champsim --warmup_instructions 200000000 --simulation_instructions 500000000 600.perlbench_s-210B.champsimtrace.xz
+$ bin/champsim --warmup-instructions 200000000 --simulation-instructions 500000000 600.perlbench_s-210B.champsimtrace.xz
 ```
 
 # How to create traces


### PR DESCRIPTION
the `--warmup_instructions` and `--simulation_instructions` options were deprecated, changed for the "-" version in the README