### PR TITLE
Replace uses of <random> with Boost.random

### DIFF
--- a/inc/vmem.h
+++ b/inc/vmem.h
@@ -21,7 +21,6 @@
 #include <deque>
 #include <map>
 #include <optional>
-#include <random>
 
 #include "address.h"
 #include "champsim.h"

--- a/replacement/random/random.h
+++ b/replacement/random/random.h
@@ -1,14 +1,14 @@
 #ifndef REPLACEMENT_RANDOM_H
 #define REPLACEMENT_RANDOM_H
 
-#include <random>
+#include <boost/random.hpp>
 
 #include "cache.h"
 #include "modules.h"
 
 struct random : public champsim::modules::replacement {
-  std::mt19937_64 rng{};
-  std::uniform_int_distribution<long> dist;
+  boost::mt19937_64 rng{};
+  boost::random::uniform_int_distribution<long> dist;
 
   explicit random(CACHE* cache);
   random(CACHE* cache, long ways);

--- a/replacement/ship/ship.cc
+++ b/replacement/ship/ship.cc
@@ -2,7 +2,7 @@
 
 #include <algorithm>
 #include <cassert>
-#include <random>
+#include <boost/random.hpp>
 
 #include "champsim.h"
 
@@ -12,7 +12,7 @@ ship::ship(CACHE* cache)
       rrpv_values(static_cast<std::size_t>(NUM_SET * NUM_WAY), maxRRPV)
 {
   // randomly selected sampler sets
-  std::generate_n(std::back_inserter(rand_sets), SAMPLER_SET_FACTOR * NUM_CPUS, std::knuth_b{1});
+  std::generate_n(std::back_inserter(rand_sets), SAMPLER_SET_FACTOR * NUM_CPUS, boost::random::knuth_b{1});
   std::sort(std::begin(rand_sets), std::end(rand_sets));
 
   std::generate_n(std::back_inserter(SHCT), NUM_CPUS, []() -> typename decltype(SHCT)::value_type { return {}; });

--- a/src/vmem.cc
+++ b/src/vmem.cc
@@ -17,10 +17,12 @@
 #include "vmem.h"
 
 #include <cassert>
+#include <boost/random.hpp>
 #include <fmt/core.h>
 
 #include "champsim.h"
 #include "dram_controller.h"
+#include "util/algorithm.h"
 #include "util/bits.h"
 
 using namespace champsim::data::data_literals;
@@ -70,7 +72,7 @@ void VirtualMemory::populate_pages()
 void VirtualMemory::shuffle_pages()
 {
   if (randomization_seed.has_value())
-    std::shuffle(ppage_free_list.begin(), ppage_free_list.end(), std::mt19937_64{randomization_seed.value()});
+    champsim::shuffle(ppage_free_list.begin(), ppage_free_list.end(), boost::mt19937_64{randomization_seed.value()});
 }
 
 champsim::dynamic_extent VirtualMemory::extent(std::size_t level) const

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,6 +2,7 @@
   "name": "champsim",
   "version-string": "1.0",
   "dependencies": [
+    "boost-random",
     "cli11",
     "nlohmann-json",
     "fmt",


### PR DESCRIPTION
While building ChampSim on two different machines, I noticed that I was getting different results for the exact same configuration. After some investigation, I found out it was due to the machines (Ubuntu 20.04 and Arch Linux) having different libstdc++ versions with different implementations of [std::uniform_int_distribution](https://en.cppreference.com/w/cpp/numeric/random/uniform_int_distribution). This led to the shuffling of vmem pages inside std::shuffle to differ between the two machines. I'm happy to provide more details on the exact issue I observed and the two systems in question.

As a quick fix for this, I replaced all uses of <random> (which thankfully weren't many) with [Boost.random](https://www.boost.org/doc/libs/1_87_0/doc/html/boost_random.html), since Boost's implementation is platform-agnostic. This appears to have resolved the issue.

To avoid this in the future, it might be a good idea to add a CI test which ensures that the outputs of the simulations match for every compiler.