### PR TITLE
Bump vcpkg from 69efe9c to 1de2026

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ override REPLACEMENT_ROOT += $(addsuffix /replacement,$(MODULE_ROOT))
 TRIPLET_DIR = $(patsubst %/,%,$(firstword $(filter-out $(ROOT_DIR)/vcpkg_installed/vcpkg/, $(wildcard $(ROOT_DIR)/vcpkg_installed/*/))))
 override CPPFLAGS += -I$(OBJ_ROOT)
 override LDFLAGS  += -L$(TRIPLET_DIR)/lib -L$(TRIPLET_DIR)/lib/manual-link
-override LDLIBS   += -llzma -lz -lbz2 -lfmt
+override LDLIBS   += -lCLI11 -llzma -lz -lbz2 -lfmt
 
 .PHONY: all clean compile_commands compile_commands_clean configclean test pytest maketest
 

--- a/test/cpp/src/044-extract.cc
+++ b/test/cpp/src/044-extract.cc
@@ -1,4 +1,5 @@
 #include <catch.hpp>
+#include <numeric>
 #include <vector>
 
 #include "util/algorithm.h"


### PR DESCRIPTION
I had to update vcpkg to get a dependency I want for my fork. I hope this change to bump the version is also useful for upstream too.

Bumps [vcpkg](https://github.com/Microsoft/vcpkg) from `69efe9c` to `1de2026`.
- [Release notes](https://github.com/Microsoft/vcpkg/releases)
- [Commits](https://github.com/microsoft/vcpkg/compare/69efe9cc2df0015f0bb2d37d55acde4a75c9a25b...1de2026f28ead93ff1773e6e680387643e914ea1)

The new revision is the last vcpkg release that is not affected by:
https://github.com/fmtlib/fmt/issues/4133