### PR TITLE
Fix is_last_step in PageTableWalker::finish_packet

### DIFF
--- a/src/ptw.cc
+++ b/src/ptw.cc
@@ -210,15 +210,15 @@ void PageTableWalker::finish_packet(const response_type& packet)
     return champsim::block_number{x.address} == block;
   };
   auto is_last_step = [](auto x) {
-    return x.translation_level > 0;
+    return x.translation_level <= 0;
   };
   auto last_finished = std::partition(std::begin(MSHR), std::end(MSHR), matches_addr);
 
   std::for_each(std::begin(MSHR), last_finished, [is_last_step, finish_step, finish_last_step](auto& mshr_entry) {
-    mshr_entry.data = is_last_step(mshr_entry) ? finish_step(mshr_entry) : finish_last_step(mshr_entry);
+    mshr_entry.data = is_last_step(mshr_entry) ? finish_last_step(mshr_entry) : finish_step(mshr_entry);
   });
 
-  std::partition_copy(std::begin(MSHR), last_finished, std::back_inserter(finished), std::back_inserter(completed), is_last_step);
+  std::partition_copy(std::begin(MSHR), last_finished, std::back_inserter(completed), std::back_inserter(finished), is_last_step);
   MSHR.erase(std::begin(MSHR), last_finished);
 }
 


### PR DESCRIPTION
The semantics of is_last_step is inverted so correct it. There is no behavioral change as callers of the function were based on the inverted semantics, which are corrected too.