### PR TITLE
Add Kanata logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,4 +86,18 @@ Example tracing utilities are provided in the `tracer/` directory.
 ChampSim measures the IPC (Instruction Per Cycle) value as a performance metric. <br>
 There are some other useful metrics printed out at the end of simulation. <br>
 
+# Generating Kanata logs
+
+[Kanata](https://github.com/shioyadan/Konata/blob/master/docs/kanata-log-format.md) is a log format to record the behavior of processor pipelines, which can be used with [Konata](https://github.com/shioyadan/Konata), an instruction pipeline visualizer.
+
+There are three options that can control Kanata log generation:
+
+- `--kanata` tells the path to write Kanata logs. If no name is specified, stdout will be used.
+- `--kanata-max` tells the maximum number of instructions to log.
+- `--kanata-skip` tells the number of instructions to skip before starting Kanata log generation.
+
+```sh
+$ bin/champsim --warmup-instructions 200000000 --simulation-instructions 500000000 --kanata >(gzip > kanata.log.gz) --kanata-max 100000 --kanata-skip 200000000 600.perlbench_s-210B.champsimtrace.xz
+```
+
 Good luck and be a champion! <br>

--- a/inc/event_listeners.h
+++ b/inc/event_listeners.h
@@ -8,8 +8,9 @@
 
 #include "events.h"
 #include "listeners/heartbeat.h"
+#include "listeners/kanata.h"
 
-inline auto listeners = std::make_tuple(Heartbeat(&std::cout));
+inline auto listeners = std::make_tuple(Heartbeat(&std::cout), champsim::kanata::Kanata());
 
 template <typename>
 struct listener_names_helper {
@@ -22,10 +23,19 @@ constexpr inline auto listener_names = listener_names_helper<decltype(listeners)
 
 inline std::bitset<std::tuple_size_v<decltype(listeners)>> listener_activation_map;
 
+template <std::size_t... Is>
+void event_listener_cli(std::index_sequence<Is...>, CLI::App& app)
+{
+  (std::get<Is>(listeners).cli(app), ...);
+}
+
+inline void event_listener_cli(CLI::App& app) { event_listener_cli(std::make_index_sequence<std::tuple_size_v<decltype(listeners)>>{}, app); }
+
 inline void init_event_listeners(const std::vector<std::string>& requested_listeners)
 {
   listener_activation_map.reset();
   listener_activation_map[0] = true; // heartbeat is always enabled
+  listener_activation_map[1] = true; // kanata has its own logic for enablement
   for (std::string name : requested_listeners) {
     bool found = false;
     for (size_t i = 0; i < listener_names.size(); i++) {

--- a/inc/events.h
+++ b/inc/events.h
@@ -1,6 +1,6 @@
 #ifndef EVENTS_H
 #define EVENTS_H
 
-enum Event { BEGIN_PHASE, RETIRE };
+enum Event { BEGIN_PHASE, COMPLETE, CYCLE, DECODE, DIB_HIT, DISPATCH, EXEC, INIT, ISSUE, RENAME, RETIRE };
 
 #endif

--- a/inc/instruction.h
+++ b/inc/instruction.h
@@ -102,6 +102,7 @@ struct ooo_model_instr : champsim::program_ordered<ooo_model_instr> {
   bool branch_taken = false;
   bool branch_prediction = false;
   bool branch_mispredicted = false; // A branch can be mispredicted even if the direction prediction is correct when the predicted target is not correct
+  bool stack_pointer_folded = false;
 
   std::array<uint8_t, 2> asid = {std::numeric_limits<uint8_t>::max(), std::numeric_limits<uint8_t>::max()};
 
@@ -197,5 +198,7 @@ public:
 
   [[nodiscard]] std::size_t num_mem_ops() const { return std::size(destination_memory) + std::size(source_memory); }
 };
+
+std::ostream& operator<<(std::ostream& os, const ooo_model_instr& instr);
 
 #endif

--- a/inc/listeners/heartbeat.h
+++ b/inc/listeners/heartbeat.h
@@ -5,6 +5,7 @@
 #include <deque>
 #include <iostream>
 #include <vector>
+#include <CLI/CLI.hpp>
 #include <fmt/chrono.h>
 
 #include "events.h"
@@ -28,6 +29,8 @@ public:
   std::vector<uint64_t> cycles_start_phase;
   std::vector<bool> switched_phase; // true if there has been a begin_phase event since the last time RETIRE occurred
 
+  void cli([[maybe_unused]] CLI::App& app) {}
+
   template <Event e, typename... Args>
   void handle_event(Args&&... args);
 
@@ -50,7 +53,7 @@ namespace heartbeat
 {
 
 template <Event e, typename... Args>
-inline void handle_event(Heartbeat* hb, Args&... args)
+inline void handle_event([[maybe_unused]] Heartbeat* hb, [[maybe_unused]] Args&... args)
 {
   // std::cout << "WARNING: generic handle event\n";
 }

--- a/inc/listeners/kanata.h
+++ b/inc/listeners/kanata.h
@@ -1,0 +1,270 @@
+/*
+ *    Copyright 2025 The ChampSim Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef KANATA_H
+#define KANATA_H
+
+#include <deque>
+#include <functional>
+#include <optional>
+#include <CLI/CLI.hpp>
+#include <fmt/os.h>
+#include <fmt/ostream.h>
+
+#include "cache.h"
+#include "dram_controller.h"
+#include "events.h"
+#include "instruction.h"
+#include "ooo_cpu.h"
+#include "ptw.h"
+
+namespace champsim
+{
+namespace kanata
+{
+class Kanata final
+{
+public:
+  static constexpr auto cli_key = "Kanata";
+
+  void cli(CLI::App& app)
+  {
+    app.add_option("--kanata", file_name, "The name of the file to receive Kanata output");
+    app.add_option("--kanata-max", max, "The maximum number of instructions for Kanata logging");
+    app.add_option("--kanata-skip", skip, "The number of instructions to skip before starting Kanata logging");
+  }
+
+  template <Event e, typename... Args>
+  inline void handle_event(Args&&... args);
+
+private:
+  struct Instr final {
+    Kanata& kanata;
+    const uint64_t id;
+    const bool flushed;
+
+    Instr(Kanata& kanata_, uint64_t id_, bool flushed_) : kanata(kanata_), id(id_), flushed(flushed_) {}
+
+    ~Instr();
+    void start(uint8_t lane, const std::string& stage);
+  };
+
+  template <typename T>
+  class Queue final
+  {
+  public:
+    T& emplace(uint64_t index)
+    {
+      if (storage.empty())
+        begin = index;
+      else
+        assert(index - begin >= storage.size());
+
+      storage.resize(index - begin + 1);
+
+      return storage[index - begin];
+    }
+
+    T* find(uint64_t index) { return index >= begin && index - begin < storage.size() ? &storage[index - begin] : nullptr; }
+
+    T& front() { return storage.front(); }
+
+    bool empty() const { return storage.empty(); }
+
+    void pop()
+    {
+      storage.pop_front();
+      ++begin;
+    }
+
+  private:
+    uint64_t begin = UINT64_MAX;
+    std::deque<T> storage;
+  };
+
+  template <typename ID, typename Label>
+  std::shared_ptr<Instr> init(uint32_t cpu, ID id, Label label, bool flushed)
+  {
+    auto index = num;
+
+    ++num;
+
+    if (index < skip || index - skip > max)
+      return {};
+
+    if (!file) {
+      if (!file_name) {
+        skip = UINT64_MAX;
+        return {};
+      }
+
+      file.emplace(fmt::output_file(*file_name));
+      file->print("Kanata\t0004\nC=\t{}\n", current_cycle);
+    }
+
+    auto instr = std::make_shared<Instr>(*this, num - skip, flushed);
+    file->print("I\t{}\t{}\t{}\nL\t{}\t0\t{}\n", instr->id, id, cpu, instr->id, label);
+    return instr;
+  }
+
+  void init(const O3_CPU& cpu, const ooo_model_instr& o3)
+  {
+    auto instr = init(cpu.cpu, o3.instr_id, fmt::streamed(o3), false);
+    if (!instr)
+      return;
+
+    if (cpu.cpu >= cpus.size())
+      cpus.resize(cpu.cpu + 1);
+
+    auto& emplaced = cpus[cpu.cpu].emplace(o3.instr_id);
+    emplaced.swap(instr);
+    emplaced->start(0, "F");
+  }
+
+  void retire();
+
+  void start(const O3_CPU& cpu, const ooo_model_instr& o3, const std::string& stage)
+  {
+    if (cpu.cpu >= cpus.size())
+      return;
+
+    auto kanata = cpus[cpu.cpu].find(o3.instr_id);
+    if (!kanata)
+      return;
+
+    (*kanata)->start(0, stage);
+  }
+
+  std::optional<fmt::ostream> file;
+  std::optional<std::string> file_name;
+  std::vector<Queue<std::shared_ptr<Instr>>> cpus;
+  uint64_t current_cycle = 0;
+  uint64_t max = UINT64_MAX;
+  uint64_t num = 0;
+  uint64_t skip = 0;
+
+  template <Event e, typename... Args>
+  friend void handle_event(Kanata& kanata, const Args&... args);
+};
+
+template <Event e, typename... Args>
+inline void handle_event([[maybe_unused]] Kanata& kanata, [[maybe_unused]] const Args&... args)
+{
+}
+
+template <>
+inline void handle_event<Event::COMPLETE>(Kanata& kanata, const O3_CPU& cpu, const ooo_model_instr& instr)
+{
+  kanata.start(cpu, instr, "C");
+}
+
+template <>
+inline void handle_event<Event::CYCLE>(Kanata& kanata)
+{
+  ++kanata.current_cycle;
+
+  if (kanata.file)
+    kanata.file->print("C\t1\n");
+}
+
+template <>
+inline void handle_event<Event::DECODE>(Kanata& kanata, const O3_CPU& cpu, const ooo_model_instr& instr)
+{
+  kanata.start(cpu, instr, "Dc");
+}
+
+template <>
+inline void handle_event<Event::DIB_HIT>(Kanata& kanata, const O3_CPU& cpu, const ooo_model_instr& instr)
+{
+  kanata.start(cpu, instr, "Dh");
+}
+
+template <>
+inline void handle_event<Event::DISPATCH>(Kanata& kanata, const O3_CPU& cpu, const ooo_model_instr& instr)
+{
+  kanata.start(cpu, instr, "Ds");
+}
+
+template <>
+inline void handle_event<Event::EXEC>(Kanata& kanata, const O3_CPU& cpu, const ooo_model_instr& instr)
+{
+  kanata.start(cpu, instr, "X");
+}
+
+template <>
+inline void handle_event<Event::INIT>(Kanata& kanata, const O3_CPU& cpu, const ooo_model_instr& instr)
+{
+  kanata.init(cpu, instr);
+}
+
+template <>
+inline void handle_event<Event::ISSUE>(Kanata& kanata, const O3_CPU& cpu, const ooo_model_instr& instr)
+{
+  if (cpu.cpu >= kanata.cpus.size())
+    return;
+
+  auto kanata_instr = kanata.cpus[cpu.cpu].find(instr.instr_id);
+  if (!kanata_instr)
+    return;
+
+  for (auto& source : instr.source_registers) {
+    auto producer = kanata.cpus[cpu.cpu].find(cpu.reg_allocator.get_physical_register(source).producing_instruction_id);
+    if (!producer)
+      continue;
+
+    kanata.file->print("W\t{}\t{}\t0\n", (*kanata_instr)->id, (*producer)->id);
+  }
+
+  (*kanata_instr)->start(0, "I");
+}
+
+template <>
+inline void handle_event<Event::RENAME>(Kanata& kanata, const O3_CPU& cpu, const ooo_model_instr& instr)
+{
+  kanata.start(cpu, instr, "R");
+}
+
+template <>
+inline void handle_event<Event::RETIRE>(Kanata& kanata, [[maybe_unused]] const uint32_t& cpu, const std::deque<ooo_model_instr>::const_iterator& begin,
+                                        const std::deque<ooo_model_instr>::const_iterator& end, [[maybe_unused]] const uint64_t& current_cycles)
+{
+  if (cpu >= kanata.cpus.size())
+    return;
+
+  for (auto it = begin; it != end; ++it) {
+    auto instr = kanata.cpus[cpu].find(it->instr_id);
+    if (!instr)
+      continue;
+
+    (*instr)->start(0, "S");
+    instr->reset();
+  }
+
+  while (!kanata.cpus[cpu].empty() && !kanata.cpus[cpu].front())
+    kanata.cpus[cpu].pop();
+
+  kanata.retire();
+}
+
+template <Event e, typename... Args>
+inline void Kanata::handle_event(Args&&... args)
+{
+  kanata::handle_event<e>(*this, std::forward<Args>(args)...);
+}
+} // namespace kanata
+} // namespace champsim
+
+#endif

--- a/inc/register_allocator.h
+++ b/inc/register_allocator.h
@@ -36,5 +36,7 @@ public:
   int count_reg_dependencies(const ooo_model_instr& instr) const;
   void reset_frontend_RAT();
   void print_deadlock();
+
+  physical_register get_physical_register(PHYSICAL_REGISTER_ID physreg) const { return physical_register_file[physreg]; }
 };
 #endif

--- a/inc/trace_instruction.h
+++ b/inc/trace_instruction.h
@@ -25,6 +25,28 @@ namespace champsim
 constexpr char REG_STACK_POINTER = 6;
 constexpr char REG_FLAGS = 25;
 constexpr char REG_INSTRUCTION_POINTER = 26;
+
+constexpr const char* reg_names[] = {
+    "invalid", "none",      "first",        "rdi",     "rsi",     "rbp",     "rsp",      "rbx",      "rdx",      "rcx",      "rax",      "r8",         "r9",
+    "r10",     "r11",       "r12",          "r13",     "r14",     "r15",     "CS",       "SS",       "DS",       "ES",       "FS",       "GS",         "rflags",
+    "rip",     "al",        "ah",           "ax",      "cl",      "ch",      "cx",       "dl",       "dh",       "dx",       "bl",       "bh",         "bx",
+    "bp",      "si",        "di",           "sp",      "flags",   "ip",      "edi",      "dil",      "esi",      "sil",      "ebp",      "bpl",        "esp",
+    "spl",     "ebx",       "edx",          "ecx",     "eax",     "eflags",  "eip",      "r8b",      "r8w",      "r8d",      "r9b",      "r9w",        "r9d",
+    "r10b",    "r10w",      "r10d",         "r11b",    "r11w",    "r11d",    "r12b",     "r12w",     "r12d",     "r13b",     "r13w",     "r13d",       "r14b",
+    "r14w",    "r14d",      "r15b",         "r15w",    "r15d",    "mm0",     "mm1",      "mm2",      "mm3",      "mm4",      "mm5",      "mm6",        "mm7",
+    "xmm0",    "xmm1",      "xmm2",         "xmm3",    "xmm4",    "xmm5",    "xmm6",     "xmm7",     "xmm8",     "xmm9",     "xmm10",    "xmm11",      "xmm12",
+    "xmm13",   "xmm14",     "xmm15",        "xmm16",   "xmm17",   "xmm18",   "xmm19",    "xmm20",    "xmm21",    "xmm22",    "xmm23",    "xmm24",      "xmm25",
+    "xmm26",   "xmm27",     "xmm28",        "xmm29",   "xmm30",   "xmm31",   "ymm0",     "ymm1",     "ymm2",     "ymm3",     "ymm4",     "ymm5",       "ymm6",
+    "ymm7",    "ymm8",      "ymm9",         "ymm10",   "ymm11",   "ymm12",   "ymm13",    "ymm14",    "ymm15",    "ymm16",    "ymm17",    "ymm18",      "ymm19",
+    "ymm20",   "ymm21",     "ymm22",        "ymm23",   "ymm24",   "ymm25",   "ymm26",    "ymm27",    "ymm28",    "ymm29",    "ymm30",    "ymm31",      "zmm0",
+    "zmm1",    "zmm2",      "zmm3",         "zmm4",    "zmm5",    "zmm6",    "zmm7",     "zmm8",     "zmm9",     "zmm10",    "zmm11",    "zmm12",      "zmm13",
+    "zmm14",   "zmm15",     "zmm16",        "zmm17",   "zmm18",   "zmm19",   "zmm20",    "zmm21",    "zmm22",    "zmm23",    "zmm24",    "zmm25",      "zmm26",
+    "zmm27",   "zmm28",     "zmm29",        "zmm30",   "zmm31",   "k0",      "k1",       "k2",       "k3",       "k4",       "k5",       "k6",         "k7",
+    "mxcsr",   "mxcsrmask", "orig_rax",     "fpcw",    "fpsw",    "fptag",   "fpip_off", "fpip_sel", "fpopcode", "fpdp_off", "fpdp_sel", "fptag_full", "st0",
+    "st1",     "st2",       "st3",          "st4",     "st5",     "st6",     "st7",      "dr0",      "dr1",      "dr2",      "dr3",      "dr4",        "dr5",
+    "dr6",     "dr7",       "cr0",          "cr1",     "cr2",     "cr3",     "cr4",      "tssr",     "ldtr",     "tr",       "tr3",      "tr4",        "tr5",
+    "tr6",     "tr7",       "status_flags", "df_flag", "gs_base", "fs_base", "g0",       "g1",       "g2",       "g3",       "g4",       "g5",         "g6",
+    "g7",      "g8",        "g9",           "g10",     "g11",     "g12",     "g13",      "g14",      "g15"};
 } // namespace champsim
 
 // instruction format

--- a/src/champsim.cc
+++ b/src/champsim.cc
@@ -40,6 +40,8 @@ namespace champsim
 {
 long do_cycle(environment& env, std::vector<tracereader>& traces, std::vector<std::size_t> trace_index, champsim::chrono::clock& global_clock)
 {
+  handle_event<Event::CYCLE>();
+
   auto operables = env.operable_view();
   std::sort(std::begin(operables), std::end(operables),
             [](const champsim::operable& lhs, const champsim::operable& rhs) { return lhs.current_time < rhs.current_time; });

--- a/src/instruction.cc
+++ b/src/instruction.cc
@@ -1,0 +1,102 @@
+/*
+ *    Copyright 2026 The ChampSim Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "instruction.h"
+
+std::ostream& operator<<(std::ostream& os, const ooo_model_instr& instr)
+{
+  fmt::print(os, "{}: ", instr.ip);
+
+  if (instr.destination_registers.empty() && instr.destination_memory.empty()) {
+    fmt::print(os, "NOP    ");
+  } else
+    switch (instr.branch) {
+    case NOT_BRANCH:
+      fmt::print(os, "Instr   ");
+      break;
+    case BRANCH_DIRECT_JUMP:
+      fmt::print(os, "Jump    ");
+      break;
+    case BRANCH_INDIRECT:
+      fmt::print(os, "IndJump ");
+      break;
+    case BRANCH_CONDITIONAL:
+      fmt::print(os, "CondBr  ");
+      break;
+    case BRANCH_DIRECT_CALL:
+      fmt::print(os, "Call    ");
+      break;
+    case BRANCH_INDIRECT_CALL:
+      fmt::print(os, "IndCall ");
+      break;
+    case BRANCH_RETURN:
+      fmt::print(os, "Return  ");
+      break;
+    case BRANCH_OTHER:
+      fmt::print(os, "OtherBr ");
+      break;
+    }
+
+  bool needs_comma = false;
+  if (instr.stack_pointer_folded) {
+    if (needs_comma)
+      fmt::print(os, ", ");
+    fmt::print(os, "rsp (folded)");
+    needs_comma = true;
+  }
+  for (auto x : instr.destination_registers) {
+    if (needs_comma)
+      fmt::print(os, ", ");
+    if (instr.scheduled) {
+      fmt::print(os, "p{}", x);
+    } else {
+      fmt::print(os, champsim::reg_names[x]);
+      if (x == champsim::REG_INSTRUCTION_POINTER && instr.branch_mispredicted)
+        fmt::print(os, " (mispredicted)");
+    }
+    needs_comma = true;
+  }
+  for (auto a : instr.destination_memory) {
+    if (needs_comma)
+      fmt::print(os, ", ");
+    fmt::print(os, "[{}]", a);
+    needs_comma = true;
+  }
+
+  fmt::print(os, " <- ");
+
+  needs_comma = false;
+  for (auto x : instr.source_registers) {
+    if (needs_comma)
+      fmt::print(os, ", ");
+    if (instr.scheduled)
+      fmt::print(os, "p{}", x);
+    else
+      fmt::print(os, champsim::reg_names[x]);
+    needs_comma = true;
+  }
+  for (auto a : instr.source_memory) {
+    if (needs_comma)
+      fmt::print(os, ", ");
+    fmt::print(os, "[{}]", a);
+    needs_comma = true;
+  }
+  if (!needs_comma) {
+    fmt::print(os, "Imm");
+  }
+
+  return os;
+}

--- a/src/kanata.cc
+++ b/src/kanata.cc
@@ -1,0 +1,33 @@
+/*
+ *    Copyright 2025 The ChampSim Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "listeners/kanata.h"
+
+champsim::kanata::Kanata::Instr::~Instr() { kanata.file->print("R\t{}\t{}\t{}\n", id, id, '0' + flushed); }
+
+void champsim::kanata::Kanata::retire()
+{
+  if (num - skip < max)
+    return;
+
+  for (auto& kanata : cpus)
+    if (!kanata.empty())
+      return;
+
+  file.reset();
+}
+
+void champsim::kanata::Kanata::Instr::start(uint8_t lane, const std::string& stage) { kanata.file->print("S\t{}\t{}\t{}\n", id, lane, stage); }

--- a/src/main.cc
+++ b/src/main.cc
@@ -87,6 +87,8 @@ int main(int argc, char** argv) // NOLINT(bugprone-exception-escape)
 
   app.add_option("--listeners", requested_listeners, "A list of the listeners to be attached to the run");
 
+  event_listener_cli(app);
+
   app.add_option("traces", trace_names, "The paths to the traces")->required()->expected(NUM_CPUS)->check(CLI::ExistingFile);
 
   CLI11_PARSE(app, argc, argv);

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -102,6 +102,7 @@ void O3_CPU::initialize_instruction()
     input_queue.pop_front();
 
     IFETCH_BUFFER.back().ready_time = current_time;
+    handle_event<Event::INIT>(*this, IFETCH_BUFFER.back());
   }
 }
 
@@ -283,12 +284,16 @@ long O3_CPU::promote_to_decode()
   // find the first not fetch completed
   auto [window_begin, window_end] = champsim::get_span_p(std::begin(IFETCH_BUFFER), fetched_check_end, available_fetch_bandwidth, fetch_complete_and_ready);
   auto decoded_window_end = std::stable_partition(window_begin, window_end, is_decoded); // reorder instructions
-  auto mark_for_decode = [time = current_time, lat = DECODE_LATENCY, warmup = warmup](auto& x) {
-    return x.ready_time = time + (warmup ? champsim::chrono::clock::duration{} : lat);
+  auto mark_for_decode = [time = current_time, lat = DECODE_LATENCY, warmup = warmup, this](auto& x) {
+    x.ready_time = time + (warmup ? champsim::chrono::clock::duration{} : lat);
+    handle_event<Event::DECODE>(*this, x);
+    return x.ready_time;
   };
   // to DIB_HIT_BUFFER
-  auto mark_for_dib = [time = current_time, lat = DIB_HIT_LATENCY, warmup = warmup](auto& x) {
-    return x.ready_time = time + lat;
+  auto mark_for_dib = [time = current_time, lat = DIB_HIT_LATENCY, warmup = warmup, this](auto& x) {
+    x.ready_time = time + lat;
+    handle_event<Event::DIB_HIT>(*this, x);
+    return x.ready_time;
   };
 
   std::for_each(window_begin, decoded_window_end, mark_for_dib); // assume DECODE_LATENCY = DIB_HIT_LATENCY
@@ -361,6 +366,7 @@ long O3_CPU::decode_instruction()
     }
     // Add to dispatch
     db_entry.ready_time = this->current_time + (this->warmup ? champsim::chrono::clock::duration{} : this->DISPATCH_LATENCY);
+    handle_event<Event::DISPATCH>(*this, db_entry);
 
     if constexpr (champsim::debug_print) {
       fmt::print("[DECODE] do_decode instr_id: {} time: {}\n", db_entry.instr_id, this->current_time.time_since_epoch() / this->clock_period);
@@ -402,6 +408,7 @@ long O3_CPU::dispatch_instruction()
 
     available_dispatch_bandwidth.consume();
     ROB.back().ready_time = current_time + (warmup ? champsim::chrono::clock::duration{} : SCHEDULING_LATENCY);
+    handle_event<Event::RENAME>(*this, ROB.back());
   }
 
   return available_dispatch_bandwidth.amount_consumed();
@@ -445,6 +452,7 @@ void O3_CPU::do_scheduling(ooo_model_instr& instr)
   }
 
   instr.scheduled = true;
+  handle_event<Event::ISSUE>(*this, instr);
 }
 
 long O3_CPU::execute_instruction()
@@ -482,6 +490,8 @@ void O3_CPU::do_execution(ooo_model_instr& instr)
       sq_entry.ready_time = current_time + (warmup ? champsim::chrono::clock::duration{} : EXEC_LATENCY);
     }
   }
+
+  handle_event<Event::EXEC>(*this, instr);
 
   if constexpr (champsim::debug_print) {
     fmt::print("[ROB] {} instr_id: {} ready_time: {}\n", __func__, instr.instr_id, instr.ready_time.time_since_epoch() / clock_period);
@@ -624,6 +634,8 @@ void O3_CPU::do_complete_execution(ooo_model_instr& instr)
   if (instr.branch_mispredicted) {
     fetch_resume_time = current_time + BRANCH_MISPREDICT_PENALTY;
   }
+
+  handle_event<Event::COMPLETE>(*this, instr);
 }
 
 long O3_CPU::complete_inflight_instruction()

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -123,6 +123,7 @@ void do_stack_pointer_folding(ooo_model_instr& arch_instr)
     if ((arch_instr.is_branch) || !(std::empty(arch_instr.destination_memory) && std::empty(arch_instr.source_memory)) || (!reads_other)) {
       auto nonsp_end = std::remove(std::begin(arch_instr.destination_registers), std::end(arch_instr.destination_registers), champsim::REG_STACK_POINTER);
       arch_instr.destination_registers.erase(nonsp_end, std::end(arch_instr.destination_registers));
+      arch_instr.stack_pointer_folded = true;
     }
   }
 }


### PR DESCRIPTION
Kanata is a log format to record the behavior of processor pipelines,
which can be used with Konata, an instruction pipeline visualizer.

I'm planning to implement a feature to generate Kanata logs in a
gradual approach to minimize the burden for both me and the reviewers. This
is the first commit to add the basic infrastructure and instrument to the
instruction pipeline. Instrumenting the memory subsystem needs
significant code changes in the subsystem itself to track memory
accesses across merging and forwarding, which this commit does not
include.

However, the added Kanata logging infrastructure is already designed to
be versatile enough to cover the memory subsystem in the
future. More concretely:

- It has its own representation of "instruction"; currently it only
  logs ooo_model_instr, but it can also log prefetches in the future.
- It implements a concept of "lane", which is a unit of execution and
  part of an instruction. An instruction can have multiple lanes to
  track multiple memory accesses initiated by an instruction.
- A lane can keep its instruction alive even after the instruction
  retires from the ROB so that it can log the following stores, for example.

Please see the README.md change to know how to use this new feature.

I attached generated Kanata logs for reference: [kanata.log.gz](https://github.com/user-attachments/files/18746562/kanata.log.gz)
Below is a screenshot of Konata visualizing the attached logs:
![Screenshot](https://github.com/user-attachments/assets/8dbef7f7-8cec-478a-bade-048bf9224ed7)
The logs were generated with the following command:
```sh
bin/champsim --kanata >(gzip > kanata.log.gz) -i 100000 600.perlbench_s-210B.champsimtrace.xz
```