### PR TITLE
Update champsim.cc to extend livelock period from 100K cycles to 10M cycles

### DIFF
--- a/src/champsim.cc
+++ b/src/champsim.cc
@@ -75,7 +75,7 @@ phase_stats do_phase(const phase_info& phase, environment& env, std::vector<trac
                                             [](const auto acc, const operable& y) { return std::min(acc, y.clock_period); });
 
   bool livelock_trigger{false};
-  uint64_t livelock_period{100000};
+  uint64_t livelock_period{10000000};
   uint64_t livelock_timer{0};
   //                                   die | critical | warning
   std::vector<double> livelock_threshold{0.01, 0.02, 0.05};


### PR DESCRIPTION
The current livelock duration is too short. This can result in significant stall-drain behavior in some traces triggering the livelock. As a resolution, we can extend the livelock period which should help prevent these false positives at the expense of potentially spending longer livelocked. Champsim can chew through 10M cycles like nothing, so I don't think this will be an issue.

This is causing problems for ECEN 676 at the university, so I would appreciate this PR having high prio.