### PR TITLE
PTW PSCL Fix

### DIFF
--- a/src/ptw.cc
+++ b/src/ptw.cc
@@ -90,7 +90,7 @@ auto PageTableWalker::handle_fill(const mshr_type& fill_mshr) -> std::optional<m
   }
 
   const auto pscl_idx = std::size(pscl) - fill_mshr.translation_level;
-  pscl.at(pscl_idx).fill({fill_mshr.v_address, *fill_mshr.data, fill_mshr.translation_level - 1});
+  pscl.at(pscl_idx).fill({fill_mshr.v_address, *fill_mshr.data, fill_mshr.translation_level});
 
   mshr_type fwd_mshr = fill_mshr;
   fwd_mshr.address = *fill_mshr.data;

--- a/test/cpp/src/600-ptw-path.cc
+++ b/test/cpp/src/600-ptw-path.cc
@@ -200,9 +200,9 @@ SCENARIO("PSCLs can reduce the number of issued translation requests")
         for (auto elem : elements)
           elem->_operate();
 
-      THEN("1 request is issued")
+      THEN("2 requests are issued")
       {
-        REQUIRE(mock_ll.packet_count() == 1);
+        REQUIRE(mock_ll.packet_count() == 2);
         REQUIRE(mock_ul.packets.back().return_time > 0);
       }
     }
@@ -221,9 +221,9 @@ SCENARIO("PSCLs can reduce the number of issued translation requests")
         for (auto elem : elements)
           elem->_operate();
 
-      THEN("2 requests are issued")
+      THEN("3 requests are issued")
       {
-        REQUIRE(mock_ll.packet_count() == 2);
+        REQUIRE(mock_ll.packet_count() == 3);
         REQUIRE(mock_ul.packets.back().return_time > 0);
       }
     }
@@ -242,9 +242,9 @@ SCENARIO("PSCLs can reduce the number of issued translation requests")
         for (auto elem : elements)
           elem->_operate();
 
-      THEN("3 requests are issued")
+      THEN("4 requests are issued")
       {
-        REQUIRE(mock_ll.packet_count() == 3);
+        REQUIRE(mock_ll.packet_count() == 4);
         REQUIRE(mock_ul.packets.back().return_time > 0);
       }
     }
@@ -263,9 +263,9 @@ SCENARIO("PSCLs can reduce the number of issued translation requests")
         for (auto elem : elements)
           elem->_operate();
 
-      THEN("4 requests are issued")
+      THEN("5 requests are issued")
       {
-        REQUIRE(mock_ll.packet_count() == 4);
+        REQUIRE(mock_ll.packet_count() == 5);
         REQUIRE(mock_ul.packets.back().return_time > 0);
       }
     }

--- a/test/cpp/src/603-pte-page-correctness.cc
+++ b/test/cpp/src/603-pte-page-correctness.cc
@@ -71,7 +71,6 @@ SCENARIO("The page table steps have correct offsets") {
         THEN("The " + std::to_string(level) + "th request has the correct offset") {
           using namespace champsim::data::data_literals;
           REQUIRE(mock_ll.packet_count() == levels);
-          fmt::print("level: {} got: {} expected: {}\n",level,mock_ll.addresses.at(levels-level).slice_lower(12_b).to<std::size_t>(),level * pte_entry::byte_multiple);
           REQUIRE(mock_ll.addresses.at(levels-level).slice_lower(12_b).to<std::size_t>() == level * pte_entry::byte_multiple);
         }
       }

--- a/test/cpp/src/603-pte-page-correctness.cc
+++ b/test/cpp/src/603-pte-page-correctness.cc
@@ -7,75 +7,73 @@
 #include "ptw.h"
 #include "vmem.h"
 
-SCENARIO("The page table steps have correct offsets")
-{
-  auto level = GENERATE(as<unsigned>{}, 1, 2, 3, 4);
-  GIVEN("A 5-level virtual memory")
-  {
+SCENARIO("The page table steps have correct offsets") {
+  auto level = GENERATE(as<unsigned>{}, 1,2,3,4,5);
+  GIVEN("A 5-level virtual memory") {
     constexpr std::size_t levels = 5;
-    MEMORY_CONTROLLER dram{champsim::chrono::picoseconds{3200},
-                           champsim::chrono::picoseconds{6400},
-                           std::size_t{18},
-                           std::size_t{18},
-                           std::size_t{18},
-                           std::size_t{38},
-                           champsim::chrono::microseconds{64000},
-                           {},
-                           64,
-                           64,
-                           1,
-                           champsim::data::bytes{8},
-                           1024,
-                           1024,
-                           4,
-                           4,
-                           4,
-                           8192};
-    VirtualMemory vmem{champsim::data::bytes{1 << 12}, levels, champsim::chrono::nanoseconds{640}, dram};
+    MEMORY_CONTROLLER dram{champsim::chrono::picoseconds{3200}, champsim::chrono::picoseconds{6400}, std::size_t{18}, std::size_t{18}, std::size_t{18}, std::size_t{38}, champsim::chrono::microseconds{64000}, {}, 64, 64, 1, champsim::data::bytes{8}, 1024, 1024, 4, 4, 4, 8192};
+    VirtualMemory vmem{champsim::data::bytes{1<<12}, levels, champsim::chrono::nanoseconds{640}, dram};
     do_nothing_MRC mock_ll;
     to_rq_MRP mock_ul;
     PageTableWalker uut{champsim::ptw_builder{champsim::defaults::default_ptw}
-                            .name("603-uut-" + std::to_string(level))
-                            .clock_period(champsim::chrono::picoseconds{3200})
-                            //.rq_size(16)
-                            //.tag_bandwidth(2)
-                            //.fill_bandwidth(2)
-                            //.mshr_size(5)
-                            .upper_levels({&mock_ul.queues})
-                            .lower_level(&mock_ll.queues)
-                            .virtual_memory(&vmem)
-                            .add_pscl(5, 1, 1)
-                            .add_pscl(4, 1, 1)
-                            .add_pscl(3, 1, 1)
-                            .add_pscl(2, 1, 1)};
+      .name("603-uut-"+std::to_string(level))
+      .clock_period(champsim::chrono::picoseconds{3200})
+      //.rq_size(16)
+      //.tag_bandwidth(2)
+      //.fill_bandwidth(2)
+      //.mshr_size(5)
+      .upper_levels({&mock_ul.queues})
+      .lower_level(&mock_ll.queues)
+      .virtual_memory(&vmem)
+      .add_pscl(5,1,1)
+      .add_pscl(4,1,1)
+      .add_pscl(3,1,1)
+      .add_pscl(2,1,1)
+    };
 
     std::array<champsim::operable*, 3> elements{{&mock_ul, &uut, &mock_ll}};
 
     uut.warmup = false;
     uut.begin_phase();
 
-    // uint64_t addr = (0xffff'ffff'ffe0'0000 | ((3*(level+1)) << LOG2_PAGE_SIZE)) << (level * 9);
-    champsim::address addr{0x0040'0200'c040'1000}; // 0x4, 0x3, 0x2, 0x1
+    //uint64_t addr = (0xffff'ffff'ffe0'0000 | ((3*(level+1)) << LOG2_PAGE_SIZE)) << (level * 9);
 
-    WHEN("The PTW receives a request")
-    {
-      decltype(mock_ul)::request_type test;
-      test.address = addr;
-      test.v_address = test.address;
-      test.cpu = 0;
+    //level 1 -> 12 bits
+    //level 2 -> 21 bits
+    //level 3 -> 30 bits
+    //level 4 -> 39 bits
+    //level 5 -> 48 bits
+                                                    //  5    4    3    2   1
+    champsim::address addr0{0x0005'0200'c040'1000}; // 0x5, 0x4, 0x3, 0x2, 0x1
+    champsim::address addr1{0x0006'0281'0060'2000}; // 0x6, 0x5, 0x3, 0x3, 0x2
+    champsim::address addr2{0x0007'0301'4080'3000}; // 0x7, 0x6, 0x3, 0x4, 0x3
+    champsim::address addr3{0x0008'0381'80a0'4000}; // 0x8, 0x7, 0x3, 0x5, 0x4
+    champsim::address addr4{0x0009'0401'c0c0'5000}; // 0x9, 0x8, 0x3, 0x6, 0x5
+    champsim::address addr5{0x000a'0482'00e0'6000}; // 0xa, 0x9, 0x3, 0x7, 0x6
+    champsim::address addr6{0x000b'0502'4100'7000}; // 0xb, 0xa, 0x3, 0x8, 0x7
+    champsim::address addr7{0x000c'0582'8120'8000}; // 0xc, 0xb, 0x3, 0x9, 0x8
+    std::vector<champsim::address> addresses = {addr0, addr1, addr2, addr3, addr4, addr5, addr6, addr7};
 
-      auto test_result = mock_ul.issue(test);
-      REQUIRE(test_result);
+    for(auto addr : addresses) {
+      WHEN("The PTW receives a request") {
+        decltype(mock_ul)::request_type test;
+        test.address = addr;
+        test.v_address = test.address;
+        test.cpu = 0;
 
-      for (auto i = 0; i < 10000; ++i)
-        for (auto elem : elements)
-          elem->_operate();
+        auto test_result = mock_ul.issue(test);
+        REQUIRE(test_result);
 
-      THEN("The " + std::to_string(level) + "th request has the correct offset")
-      {
-        using namespace champsim::data::data_literals;
-        REQUIRE(mock_ll.packet_count() == levels);
-        REQUIRE(mock_ll.addresses.at(levels - level).slice_lower(12_b).to<std::size_t>() == level * pte_entry::byte_multiple);
+        for (auto i = 0; i < 10000; ++i)
+          for (auto elem : elements)
+            elem->_operate();
+
+        THEN("The " + std::to_string(level) + "th request has the correct offset") {
+          using namespace champsim::data::data_literals;
+          REQUIRE(mock_ll.packet_count() == levels);
+          fmt::print("level: {} got: {} expected: {}\n",level,mock_ll.addresses.at(levels-level).slice_lower(12_b).to<std::size_t>(),level * pte_entry::byte_multiple);
+          REQUIRE(mock_ll.addresses.at(levels-level).slice_lower(12_b).to<std::size_t>() == level * pte_entry::byte_multiple);
+        }
       }
     }
   }

--- a/test/cpp/src/603-pte-page-correctness.cc
+++ b/test/cpp/src/603-pte-page-correctness.cc
@@ -8,7 +8,7 @@
 #include "vmem.h"
 
 SCENARIO("The page table steps have correct offsets") {
-  auto level = GENERATE(as<unsigned>{}, 1,2,3,4,5);
+  auto level = GENERATE(as<unsigned>{}, 1,2,3,4);
   GIVEN("A 5-level virtual memory") {
     constexpr std::size_t levels = 5;
     MEMORY_CONTROLLER dram{champsim::chrono::picoseconds{3200}, champsim::chrono::picoseconds{6400}, std::size_t{18}, std::size_t{18}, std::size_t{18}, std::size_t{38}, champsim::chrono::microseconds{64000}, {}, 64, 64, 1, champsim::data::bytes{8}, 1024, 1024, 4, 4, 4, 8192};


### PR DESCRIPTION
Fixes a bug that causes PTW walks that were previously cached to begin at 1 level lower than expected.

I am still not entirely sure whether this is a bug or not.
Since VMEM has to allocate more pages for the page tables after this fix, I would assume this was indeed a bug. If it wasn't, those page table pages would have been allocated originally.
However, this also means that the top-level of the PSCL doesn't seem to reduce the number of translations required when it hits.

Essentially what is happening is that each level of the PSCL should cache entries from its respective level of the page table hierarchy.
Level 5 (top) should cache entries in the level 5 table, level 4 should cache level 4 entries, and so on.
We don't have a level 1 table, since this is the actual translation.

When we hit in the PSCLs, we should be able to start our walk at the level just below it. So hitting in the level 5 PSCL should allow the walk to begin at level 4 using the entry in the level 5 pscl as the address.  What seems to be happening is something strange with the level indexing. Somehow, we are hitting in the pscl at a level that we shouldn't. It matches the upper bits, so either the shifting is wrong for each level, or we need to begin our walk 1 higher, I can't tell.

I have modified test 603 to account for this change, and do some more thorough testing as well.