### PR TITLE
DRRIP Set Dueling + SHiP Set Sampling Fix

### DIFF
--- a/inc/modules.h
+++ b/inc/modules.h
@@ -155,6 +155,11 @@ struct prefetcher : public bound_to<CACHE> {
 
 struct replacement : public bound_to<CACHE> {
   explicit replacement(CACHE* cache) : bound_to<CACHE>(cache) {}
+  long get_set_sample_rate() const;
+  long get_set_sample_category(long set, long set_sample_rate) const;
+  long get_set_sample_category(long set) const;
+  long get_num_sampled_sets(long set_sample_rate) const;
+  long get_num_sampled_sets() const;
 
   template <typename T, typename... Args>
   static auto initialize_member_impl(int) -> decltype(std::declval<T>().initialize_replacement(std::declval<Args>()...), std::true_type{});

--- a/replacement/drrip/drrip.h
+++ b/replacement/drrip/drrip.h
@@ -14,15 +14,12 @@ private:
 
 public:
   static constexpr unsigned maxRRPV = 3;
-  static constexpr std::size_t NUM_POLICY = 2;
-  static constexpr std::size_t SDM_SIZE = 32;
-  static constexpr unsigned BIP_MAX = 32;
+  static constexpr unsigned BRRIP_MAX = 32;
   static constexpr unsigned PSEL_WIDTH = 10;
 
   long NUM_SET, NUM_WAY;
 
-  unsigned bip_counter;
-  std::vector<std::size_t> rand_sets;
+  unsigned brrip_counter;
   std::vector<champsim::msl::fwcounter<PSEL_WIDTH>> PSEL;
   std::vector<unsigned> rrpv;
 
@@ -31,13 +28,15 @@ public:
   // void initialize_replacement()
   long find_victim(uint32_t triggering_cpu, uint64_t instr_id, long set, const champsim::cache_block* current_set, champsim::address ip,
                    champsim::address full_addr, access_type type);
+  void replacement_cache_fill(uint32_t triggering_cpu, long set, long way, champsim::address full_addr, champsim::address ip, champsim::address victim_addr,
+                              access_type type);
   void update_replacement_state(uint32_t triggering_cpu, long set, long way, champsim::address full_addr, champsim::address ip, champsim::address victim_addr,
                                 access_type type, uint8_t hit);
 
   // use this function to print out your own stats at the end of simulation
   // void replacement_final_stats() {}
 
-  void update_bip(long set, long way);
+  void update_brrip(long set, long way);
   void update_srrip(long set, long way);
 };
 

--- a/replacement/drrip/drrip.h
+++ b/replacement/drrip/drrip.h
@@ -21,7 +21,7 @@ public:
     follower, brrip_leader, srrip_leader
   };
 
-  long NUM_SET, NUM_WAY, SET_SAMPLE_RATE;
+  long NUM_SET, NUM_WAY;
 
   unsigned brrip_counter;
   std::vector<champsim::msl::fwcounter<PSEL_WIDTH>> PSEL;
@@ -43,17 +43,15 @@ public:
   void update_brrip(long set, long way);
   void update_srrip(long set, long way);
 
-  [[nodiscard]] constexpr set_type get_set_type(long set) {
-    auto mask = SET_SAMPLE_RATE - 1;
-    auto shift = champsim::lg2(SET_SAMPLE_RATE);
-    auto low_slice = set & mask;
-    auto high_slice = (set >> shift) & mask;
-    if (high_slice == ~low_slice) {
-      return set_type::brrip_leader;
-    } else if (high_slice == low_slice) {
-      return set_type::srrip_leader;
+  [[nodiscard]] set_type get_set_type(long set) {
+    switch(get_set_sample_category(set)) {
+      case 0:
+        return set_type::brrip_leader;
+      case 1:
+        return set_type::srrip_leader;
+      default:
+        return set_type::follower;
     }
-    return set_type::follower;
   }
 
 };

--- a/replacement/drrip/drrip.h
+++ b/replacement/drrip/drrip.h
@@ -17,7 +17,11 @@ public:
   static constexpr unsigned BRRIP_MAX = 32;
   static constexpr unsigned PSEL_WIDTH = 10;
 
-  long NUM_SET, NUM_WAY;
+  enum class set_type {
+    follower, brrip_leader, srrip_leader
+  };
+
+  long NUM_SET, NUM_WAY, SET_SAMPLE_RATE;
 
   unsigned brrip_counter;
   std::vector<champsim::msl::fwcounter<PSEL_WIDTH>> PSEL;
@@ -38,6 +42,20 @@ public:
 
   void update_brrip(long set, long way);
   void update_srrip(long set, long way);
+
+  [[nodiscard]] constexpr set_type get_set_type(long set) {
+    auto mask = SET_SAMPLE_RATE - 1;
+    auto shift = champsim::lg2(SET_SAMPLE_RATE);
+    auto low_slice = set & mask;
+    auto high_slice = (set >> shift) & mask;
+    if (high_slice == ~low_slice) {
+      return set_type::brrip_leader;
+    } else if (high_slice == low_slice) {
+      return set_type::srrip_leader;
+    }
+    return set_type::follower;
+  }
+
 };
 
 #endif

--- a/replacement/ship/ship.cc
+++ b/replacement/ship/ship.cc
@@ -12,7 +12,6 @@ ship::ship(CACHE* cache)
       rrpv_values(static_cast<std::size_t>(NUM_SET * NUM_WAY), maxRRPV)
 {
   assert(NUM_SET >= SET_SAMPLE_RATE); // Guarantee at least one sampled set
-  assert(NUM_CPUS <= 32); // No more sets left to sample otherwise. Would need to refactor update_replacement_state to support more than 32
   // randomly selected sampler sets
   std::generate_n(std::back_inserter(SHCT), NUM_CPUS, []() -> typename decltype(SHCT)::value_type { return {}; });
 }
@@ -44,7 +43,7 @@ void ship::update_replacement_state(uint32_t triggering_cpu, long set, long way,
   using namespace champsim::data::data_literals;
 
   // update sampler
-  auto set_lower = (set + triggering_cpu) & 0x1F; // Bits 0 - 4 inclusive
+  auto set_lower = set & 0x1F; // Bits 0 - 4 inclusive
   auto set_upper = (set >> 5) & 0x1F; // Bits 5 - 9 inclusive
   auto is_sampled = set_lower == set_upper;
   if (is_sampled) {

--- a/replacement/ship/ship.cc
+++ b/replacement/ship/ship.cc
@@ -8,13 +8,12 @@
 
 // initialize replacement state
 ship::ship(CACHE* cache)
-    : replacement(cache), NUM_SET(cache->NUM_SET), NUM_WAY(cache->NUM_WAY), sampler(SAMPLER_SET_FACTOR * NUM_CPUS * static_cast<std::size_t>(NUM_WAY)),
+    : replacement(cache), NUM_SET(cache->NUM_SET), NUM_WAY(cache->NUM_WAY), sampler(NUM_SET / SET_SAMPLE_RATE * NUM_CPUS * static_cast<std::size_t>(NUM_WAY)),
       rrpv_values(static_cast<std::size_t>(NUM_SET * NUM_WAY), maxRRPV)
 {
+  assert(NUM_SET >= SET_SAMPLE_RATE); // Guarantee at least one sampled set
+  assert(NUM_CPUS <= 32); // No more sets left to sample otherwise. Would need to refactor update_replacement_state to support more than 32
   // randomly selected sampler sets
-  std::generate_n(std::back_inserter(rand_sets), SAMPLER_SET_FACTOR * NUM_CPUS, std::knuth_b{1});
-  std::sort(std::begin(rand_sets), std::end(rand_sets));
-
   std::generate_n(std::back_inserter(SHCT), NUM_CPUS, []() -> typename decltype(SHCT)::value_type { return {}; });
 }
 
@@ -43,35 +42,31 @@ void ship::update_replacement_state(uint32_t triggering_cpu, long set, long way,
                                     champsim::address victim_addr, access_type type, uint8_t hit)
 {
   using namespace champsim::data::data_literals;
-  // handle writeback access
-  if (access_type{type} == access_type::WRITE) {
-    if (!hit)
-      get_rrpv(set, way) = maxRRPV - 1;
-
-    return;
-  }
 
   // update sampler
-  auto s_idx = std::find(std::begin(rand_sets), std::end(rand_sets), set);
-  if (s_idx != std::end(rand_sets)) {
-    auto s_set_begin = std::next(std::begin(sampler), std::distance(std::begin(rand_sets), s_idx));
+  auto set_lower = (set + triggering_cpu) & 0x1F; // Bits 0 - 4 inclusive
+  auto set_upper = (set >> 5) & 0x1F; // Bits 5 - 9 inclusive
+  auto is_sampled = set_lower == set_upper;
+  if (is_sampled) {
+    auto s_idx = set / SET_SAMPLE_RATE;
+    auto s_set_begin = std::next(std::begin(sampler), s_idx * NUM_WAY + (NUM_SET / SET_SAMPLE_RATE) * NUM_WAY * triggering_cpu);
     auto s_set_end = std::next(s_set_begin, NUM_WAY);
 
     // check hit
-    auto match = std::find_if(s_set_begin, s_set_end, [addr = full_addr, shamt = champsim::data::bits{8 + champsim::lg2(NUM_WAY)}](auto x) {
+    auto match = std::find_if(s_set_begin, s_set_end, [addr = full_addr, shamt = champsim::data::bits{champsim::lg2(NUM_SET / SET_SAMPLE_RATE) + champsim::lg2(NUM_WAY)}](auto x) {
       return x.valid && x.address.slice_upper(shamt) == addr.slice_upper(shamt);
     });
     if (match != s_set_end) {
       auto SHCT_idx = match->ip.slice_lower<32_b>().to<std::size_t>() % SHCT_PRIME;
-      SHCT[triggering_cpu][SHCT_idx]--;
+      SHCT[triggering_cpu][SHCT_idx] -= 1;
 
       match->used = true;
     } else {
       match = std::min_element(s_set_begin, s_set_end, [](auto x, auto y) { return x.last_used < y.last_used; });
 
-      if (match->used) {
+      if (!match->used) {
         auto SHCT_idx = match->ip.slice_lower<32_b>().to<std::size_t>() % SHCT_PRIME;
-        SHCT[triggering_cpu][SHCT_idx]++;
+        SHCT[triggering_cpu][SHCT_idx] += 1;
       }
 
       match->valid = true;
@@ -84,14 +79,23 @@ void ship::update_replacement_state(uint32_t triggering_cpu, long set, long way,
     match->last_used = access_count++;
   }
 
-  if (hit)
+  if(hit)
     get_rrpv(set, way) = 0;
-  else {
-    // SHIP prediction
-    auto SHCT_idx = ip.slice_lower<32_b>().to<std::size_t>() % SHCT_PRIME;
+}
 
+void ship::replacement_cache_fill(uint32_t triggering_cpu, long set, long way, champsim::address full_addr, champsim::address ip, champsim::address victim_addr, access_type type)
+{
+  // handle writeback access
+  if (access_type{type} == access_type::WRITE) {
     get_rrpv(set, way) = maxRRPV - 1;
-    if (SHCT[triggering_cpu][SHCT_idx].is_max())
-      get_rrpv(set, way) = maxRRPV;
+    return;
   }
+
+  using namespace champsim::data::data_literals;
+  // SHIP prediction
+  auto SHCT_idx = ip.slice_lower<32_b>().to<std::size_t>() % SHCT_PRIME;
+
+  get_rrpv(set, way) = maxRRPV - 1;
+  if (SHCT[triggering_cpu][SHCT_idx].is_max())
+    get_rrpv(set, way) = maxRRPV;
 }

--- a/replacement/ship/ship.h
+++ b/replacement/ship/ship.h
@@ -17,7 +17,7 @@ public:
   static constexpr int maxRRPV = 3;
   static constexpr std::size_t SHCT_SIZE = 16384;
   static constexpr unsigned SHCT_PRIME = 16381;
-  static constexpr std::size_t SAMPLER_SET_FACTOR = 256;
+  static constexpr std::size_t SET_SAMPLE_RATE = 32; // 1 in 32
   static constexpr unsigned SHCT_MAX = 7;
 
   // sampler structure
@@ -35,7 +35,6 @@ public:
   uint64_t access_count = 0;
 
   // sampler
-  std::vector<std::size_t> rand_sets;
   std::vector<SAMPLER_class> sampler;
   std::vector<int> rrpv_values;
 
@@ -46,6 +45,8 @@ public:
 
   long find_victim(uint32_t triggering_cpu, uint64_t instr_id, long set, const champsim::cache_block* current_set, champsim::address ip,
                    champsim::address full_addr, access_type type);
+  void replacement_cache_fill(uint32_t triggering_cpu, long set, long way, champsim::address full_addr, champsim::address ip, champsim::address victim_addr,
+                              access_type type);
   void update_replacement_state(uint32_t triggering_cpu, long set, long way, champsim::address full_addr, champsim::address ip, champsim::address victim_addr,
                                 access_type type, uint8_t hit);
 

--- a/replacement/ship/ship.h
+++ b/replacement/ship/ship.h
@@ -17,8 +17,9 @@ public:
   static constexpr int maxRRPV = 3;
   static constexpr std::size_t SHCT_SIZE = 16384;
   static constexpr unsigned SHCT_PRIME = 16381;
-  static constexpr std::size_t SET_SAMPLE_RATE = 32; // 1 in 32
   static constexpr unsigned SHCT_MAX = 7;
+
+  long SET_SAMPLE_RATE;
 
   // sampler structure
   class SAMPLER_class
@@ -49,6 +50,14 @@ public:
                               access_type type);
   void update_replacement_state(uint32_t triggering_cpu, long set, long way, champsim::address full_addr, champsim::address ip, champsim::address victim_addr,
                                 access_type type, uint8_t hit);
+
+  [[nodiscard]] constexpr bool is_sampled(long set) {
+    auto mask = SET_SAMPLE_RATE - 1;
+    auto shift = champsim::lg2(SET_SAMPLE_RATE);
+    auto low_slice = set & mask;
+    auto high_slice = (set >> shift) & mask;
+    return high_slice == low_slice;
+  }
 
   // use this function to print out your own stats at the end of simulation
   // void replacement_final_stats() {}

--- a/replacement/ship/ship.h
+++ b/replacement/ship/ship.h
@@ -19,8 +19,6 @@ public:
   static constexpr unsigned SHCT_PRIME = 16381;
   static constexpr unsigned SHCT_MAX = 7;
 
-  long SET_SAMPLE_RATE;
-
   // sampler structure
   class SAMPLER_class
   {
@@ -51,12 +49,8 @@ public:
   void update_replacement_state(uint32_t triggering_cpu, long set, long way, champsim::address full_addr, champsim::address ip, champsim::address victim_addr,
                                 access_type type, uint8_t hit);
 
-  [[nodiscard]] constexpr bool is_sampled(long set) {
-    auto mask = SET_SAMPLE_RATE - 1;
-    auto shift = champsim::lg2(SET_SAMPLE_RATE);
-    auto low_slice = set & mask;
-    auto high_slice = (set >> shift) & mask;
-    return high_slice == low_slice;
+  [[nodiscard]] bool is_sampled(long set) {
+    return get_set_sample_category(set) == 0;
   }
 
   // use this function to print out your own stats at the end of simulation


### PR DESCRIPTION
Fixes for issues brought up in #599.

### Issues with Set Dueling / Sampling

Rather than utilizing random sampling for DRRIP / SHiP, I instead used the leader set selection mechanism proposed in the original set dueling paper.  Namely, to determine the leader set for one policy we check `set[0:5] == set[5:10]` and to determine the other we check `set[0:5] == ~set[5:10]`.  For SHiP, I used the same approach for determining which sets should be sampled for tracking.

By adopting the above approach, there will be one BRRIP and one SRRIP leader set per 32 sets and one SHiP sampled set per 32 sets.

### Other Issues

SHiP had a separate bug where the `if (match->used)` condition should have been reversed.

In order to make both policies work in light of #570 and #598, I modified both policies to have `replacement_cache_fill` and disregarded misses as needed in `update_replacement_state`.

### Overall Results

After making these changes, the performance now typically follows the SHiP >= DRRIP > LRU trend.  Before, SHiP, DRRIP, and LRU would often have similar performance.