### PR TITLE
Check dependencies of the main file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ override LDLIBS   += -lCLI11 -llzma -lz -lbz2 -lfmt
 .PHONY: all clean compile_commands compile_commands_clean configclean test pytest maketest
 
 test_main_name=test/bin/000-test-main
+build_ids:=
 executable_name:=
 prereq_for_generated:=
 
@@ -331,7 +332,7 @@ pytest:
 	PYTHONPATH=$(PYTHONPATH):$(ROOT_DIR) python3 -m unittest discover -v --start-directory='test/python'
 
 ifeq (,$(filter clean compile_commands compile_commands_clean configclean pytest maketest, $(MAKECMDGOALS)))
--include $(patsubst $(OBJ_ROOT)/%.o,$(DEP_ROOT)/%.d,$(call get_base_objs,TEST) $(test_base_objs) $(base_module_objs))
+-include $(patsubst $(OBJ_ROOT)/%.o,$(DEP_ROOT)/%.d,$(foreach build_id,TEST $(build_ids),$(call get_base_objs,$(build_id))) $(test_base_objs) $(base_module_objs))
 endif
 
 ifeq (maketest,$(findstring maketest,$(MAKECMDGOALS)))

--- a/config/makefile.py
+++ b/config/makefile.py
@@ -84,6 +84,7 @@ def get_makefile_lines(build_id, executable, module_info):
     if legacy_paths:
         yield from append_variable('prereq_for_generated', *legacy_paths, targets=['$(generated_files)'])
 
+    yield from append_variable('build_ids', build_id)
     yield from append_variable('executable_name', exe_basename)
 
     yield ''


### PR DESCRIPTION
The dependencies of the main file in a build not for testing was not checked, which could result in an invalid build when one of the dependencies like inc/channel.h was modified. Check them properly by including dependency rules of the build specified in _configuration.mk.