### PR TITLE
Stop testing on Ubuntu 20.04 on GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,22 +38,12 @@ jobs:
         config:
         # GCC-9
         - {
-            name: "Ubuntu 20.04 GCC 9",
-            os: ubuntu-20.04,
-            cxx: "g++-9",
-          }
-        - {
             name: "Ubuntu 22.04 GCC 9",
             os: ubuntu-22.04,
             cxx: "g++-9",
           }
 
         # GCC-10
-        - {
-            name: "Ubuntu 20.04 GCC 10",
-            os: ubuntu-20.04,
-            cxx: "g++-10",
-          }
         - {
             name: "Ubuntu 22.04 GCC 10",
             os: ubuntu-22.04,
@@ -68,26 +58,7 @@ jobs:
             coverage: true,
           }
 
-        # Clang-10
-        - {
-            name: "Ubuntu 20.04 Clang 10",
-            os: ubuntu-20.04,
-            cxx: "clang++-10",
-          }
-
-        # Clang-11
-        - {
-            name: "Ubuntu 20.04 Clang 11",
-            os: ubuntu-20.04,
-            cxx: "clang++-11",
-          }
-
         # Clang-12
-        - {
-            name: "Ubuntu 20.04 Clang 12",
-            os: ubuntu-20.04,
-            cxx: "clang++-12",
-          }
         - {
             name: "Ubuntu 22.04 Clang 12",
             os: ubuntu-22.04,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,7 +132,6 @@ jobs:
         --directory . \
         --exclude $(pwd)/.csconfig/\* \
         --exclude $(pwd)/test/\* \
-        --exclude $(pwd)/tracer/\* \
         --exclude $(pwd)/vcpkg_installed/\* \
         --output-file lcov_cpp.info
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,33 @@ jobs:
             name: "Ubuntu 22.04 GCC 11",
             os: ubuntu-22.04,
             cxx: "g++-11",
+          }
+
+        # GCC-12
+        - {
+            name: "Ubuntu 22.04 GCC 12",
+            os: ubuntu-22.04,
+            cxx: "g++-12",
+          }
+        - {
+            name: "Ubuntu 24.04 GCC 12",
+            os: ubuntu-24.04,
+            cxx: "g++-12",
+          }
+
+        # GCC-13
+        - {
+            name: "Ubuntu 24.04 GCC 13",
+            os: ubuntu-24.04,
+            cxx: "g++-13",
             coverage: true,
+          }
+
+        # GCC-14
+        - {
+            name: "Ubuntu 24.04 GCC 14",
+            os: ubuntu-24.04,
+            cxx: "g++-14",
           }
 
         # Clang-12
@@ -77,6 +103,34 @@ jobs:
             name: "Ubuntu 22.04 Clang 14",
             os: ubuntu-22.04,
             cxx: "clang++-14",
+          }
+
+        # Clang-15
+        - {
+            name: "Ubuntu 22.04 Clang 15",
+            os: ubuntu-22.04,
+            cxx: "clang++-15",
+          }
+
+        # Clang-16
+        - {
+            name: "Ubuntu 24.04 Clang 16",
+            os: ubuntu-24.04,
+            cxx: "clang++-16",
+          }
+
+        # Clang-17
+        - {
+            name: "Ubuntu 24.04 Clang 17",
+            os: ubuntu-24.04,
+            cxx: "clang++-17",
+          }
+
+        # Clang-18
+        - {
+            name: "Ubuntu 24.04 Clang 18",
+            os: ubuntu-24.04,
+            cxx: "clang++-18",
           }
 
         # AppleClang


### PR DESCRIPTION
Ubuntu 20.04 on GitHub Actions became fully unsupported by 2025-04-15.