### PR TITLE
Fix TEST_NUM parameter parsing in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,7 @@ compile_commands: $(src_compile_commands_file) $(inc_compile_commands_file) $(te
 
 # Tests: build and run
 ifdef TEST_NUM
-selected_test = -\# "[$(addprefix #,$(filter $(addsuffix %,$(TEST_NUM)), $(patsubst %.cc,%,$(notdir $(wildcard $(test_source_dir)/*.cc)))))]"
+selected_test = -\# "[$(addprefix \#,$(filter $(addsuffix %,$(TEST_NUM)), $(patsubst %.cc,%,$(notdir $(wildcard $(test_source_dir)/*.cc)))))]"
 endif
 test: $(test_main_name)
 	$(test_main_name) $(selected_test)


### PR DESCRIPTION
  Closes #650 
  
  The `TEST_NUM` parameter was not working correctly when running individual
  tests due to incorrect pattern matching in the `selected_test` variable.
  This prevented commands like `make test TEST_NUM=401` from executing.

  Fixed by correcting the `addprefix/filter/addsuffix` pattern matching
  logic to properly identify test files based on the provided `TEST_NUM`.

  Before: `make test TEST_NUM=401` would fail to find matching tests
  After: `make test TEST_NUM=401` correctly runs `401-hit-latency.cc`

  Tested with various `TEST_NUM` values and `TEST_ORDER` parameters.