### PR TITLE
changes to vmem physical page allocation policy

### DIFF
--- a/inc/vmem.h
+++ b/inc/vmem.h
@@ -123,8 +123,6 @@ public:
   std::pair<champsim::address, champsim::chrono::clock::duration> get_pte_pa(uint32_t cpu_num, champsim::page_number vaddr, std::size_t level);
 
   auto ppage_index(uint32_t cpu_num, champsim::page_number vaddr);
-  
-  void ppage_pop_idx(std::deque<std::pair<champsim::page_number, bool>>::iterator it);
 };
 
 #endif

--- a/inc/vmem.h
+++ b/inc/vmem.h
@@ -39,7 +39,7 @@ private:
   std::optional<uint64_t> randomization_seed;
   MEMORY_CONTROLLER& dram;
   std::vector<uint64_t> hash_constants;
-
+  size_t free_ppages;
 public:
   const champsim::chrono::clock::duration minor_fault_penalty;
   const std::size_t pt_levels;

--- a/inc/vmem.h
+++ b/inc/vmem.h
@@ -38,6 +38,7 @@ private:
   std::map<std::tuple<uint32_t, uint32_t, champsim::address_slice<champsim::dynamic_extent>>, champsim::address> page_table;
   std::optional<uint64_t> randomization_seed;
   MEMORY_CONTROLLER& dram;
+  std::vector<uint64_t> hash_constants;
 
 public:
   const champsim::chrono::clock::duration minor_fault_penalty;
@@ -45,7 +46,8 @@ public:
   const pte_entry pte_page_size; // Size of a PTE page
 
 private:
-  std::deque<champsim::page_number> ppage_free_list;
+  // std::deque<champsim::page_number> ppage_free_list;
+  std::deque<std::pair<champsim::page_number, bool>> ppage_free_list;
   champsim::page_number active_pte_page{};
   champsim::address_slice<champsim::dynamic_extent> next_pte_page;
 
@@ -53,6 +55,7 @@ private:
   // champsim::page_number last_ppage;
 
   [[nodiscard]] champsim::page_number ppage_front() const;
+  
   void ppage_pop();
 
   void shuffle_pages();
@@ -118,6 +121,10 @@ public:
    * :returns: A pair of the page table page address and the latency to be applied to the operation.
    */
   std::pair<champsim::address, champsim::chrono::clock::duration> get_pte_pa(uint32_t cpu_num, champsim::page_number vaddr, std::size_t level);
+
+  std::deque<std::pair<champsim::page_number, bool>>::iterator ppage_index(uint32_t cpu_num, champsim::page_number vaddr);
+  
+  void ppage_pop_idx(std::deque<std::pair<champsim::page_number, bool>>::iterator it);
 };
 
 #endif

--- a/inc/vmem.h
+++ b/inc/vmem.h
@@ -122,7 +122,7 @@ public:
    */
   std::pair<champsim::address, champsim::chrono::clock::duration> get_pte_pa(uint32_t cpu_num, champsim::page_number vaddr, std::size_t level);
 
-  std::deque<std::pair<champsim::page_number, bool>>::iterator ppage_index(uint32_t cpu_num, champsim::page_number vaddr);
+  auto ppage_index(uint32_t cpu_num, champsim::page_number vaddr);
   
   void ppage_pop_idx(std::deque<std::pair<champsim::page_number, bool>>::iterator it);
 };

--- a/src/vmem.cc
+++ b/src/vmem.cc
@@ -50,14 +50,7 @@ VirtualMemory::VirtualMemory(champsim::data::bytes page_table_page_size, std::si
   std::mt19937_64 rng(randomization_seed.value_or(0));
   std::uniform_int_distribution<uint64_t> dist(0, ppage_free_list.size() - 1);
 
-  // std::vector<uint64_t> hash_constants;
-  hash_constants.resize(NUM_CPUS);
-
-  
-
-  for(std::size_t i=0; i < hash_constants.size(); i++){
-    hash_constants[i] = dist(rng);
-  }
+  std::generate_n(std::back_inserter(hash_constants), NUM_CPUS, [rng, dist]{ return dist(rng); });
 
 }
 

--- a/src/vmem.cc
+++ b/src/vmem.cc
@@ -46,6 +46,19 @@ VirtualMemory::VirtualMemory(champsim::data::bytes page_table_page_size, std::si
   }
   populate_pages();
   shuffle_pages();
+
+  std::mt19937_64 rng(randomization_seed.value_or(0));
+  std::uniform_int_distribution<uint64_t> dist(0, ppage_free_list.size() - 1);
+
+  // std::vector<uint64_t> hash_constants;
+  hash_constants.resize(NUM_CPUS);
+
+  
+
+  for(std::size_t i=0; i < hash_constants.size(); i++){
+    hash_constants[i] = dist(rng);
+  }
+
 }
 
 VirtualMemory::VirtualMemory(champsim::data::bytes page_table_page_size, std::size_t page_table_levels, champsim::chrono::clock::duration minor_penalty,
@@ -53,6 +66,19 @@ VirtualMemory::VirtualMemory(champsim::data::bytes page_table_page_size, std::si
     : VirtualMemory(page_table_page_size, page_table_levels, minor_penalty, dram_, {})
 {
 }
+
+// void VirtualMemory::populate_pages()
+// {
+//   assert(dram.size() > 1_MiB);
+//   ppage_free_list.resize(((dram.size() - 1_MiB) / PAGE_SIZE).count());
+//   assert(ppage_free_list.size() != 0);
+//   champsim::page_number base_address =
+//       champsim::page_number{champsim::lowest_address_for_size(std::max<champsim::data::mebibytes>(champsim::data::bytes{PAGE_SIZE}, 1_MiB))};
+//   for (auto it = ppage_free_list.begin(); it != ppage_free_list.end(); it++) {
+//     *it = base_address;
+//     base_address++;
+//   }
+// }
 
 void VirtualMemory::populate_pages()
 {
@@ -62,7 +88,8 @@ void VirtualMemory::populate_pages()
   champsim::page_number base_address =
       champsim::page_number{champsim::lowest_address_for_size(std::max<champsim::data::mebibytes>(champsim::data::bytes{PAGE_SIZE}, 1_MiB))};
   for (auto it = ppage_free_list.begin(); it != ppage_free_list.end(); it++) {
-    *it = base_address;
+    it->first = base_address;
+    it->second = false;
     base_address++;
   }
 }
@@ -86,10 +113,52 @@ uint64_t VirtualMemory::get_offset(champsim::address vaddr, std::size_t level) c
 
 uint64_t VirtualMemory::get_offset(champsim::page_number vaddr, std::size_t level) const { return get_offset(champsim::address{vaddr}, level); }
 
-champsim::page_number VirtualMemory::ppage_front() const
+// champsim::page_number VirtualMemory::ppage_front() const
+// {
+//   assert(available_ppages() > 0);
+//   return ppage_free_list.front();
+// }
+
+
+std::deque<std::pair<champsim::page_number, bool>>::iterator
+VirtualMemory::ppage_index(uint32_t cpu_num, champsim::page_number vaddr)
 {
-  assert(available_ppages() > 0);
-  return ppage_free_list.front();
+    auto vaddr_val = vaddr.to<uint64_t>();
+    std::size_t idx = (hash_constants[cpu_num] ^ vaddr_val) % ppage_free_list.size();
+
+    auto it = ppage_free_list.begin() + idx;
+    
+    // for keeping track of the original ptr
+    auto start_itr = it;
+    while(it != ppage_free_list.end() && it->second){
+      it++;
+    }
+
+    if(it == ppage_free_list.end()){
+      it = ppage_free_list.begin();
+      while(it != start_itr && it->second){
+        it++;
+      }
+
+      if(it == start_itr){
+        fmt::print("[VMEM] ABORT: Out of physical memory\n");
+        std::abort();
+      }
+      
+    }
+
+    return it;
+}
+
+
+void VirtualMemory::ppage_pop_idx(std::deque<std::pair<champsim::page_number, bool>>::iterator it){
+  it->second = true;
+  // ppage_free_list.erase(it);
+  // if (available_ppages() == 0) {
+  //   fmt::print("[VMEM] WARNING: Out of physical memory, freeing ppages\n");
+  //   populate_pages();
+  //   shuffle_pages();
+  // }
 }
 
 void VirtualMemory::ppage_pop()
@@ -106,11 +175,23 @@ std::size_t VirtualMemory::available_ppages() const { return (ppage_free_list.si
 
 std::pair<champsim::page_number, champsim::chrono::clock::duration> VirtualMemory::va_to_pa(uint32_t cpu_num, champsim::page_number vaddr)
 {
-  auto [ppage, fault] = vpage_to_ppage_map.try_emplace({cpu_num, champsim::page_number{vaddr}}, ppage_front());
+  // auto [ppage, fault] = vpage_to_ppage_map.try_emplace({cpu_num, champsim::page_number{vaddr}}, ppage_front());
+
+
+  auto candidate_it = ppage_index(cpu_num, vaddr);
+
+  auto [ppage, fault] = vpage_to_ppage_map.try_emplace(
+      {cpu_num, vaddr},
+      candidate_it->first
+  );
 
   // this vpage doesn't yet have a ppage mapping
+  // if (fault) {
+  //   ppage_pop();
+  // }
+
   if (fault) {
-    ppage_pop();
+    ppage_pop_idx(candidate_it);
   }
 
   auto penalty = fault ? minor_fault_penalty : champsim::chrono::clock::duration::zero();
@@ -124,10 +205,18 @@ std::pair<champsim::page_number, champsim::chrono::clock::duration> VirtualMemor
 
 std::pair<champsim::address, champsim::chrono::clock::duration> VirtualMemory::get_pte_pa(uint32_t cpu_num, champsim::page_number vaddr, std::size_t level)
 {
+  // if (champsim::page_offset{next_pte_page} == champsim::page_offset{0}) {
+  //   active_pte_page = ppage_front();
+  //   ppage_pop();
+  // }
+
   if (champsim::page_offset{next_pte_page} == champsim::page_offset{0}) {
-    active_pte_page = ppage_front();
-    ppage_pop();
+    auto candidate_it = ppage_index(cpu_num, vaddr);
+    active_pte_page = candidate_it->first;
+    ppage_pop_idx(candidate_it);
+
   }
+
 
   champsim::dynamic_extent pte_table_entry_extent{champsim::address::bits, shamt(level)};
   auto [ppage, fault] =

--- a/src/vmem.cc
+++ b/src/vmem.cc
@@ -126,12 +126,6 @@ VirtualMemory::ppage_index(uint32_t cpu_num, champsim::page_number vaddr)
     return it;
 }
 
-
-void VirtualMemory::ppage_pop_idx(std::deque<std::pair<champsim::page_number, bool>>::iterator it){
-  it->second = true;
-  free_ppages--; // decrement the number of free ppages.
-}
-
 void VirtualMemory::ppage_pop()
 {
   ppage_free_list.pop_front();
@@ -155,7 +149,8 @@ std::pair<champsim::page_number, champsim::chrono::clock::duration> VirtualMemor
 
   // this vpage doesn't yet have a ppage mapping
   if (fault) {
-    ppage_pop_idx(candidate_it);
+    candidate_it->second = true;
+    free_ppages--;
   }
 
   auto penalty = fault ? minor_fault_penalty : champsim::chrono::clock::duration::zero();
@@ -173,8 +168,8 @@ std::pair<champsim::address, champsim::chrono::clock::duration> VirtualMemory::g
   if (champsim::page_offset{next_pte_page} == champsim::page_offset{0}) {
     auto candidate_it = ppage_index(cpu_num, vaddr);
     active_pte_page = candidate_it->first;
-    ppage_pop_idx(candidate_it);
-
+    candidate_it->second = true;
+    free_ppages--;
   }
 
 

--- a/src/vmem.cc
+++ b/src/vmem.cc
@@ -50,7 +50,7 @@ VirtualMemory::VirtualMemory(champsim::data::bytes page_table_page_size, std::si
   std::mt19937_64 rng(randomization_seed.value_or(0));
   std::uniform_int_distribution<uint64_t> dist(0, ppage_free_list.size() - 1);
 
-  std::generate_n(std::back_inserter(hash_constants), NUM_CPUS, [rng, dist]{ return dist(rng); });
+  std::generate_n(std::back_inserter(hash_constants), NUM_CPUS, [&rng, &dist]{ return dist(rng); });
 
 }
 
@@ -73,6 +73,8 @@ void VirtualMemory::populate_pages()
     it->second = false;
     base_address++;
   }
+
+  free_ppages = ppage_free_list.size();
 }
 
 void VirtualMemory::shuffle_pages()
@@ -93,13 +95,6 @@ champsim::data::bits VirtualMemory::shamt(std::size_t level) const { return exte
 uint64_t VirtualMemory::get_offset(champsim::address vaddr, std::size_t level) const { return champsim::address_slice{extent(level), vaddr}.to<uint64_t>(); }
 
 uint64_t VirtualMemory::get_offset(champsim::page_number vaddr, std::size_t level) const { return get_offset(champsim::address{vaddr}, level); }
-
-// champsim::page_number VirtualMemory::ppage_front() const
-// {
-//   assert(available_ppages() > 0);
-//   return ppage_free_list.front();
-// }
-
 
 auto
 VirtualMemory::ppage_index(uint32_t cpu_num, champsim::page_number vaddr)
@@ -134,12 +129,7 @@ VirtualMemory::ppage_index(uint32_t cpu_num, champsim::page_number vaddr)
 
 void VirtualMemory::ppage_pop_idx(std::deque<std::pair<champsim::page_number, bool>>::iterator it){
   it->second = true;
-  // ppage_free_list.erase(it);
-  // if (available_ppages() == 0) {
-  //   fmt::print("[VMEM] WARNING: Out of physical memory, freeing ppages\n");
-  //   populate_pages();
-  //   shuffle_pages();
-  // }
+  free_ppages--; // decrement the number of free ppages.
 }
 
 void VirtualMemory::ppage_pop()
@@ -152,13 +142,10 @@ void VirtualMemory::ppage_pop()
   }
 }
 
-std::size_t VirtualMemory::available_ppages() const { return (ppage_free_list.size()); }
+std::size_t VirtualMemory::available_ppages() const { return free_ppages; }
 
 std::pair<champsim::page_number, champsim::chrono::clock::duration> VirtualMemory::va_to_pa(uint32_t cpu_num, champsim::page_number vaddr)
 {
-  // auto [ppage, fault] = vpage_to_ppage_map.try_emplace({cpu_num, champsim::page_number{vaddr}}, ppage_front());
-
-
   auto candidate_it = ppage_index(cpu_num, vaddr);
 
   auto [ppage, fault] = vpage_to_ppage_map.try_emplace(
@@ -167,10 +154,6 @@ std::pair<champsim::page_number, champsim::chrono::clock::duration> VirtualMemor
   );
 
   // this vpage doesn't yet have a ppage mapping
-  // if (fault) {
-  //   ppage_pop();
-  // }
-
   if (fault) {
     ppage_pop_idx(candidate_it);
   }
@@ -186,11 +169,7 @@ std::pair<champsim::page_number, champsim::chrono::clock::duration> VirtualMemor
 
 std::pair<champsim::address, champsim::chrono::clock::duration> VirtualMemory::get_pte_pa(uint32_t cpu_num, champsim::page_number vaddr, std::size_t level)
 {
-  // if (champsim::page_offset{next_pte_page} == champsim::page_offset{0}) {
-  //   active_pte_page = ppage_front();
-  //   ppage_pop();
-  // }
-
+  
   if (champsim::page_offset{next_pte_page} == champsim::page_offset{0}) {
     auto candidate_it = ppage_index(cpu_num, vaddr);
     active_pte_page = candidate_it->first;

--- a/src/vmem.cc
+++ b/src/vmem.cc
@@ -67,18 +67,6 @@ VirtualMemory::VirtualMemory(champsim::data::bytes page_table_page_size, std::si
 {
 }
 
-// void VirtualMemory::populate_pages()
-// {
-//   assert(dram.size() > 1_MiB);
-//   ppage_free_list.resize(((dram.size() - 1_MiB) / PAGE_SIZE).count());
-//   assert(ppage_free_list.size() != 0);
-//   champsim::page_number base_address =
-//       champsim::page_number{champsim::lowest_address_for_size(std::max<champsim::data::mebibytes>(champsim::data::bytes{PAGE_SIZE}, 1_MiB))};
-//   for (auto it = ppage_free_list.begin(); it != ppage_free_list.end(); it++) {
-//     *it = base_address;
-//     base_address++;
-//   }
-// }
 
 void VirtualMemory::populate_pages()
 {
@@ -120,7 +108,7 @@ uint64_t VirtualMemory::get_offset(champsim::page_number vaddr, std::size_t leve
 // }
 
 
-std::deque<std::pair<champsim::page_number, bool>>::iterator
+auto
 VirtualMemory::ppage_index(uint32_t cpu_num, champsim::page_number vaddr)
 {
     auto vaddr_val = vaddr.to<uint64_t>();


### PR DESCRIPTION
This PR updates the virtual-to-physical page allocation policy to use a hash-based index instead of sequential allocation. This makes physical page selection deterministic and reproducible across runs, addressing variability discussed in [#656](https://github.com/ChampSim/ChampSim/discussions/656)

Sequential allocation caused differences in mappings depending on timing/order of page faults, leading to inconsistent behavior even with identical seeds. A hash-based mapping stabilizes this.