### PR TITLE
Trace by symbol instead of instruction count.

### DIFF
--- a/tracer/pin/README.md
+++ b/tracer/pin/README.md
@@ -31,12 +31,29 @@ Specify the number of instructions to skip in the program before tracing begins.
 The default value is 0.
 
 -t <number>
-The number of instructions to trace, after -s instructions have been skipped.
+The cumulative number of instructions to trace.
 The default value is 1,000,000.
+
+-start_symbol <symbol_name>
+Symbol name to start tracing (e.g., 'main' or '_Z4testv'). If specified `-s` argument is ignored.
+
+-stop_symbol <symbol_name>
+"Symbol name to stop tracing (optional)"
 ```
 For example, you could trace 200,000 instructions of the program ls, after skipping the first 100,000 instructions, with this command:
 
     pin -t obj/champsim_tracer.so -o traces/ls_trace.champsim -s 100000 -t 200000 -- ls
+
+Or if you are interested only in a particular section of the executible you could add symbols marking the beginning and end of the region. For example, [`symbol_trace_example.cpp`](symbol_trace_example.cpp) used like the following:
+
+```bash
+# compile the program to `a.out`
+g++ symbol_trace_example.cpp
+# check the symbols are present in the output binary
+nm a.out | grep champsim
+# run the tracer with the symbols demarcating where to start and stop
+pin -t obj/champsim_tracer.so -o traces/symbol_trace_example.champsim -start_symbol __champsim_start_trace -stop_symbol __champsim_start_trace -- ./a.out
+```
 
 Traces created with the champsim_tracer.so are approximately 64 bytes per instruction, but they generally compress down to less than a byte per instruction using xz compression.
 

--- a/tracer/pin/champsim_tracer.cpp
+++ b/tracer/pin/champsim_tracer.cpp
@@ -82,7 +82,13 @@ void ResetCurrentInstruction(VOID* ip)
 BOOL ShouldWrite()
 {
   ++instrCount;
-  return (instrCount > KnobSkipInstructions.Value()) && (instrCount <= (KnobTraceInstructions.Value() + KnobSkipInstructions.Value()));
+  if (instrCount > (KnobTraceInstructions.Value() + KnobSkipInstructions.Value())) {
+    // Stop the application with code 0.
+    // Note we don't use `PIN_Detach()` because that would stop instrumentation, but let the process continue, and there's no reason to do that.
+    PIN_ExitApplication(0);
+    return false;
+  }
+  return (instrCount > KnobSkipInstructions.Value());
 }
 
 void WriteCurrentInstruction()

--- a/tracer/pin/champsim_tracer.cpp
+++ b/tracer/pin/champsim_tracer.cpp
@@ -157,11 +157,6 @@ VOID StopTracing(VOID* ip)
 // Instrument image loads to find symbols
 VOID ImageLoad(IMG img, VOID* v)
 {
-  /* // List all symbols in the image to debug
-  for (SYM sym = IMG_RegsymHead(img); SYM_Valid(sym); sym = SYM_Next(sym)) {
-    std::cout << "Found symbol: " << SYM_Name(sym) << " at " << std::hex << SYM_Address(sym) << std::dec << std::endl;
-  } */
-
   // Look for start symbol
   if (!KnobStartSymbol.Value().empty() && !foundStartSymbol.load()) {
     RTN rtn = RTN_FindByName(img, KnobStartSymbol.Value().c_str());

--- a/tracer/pin/champsim_tracer.cpp
+++ b/tracer/pin/champsim_tracer.cpp
@@ -19,6 +19,7 @@
  *  and could serve as the starting point for developing your first PIN tool
  */
 
+#include <atomic>
 #include <fstream>
 #include <iostream>
 #include <stdlib.h>
@@ -34,7 +35,13 @@ using trace_instr_format_t = input_instr;
 // Global variables
 /* ================================================================== */
 
-UINT64 instrCount = 0;
+static std::atomic<UINT64> skippedInstrCount(0);
+static std::atomic<UINT64> tracedInstructions(0);
+static std::atomic<UINT64> tracedCumulativeInstructions(0);
+static std::atomic<bool> tracingActive(false);
+static std::atomic<bool> foundStartSymbol(false);
+static std::atomic<bool> foundStopSymbol(false);
+static std::atomic<bool> mainImageLoaded(false);
 
 std::ofstream outfile;
 
@@ -48,6 +55,11 @@ KNOB<std::string> KnobOutputFile(KNOB_MODE_WRITEONCE, "pintool", "o", "champsim.
 KNOB<UINT64> KnobSkipInstructions(KNOB_MODE_WRITEONCE, "pintool", "s", "0", "How many instructions to skip before tracing begins");
 
 KNOB<UINT64> KnobTraceInstructions(KNOB_MODE_WRITEONCE, "pintool", "t", "1000000", "How many instructions to trace");
+
+KNOB<std::string> KnobStartSymbol(KNOB_MODE_WRITEONCE, "pintool", "start_symbol", "",
+                                  "Symbol name to start tracing (e.g., 'main' or '_Z4testv'). If specified `-s` argument is ignored.");
+
+KNOB<std::string> KnobStopSymbol(KNOB_MODE_WRITEONCE, "pintool", "stop_symbol", "", "Symbol name to stop tracing (optional)");
 
 /* ===================================================================== */
 // Utilities
@@ -81,14 +93,27 @@ void ResetCurrentInstruction(VOID* ip)
 
 BOOL ShouldWrite()
 {
-  ++instrCount;
-  if (instrCount > (KnobTraceInstructions.Value() + KnobSkipInstructions.Value())) {
-    // Stop the application with code 0.
-    // Note we don't use `PIN_Detach()` because that would stop instrumentation, but let the process continue, and there's no reason to do that.
-    PIN_ExitApplication(0);
+  // Enable tracing when skip limit reached if not symbol-based tracing.
+  // If using symbol-based tracing, `tracingActive` is set at the symbol instead.
+  if (KnobStartSymbol.Value().empty() && skippedInstrCount > KnobSkipInstructions.Value()) {
+    tracingActive = true;
+  }
+  if (tracingActive) {
+    ++tracedInstructions;
+    ++tracedCumulativeInstructions;
+  } else {
+    ++skippedInstrCount;
     return false;
   }
-  return (instrCount > KnobSkipInstructions.Value());
+  if (tracedCumulativeInstructions > KnobTraceInstructions.Value()) {
+    tracingActive = false;
+    std::cout << "Reached instruction limit: " << KnobTraceInstructions.Value() << ". Stopping trace." << std::endl;
+    // Note we don't use `PIN_Detach()` because that would stop instrumentation, but let the process continue, and there's no reason to do that.
+    // Stop the application with code 0.
+    PIN_ExitApplication(0);
+    return false; // unreachable
+  }
+  return true;
 }
 
 void WriteCurrentInstruction()
@@ -110,6 +135,77 @@ void WriteToSet(T* begin, T* end, UINT32 r)
   auto set_end = std::find(begin, end, 0);
   auto found_reg = std::find(begin, set_end, r); // check to see if this register is already in the list
   *found_reg = r;
+}
+
+VOID StartTracing(VOID* ip)
+{
+  if (!tracingActive) {
+    tracingActive = true;
+    tracedInstructions = 0;
+    std::cout << "[PIN] Started tracing at IP: 0x" << std::hex << ip << std::dec << std::endl;
+  }
+}
+
+VOID StopTracing(VOID* ip)
+{
+  if (tracingActive) {
+    tracingActive = false;
+    std::cout << "[PIN] Stopped tracing at IP: 0x" << std::hex << ip << std::dec << " after " << tracedInstructions << " instructions" << std::endl;
+  }
+}
+
+// Instrument image loads to find symbols
+VOID ImageLoad(IMG img, VOID* v)
+{
+  /* // List all symbols in the image to debug
+  for (SYM sym = IMG_RegsymHead(img); SYM_Valid(sym); sym = SYM_Next(sym)) {
+    std::cout << "Found symbol: " << SYM_Name(sym) << " at " << std::hex << SYM_Address(sym) << std::dec << std::endl;
+  } */
+
+  // Look for start symbol
+  if (!KnobStartSymbol.Value().empty() && !foundStartSymbol.load()) {
+    RTN rtn = RTN_FindByName(img, KnobStartSymbol.Value().c_str());
+
+    if (RTN_Valid(rtn)) {
+      foundStartSymbol.store(true);
+      RTN_Open(rtn);
+      // Insert call at function entry
+      RTN_InsertCall(rtn, IPOINT_BEFORE, (AFUNPTR)StartTracing, IARG_INST_PTR, IARG_END);
+      RTN_Close(rtn);
+
+      std::cout << "Found start symbol '" << KnobStartSymbol.Value() << "' in image " << IMG_Name(img) << std::endl;
+    }
+  }
+
+  // Look for stop symbol
+  if (!KnobStopSymbol.Value().empty() && !foundStopSymbol.load()) {
+    foundStopSymbol.store(true);
+    RTN rtn = RTN_FindByName(img, KnobStopSymbol.Value().c_str());
+
+    if (RTN_Valid(rtn)) {
+      RTN_Open(rtn);
+      // Insert call at function entry (or use IPOINT_AFTER for function exit)
+      RTN_InsertCall(rtn, IPOINT_BEFORE, (AFUNPTR)StopTracing, IARG_INST_PTR, IARG_END);
+      RTN_Close(rtn);
+
+      std::cout << "Found stop symbol '" << KnobStopSymbol.Value() << "' in image " << IMG_Name(img) << std::endl;
+    }
+  }
+
+  if (IMG_IsMainExecutable(img)) {
+    bool exit = false;
+    if (!KnobStartSymbol.Value().empty() && !foundStartSymbol.load()) {
+      std::cerr << "[PIN] ERROR: Trace start symbol '" << KnobStartSymbol.Value() << "' not found!" << std::endl;
+      exit = true;
+    }
+    if (!KnobStopSymbol.Value().empty() && !foundStopSymbol.load()) {
+      std::cerr << "[PIN] ERROR: Trace stop symbol '" << KnobStopSymbol.Value() << "' not found!" << std::endl;
+      exit = true;
+    }
+    if (exit) {
+      PIN_ExitApplication(1);
+    }
+  }
 }
 
 /* ===================================================================== */
@@ -178,6 +274,8 @@ VOID Fini(INT32 code, VOID* v) { outfile.close(); }
  */
 int main(int argc, char* argv[])
 {
+  PIN_InitSymbols();
+
   // Initialize PIN library. Print help message if -h(elp) is specified
   // in the command line or the command line is invalid
   if (PIN_Init(argc, argv))
@@ -188,6 +286,9 @@ int main(int argc, char* argv[])
     std::cout << "Couldn't open output trace file. Exiting." << std::endl;
     exit(1);
   }
+
+  // Register function to perform symbol lookup
+  IMG_AddInstrumentFunction(ImageLoad, 0);
 
   // Register function to be called to instrument instructions
   INS_AddInstrumentFunction(Instruction, 0);

--- a/tracer/pin/symbol_trace_example.cpp
+++ b/tracer/pin/symbol_trace_example.cpp
@@ -1,0 +1,14 @@
+#include "stdio.h"
+
+extern "C" {
+__attribute__((noinline)) void __champsim_start_trace(void) { asm volatile(""); }
+__attribute__((noinline)) void __champsim_stop_trace(void) { asm volatile(""); }
+}
+int main()
+{
+  for (size_t i = 0; i < 10; ++i) { // not tracing the loop maintainance code
+    __champsim_start_trace();
+    printf("Hello World"); // but tracing this code
+    __champsim_stop_trace();
+  }
+}


### PR DESCRIPTION
# Feature
Adds two new command line options to the pin tracer:  `start_symbol` and `stop_symbol`.

These allow precisely controlling when tracing occurs. When the start_symbol is reached tracing is enabled, and when the stop_symbol is reached tracing is disabled. This can be used on existing binaries (possibly by using `objdump -d -j .text` or similar to find the symbol) or by purposefully creating an unmangled function and inserting it into the binary which is intended on being traced.

If the new arguments are unspecified, behavior is the same as before the feature except that:

This pr also changes the tracer so that after the number of instructions specified by `-t` have been traced, the pin tool terminates the traced program, since there is no reason to continue execution.

# Misc
From what I can see prs are expected to pull request into the `develop` branch. Let me know if I'm mistaken.
I wrote this because I found it useful. If inclusion is unwanted, let me know and I'll close the pr.