### PR TITLE
Fix for pin tracer instruction count bug

### DIFF
--- a/tracer/pin/champsim_tracer.cpp
+++ b/tracer/pin/champsim_tracer.cpp
@@ -34,7 +34,9 @@ using trace_instr_format_t = input_instr;
 // Global variables
 /* ================================================================== */
 
-UINT64 instrCount = 0;
+volatile UINT64 instrCount = 0;
+UINT64 skipInstrs = 0;
+UINT64 traceInstrs = 1000000;
 
 std::ofstream outfile;
 
@@ -82,7 +84,10 @@ void ResetCurrentInstruction(VOID* ip)
 BOOL ShouldWrite()
 {
   ++instrCount;
-  return (instrCount > KnobSkipInstructions.Value()) && (instrCount <= (KnobTraceInstructions.Value() + KnobSkipInstructions.Value()));
+  if (instrCount > (traceInstrs + skipInstrs)) {
+    PIN_ExitApplication(0);
+  }
+  return (instrCount > skipInstrs) && (instrCount <= (traceInstrs + skipInstrs));
 }
 
 void WriteCurrentInstruction()
@@ -182,6 +187,9 @@ int main(int argc, char* argv[])
     std::cout << "Couldn't open output trace file. Exiting." << std::endl;
     exit(1);
   }
+
+  traceInstrs = KnobTraceInstructions.Value();
+  skipInstrs = KnobSkipInstructions.Value();
 
   // Register function to be called to instrument instructions
   INS_AddInstrumentFunction(Instruction, 0);

--- a/tracer/pin/champsim_tracer.cpp
+++ b/tracer/pin/champsim_tracer.cpp
@@ -77,16 +77,16 @@ INT32 Usage()
 
 void ResetCurrentInstruction(VOID* ip)
 {
+  ++instrCount;
+  if (instrCount > (traceInstrs + skipInstrs)) {
+    PIN_ExitApplication(0);
+  }
   curr_instr = {};
   curr_instr.ip = (unsigned long long int)ip;
 }
 
 BOOL ShouldWrite()
 {
-  ++instrCount;
-  if (instrCount > (traceInstrs + skipInstrs)) {
-    PIN_ExitApplication(0);
-  }
   return (instrCount > skipInstrs) && (instrCount <= (traceInstrs + skipInstrs));
 }
 


### PR DESCRIPTION
Fixes issue #455 . I made the numbers of instructions to trace and skip into globals, filled in main, instead of in the instrumentation. I also made the instruction count volatile. It appears to have rectified the issue.