### PR TITLE
Do not merge requests and responses in completers

### DIFF
--- a/inc/cache.h
+++ b/inc/cache.h
@@ -78,7 +78,7 @@ class CACHE : public champsim::operable
     champsim::chrono::clock::time_point event_cycle = champsim::chrono::clock::time_point::max();
 
     std::vector<uint64_t> instr_depend_on_me{};
-    std::vector<std::deque<response_type>*> to_return{};
+    std::deque<response_type>* to_return{};
 
     explicit tag_lookup_type(request_type req) : tag_lookup_type(req, false, false) {}
     tag_lookup_type(const request_type& req, bool local_pref, bool skip);
@@ -105,11 +105,10 @@ public:
 
     champsim::chrono::clock::time_point time_enqueued;
 
-    std::vector<uint64_t> instr_depend_on_me{};
-    std::vector<std::deque<response_type>*> to_return{};
+    std::vector<tag_lookup_type> reqs;
 
-    fill_type(const tag_lookup_type& req, champsim::chrono::clock::time_point _time_enqueued);
-    static fill_type merge(fill_type predecessor, fill_type successor);
+    fill_type(const tag_lookup_type& req, champsim::chrono::clock::time_point _time_enqueued, std::vector<tag_lookup_type>&& _reqs = {});
+    void insert(const tag_lookup_type& req, champsim::chrono::clock::time_point current_time);
   };
 
 private:

--- a/inc/dram_controller.h
+++ b/inc/dram_controller.h
@@ -96,24 +96,31 @@ struct DRAM_CHANNEL final : public champsim::operable {
   const DRAM_ADDRESS_MAPPING address_mapping;
 
   struct request_type {
-    bool scheduled = false;
-    bool forward_checked = false;
-
-    uint8_t asid[2] = {std::numeric_limits<uint8_t>::max(), std::numeric_limits<uint8_t>::max()};
-
     uint32_t pf_metadata = 0;
 
     champsim::address address{};
     champsim::address v_address{};
     champsim::address data{};
-    champsim::chrono::clock::time_point ready_time = champsim::chrono::clock::time_point::max();
 
     std::vector<uint64_t> instr_depend_on_me{};
-    std::vector<std::deque<response_type>*> to_return{};
-
-    explicit request_type(const typename champsim::channel::request_type& req);
+    std::deque<response_type>* to_return{};
   };
-  using value_type = request_type;
+
+  struct status_type {
+    bool scheduled = false;
+    bool forward_checked = false;
+
+    uint8_t asid[2] = {std::numeric_limits<uint8_t>::max(), std::numeric_limits<uint8_t>::max()};
+
+    champsim::address address{};
+    champsim::address data{};
+    champsim::chrono::clock::time_point ready_time = champsim::chrono::clock::time_point::max();
+
+    std::vector<request_type> reqs{};
+
+    explicit status_type(const typename champsim::channel::request_type& req);
+  };
+  using value_type = status_type;
   using queue_type = std::vector<std::optional<value_type>>;
   queue_type WQ;
   queue_type RQ;

--- a/inc/ptw.h
+++ b/inc/ptw.h
@@ -56,7 +56,7 @@ class PageTableWalker : public champsim::operable
     champsim::waitable<champsim::address> data{};
 
     std::vector<uint64_t> instr_depend_on_me{};
-    std::vector<std::deque<response_type>*> to_return{};
+    std::deque<response_type>* to_return{};
 
     uint32_t pf_metadata = 0;
     uint32_t cpu = std::numeric_limits<uint32_t>::max();

--- a/inc/ptw.h
+++ b/inc/ptw.h
@@ -67,7 +67,7 @@ class PageTableWalker : public champsim::operable
     mshr_type(const request_type& req, std::size_t level);
   };
 
-  std::deque<mshr_type> MSHR;
+  std::vector<mshr_type> MSHR;
   std::deque<mshr_type> finished;
   std::deque<mshr_type> completed;
 

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -636,13 +636,20 @@ void CACHE::finish_translation(const response_type& packet)
 
   // Restart stashed translations
   auto finish_begin = std::find_if_not(std::begin(translation_stash), std::end(translation_stash), [](const auto& x) { return x.is_translated; });
-  auto finish_end = std::stable_partition(finish_begin, std::end(translation_stash), matches_vpage);
-  std::for_each(finish_begin, finish_end, mark_translated);
 
-  // Find all packets that match the page of the returned packet
+  for (auto it = finish_begin; it != std::end(translation_stash); it++) {
+    if (matches_vpage(*it)) {
+      mark_translated(*it);
+      std::swap(*finish_begin, *it);
+      return;
+    }
+  }
+
+  // Find a packet that match the page of the returned packet
   for (auto& entry : inflight_tag_check) {
     if (matches_vpage(entry)) {
       mark_translated(entry);
+      return;
     }
   }
 }

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -98,44 +98,41 @@ CACHE::tag_lookup_type::tag_lookup_type(const request_type& req, bool local_pref
 {
 }
 
-CACHE::fill_type::fill_type(const tag_lookup_type& req, champsim::chrono::clock::time_point _time_enqueued)
+CACHE::fill_type::fill_type(const tag_lookup_type& req, champsim::chrono::clock::time_point _time_enqueued, std::vector<tag_lookup_type>&& _reqs)
     : address(req.address), v_address(req.v_address), ip(req.ip), instr_id(req.instr_id), cpu(req.cpu), type(req.type),
-      prefetch_from_this(req.prefetch_from_this), time_enqueued(_time_enqueued), instr_depend_on_me(req.instr_depend_on_me), to_return(req.to_return)
+      prefetch_from_this(req.prefetch_from_this), time_enqueued(_time_enqueued), reqs(std::move(_reqs))
 {
+  if (req.to_return) {
+    reqs.push_back(req);
+  }
 }
 
-CACHE::fill_type CACHE::fill_type::merge(fill_type predecessor, fill_type successor)
+void CACHE::fill_type::insert(const tag_lookup_type& req, champsim::chrono::clock::time_point current_time)
 {
-  std::vector<uint64_t> merged_instr{};
-  std::vector<std::deque<response_type>*> merged_return{};
-
-  std::set_union(std::begin(predecessor.instr_depend_on_me), std::end(predecessor.instr_depend_on_me), std::begin(successor.instr_depend_on_me),
-                 std::end(successor.instr_depend_on_me), std::back_inserter(merged_instr));
-  std::set_union(std::begin(predecessor.to_return), std::end(predecessor.to_return), std::begin(successor.to_return), std::end(successor.to_return),
-                 std::back_inserter(merged_return));
-
-  fill_type retval{(successor.type == access_type::PREFETCH) ? predecessor : successor};
-
-  // set the time enqueued to the predecessor unless its a demand into prefetch, in which case we use the successor
-  retval.time_enqueued =
-      ((successor.type != access_type::PREFETCH && predecessor.type == access_type::PREFETCH)) ? successor.time_enqueued : predecessor.time_enqueued;
-  retval.instr_depend_on_me = merged_instr;
-  retval.to_return = merged_return;
-  retval.data_promise = predecessor.data_promise;
-
   if constexpr (champsim::debug_print) {
-    if (successor.type == access_type::PREFETCH) {
-      fmt::print("[MSHR] {} address {} type: {} into address {} type: {}\n", __func__, successor.address,
-                 access_type_names.at(champsim::to_underlying(successor.type)), predecessor.address,
-                 access_type_names.at(champsim::to_underlying(successor.type)));
+    if (req.type == access_type::PREFETCH) {
+      fmt::print("[MSHR] {} address {} type: {} into address {} type: {}\n", __func__, req.address, access_type_names.at(champsim::to_underlying(req.type)),
+                 address, access_type_names.at(champsim::to_underlying(req.type)));
     } else {
-      fmt::print("[MSHR] {} address {} type: {} into address {} type: {}\n", __func__, predecessor.address,
-                 access_type_names.at(champsim::to_underlying(predecessor.type)), successor.address,
-                 access_type_names.at(champsim::to_underlying(successor.type)));
+      fmt::print("[MSHR] {} address {} type: {} into address {} type: {}\n", __func__, address, access_type_names.at(champsim::to_underlying(type)),
+                 req.address, access_type_names.at(champsim::to_underlying(req.type)));
     }
   }
 
-  return retval;
+  if (req.type == access_type::PREFETCH) {
+    if (req.to_return) {
+      reqs.push_back(req);
+    }
+  } else {
+    // set the time enqueued to the predecessor unless its a demand into prefetch, in which case we use the successor
+    if (type == access_type::PREFETCH) {
+      time_enqueued = current_time;
+    }
+
+    auto _data_promise = data_promise;
+    *this = {req, time_enqueued, std::move(reqs)};
+    data_promise = _data_promise;
+  }
 }
 
 auto CACHE::fill_block(fill_type fill, uint32_t metadata) -> BLOCK
@@ -236,10 +233,8 @@ bool CACHE::handle_fill(const fill_type& fill)
     sim_stats.total_miss_latency_cycles += (current_time - (fill.time_enqueued + clock_period)) / clock_period;
   sim_stats.fill.increment(std::pair{fill.type, fill.cpu});
 
-  response_type response{fill.address, fill.v_address, fill.data_promise->data, metadata_thru, fill.instr_depend_on_me};
-  for (auto* ret : fill.to_return) {
-    ret->push_back(response);
-  }
+  for (auto req : fill.reqs)
+    req.to_return->emplace_back(req.address, req.v_address, fill.data_promise->data, metadata_thru, req.instr_depend_on_me);
 
   return true;
 }
@@ -273,10 +268,8 @@ bool CACHE::try_hit(const tag_lookup_type& handle_pkt)
   if (hit) {
     sim_stats.hits.increment(std::pair{handle_pkt.type, handle_pkt.cpu});
 
-    response_type response{handle_pkt.address, handle_pkt.v_address, way->data, metadata_thru, handle_pkt.instr_depend_on_me};
-    for (auto* ret : handle_pkt.to_return) {
-      ret->push_back(response);
-    }
+    if (handle_pkt.to_return)
+      handle_pkt.to_return->emplace_back(handle_pkt.address, handle_pkt.v_address, way->data, metadata_thru, handle_pkt.instr_depend_on_me);
 
     way->dirty |= (handle_pkt.type == access_type::WRITE);
 
@@ -322,8 +315,6 @@ bool CACHE::handle_miss(const tag_lookup_type& handle_pkt)
                current_time.time_since_epoch() / clock_period);
   }
 
-  fill_type to_allocate{handle_pkt, current_time};
-
   cpu = handle_pkt.cpu;
 
   auto mshr_pkt = mshr_and_forward_packet(handle_pkt);
@@ -347,9 +338,9 @@ bool CACHE::handle_miss(const tag_lookup_type& handle_pkt)
     }
 
     // COLLECT STATS
-    sim_stats.miss_merge.increment(std::pair{to_allocate.type, to_allocate.cpu});
+    sim_stats.miss_merge.increment(std::pair{handle_pkt.type, handle_pkt.cpu});
 
-    *fill_entry = fill_type::merge(*fill_entry, to_allocate);
+    fill_entry->insert(handle_pkt, current_time);
   } else {
     if (mshr_full) { // not enough MSHR resource
       return false;  // TODO should we allow prefetches anyway if they will not be filled to this level?
@@ -399,7 +390,7 @@ auto CACHE::initiate_tag_check(champsim::channel* ul)
 
     if constexpr (UpdateRequest) {
       if (entry.response_requested) {
-        retval.to_return = {&ul->returned};
+        retval.to_return = &ul->returned;
       }
     } else {
       (void)ul; // supress warning about ul being unused
@@ -407,7 +398,7 @@ auto CACHE::initiate_tag_check(champsim::channel* ul)
 
     if constexpr (champsim::debug_print) {
       fmt::print("[TAG] initiate_tag_check instr_id: {} address: {} v_address: {} type: {} response_requested: {}\n", retval.instr_id, retval.address,
-                 retval.v_address, access_type_names.at(champsim::to_underlying(retval.type)), !std::empty(retval.to_return));
+                 retval.v_address, access_type_names.at(champsim::to_underlying(retval.type)), !!retval.to_return);
     }
 
     return retval;

--- a/src/dram_controller.cc
+++ b/src/dram_controller.cc
@@ -111,9 +111,8 @@ long DRAM_CHANNEL::operate()
   if (warmup) {
     for (auto& entry : RQ) {
       if (entry.has_value()) {
-        response_type response{entry->address, entry->v_address, entry->data, entry->pf_metadata, entry->instr_depend_on_me};
-        for (auto* ret : entry.value().to_return) {
-          ret->push_back(response);
+        for (auto& req : entry.value().reqs) {
+          req.to_return->emplace_back(req.address, req.v_address, req.data, req.pf_metadata, req.instr_depend_on_me);
         }
 
         ++progress;
@@ -145,10 +144,8 @@ long DRAM_CHANNEL::finish_dbus_request()
   long progress{0};
 
   if (active_request != std::end(bank_request) && active_request->ready_time <= current_time) {
-    response_type response{active_request->pkt->value().address, active_request->pkt->value().v_address, active_request->pkt->value().data,
-                           active_request->pkt->value().pf_metadata, active_request->pkt->value().instr_depend_on_me};
-    for (auto* ret : active_request->pkt->value().to_return) {
-      ret->push_back(response);
+    for (auto& req : active_request->pkt->value().reqs) {
+      req.to_return->emplace_back(req.address, req.v_address, req.data, req.pf_metadata, req.instr_depend_on_me);
     }
 
     active_request->valid = false;
@@ -452,10 +449,8 @@ void DRAM_CHANNEL::check_read_collision()
       };
       // write forward
       if (auto wq_it = std::find_if(std::begin(WQ), std::end(WQ), checker); wq_it != std::end(WQ)) {
-        response_type response{rq_it->value().address, rq_it->value().v_address, wq_it->value().data, rq_it->value().pf_metadata,
-                               rq_it->value().instr_depend_on_me};
-        for (auto* ret : rq_it->value().to_return) {
-          ret->push_back(response);
+        for (auto& req : rq_it->value().reqs) {
+          req.to_return->emplace_back(req.address, req.v_address, wq_it->value().data, req.pf_metadata, req.instr_depend_on_me);
         }
 
         rq_it->reset();
@@ -463,27 +458,15 @@ void DRAM_CHANNEL::check_read_collision()
       }
       // backwards check
       else if (auto found = std::find_if(std::begin(RQ), rq_it, checker); found != rq_it) {
-        auto instr_copy = std::move(found->value().instr_depend_on_me);
-        auto ret_copy = std::move(found->value().to_return);
-
-        std::set_union(std::begin(instr_copy), std::end(instr_copy), std::begin(rq_it->value().instr_depend_on_me), std::end(rq_it->value().instr_depend_on_me),
-                       std::back_inserter(found->value().instr_depend_on_me));
-        std::set_union(std::begin(ret_copy), std::end(ret_copy), std::begin(rq_it->value().to_return), std::end(rq_it->value().to_return),
-                       std::back_inserter(found->value().to_return));
-
+        found->value().reqs.insert(std::end(found->value().reqs), std::make_move_iterator(std::begin(rq_it->value().reqs)),
+                                   std::make_move_iterator(std::end(rq_it->value().reqs)));
         rq_it->reset();
 
       }
       // forwards check
       else if (found = std::find_if(std::next(rq_it), std::end(RQ), checker); found != std::end(RQ)) {
-        auto instr_copy = std::move(found->value().instr_depend_on_me);
-        auto ret_copy = std::move(found->value().to_return);
-
-        std::set_union(std::begin(instr_copy), std::end(instr_copy), std::begin(rq_it->value().instr_depend_on_me), std::end(rq_it->value().instr_depend_on_me),
-                       std::back_inserter(found->value().instr_depend_on_me));
-        std::set_union(std::begin(ret_copy), std::end(ret_copy), std::begin(rq_it->value().to_return), std::end(rq_it->value().to_return),
-                       std::back_inserter(found->value().to_return));
-
+        found->value().reqs.insert(std::end(found->value().reqs), std::make_move_iterator(std::begin(rq_it->value().reqs)),
+                                   std::make_move_iterator(std::end(rq_it->value().reqs)));
         rq_it->reset();
       } else {
         rq_it->value().forward_checked = true;
@@ -497,18 +480,17 @@ void MEMORY_CONTROLLER::initiate_requests()
   // Initiate read requests
   for (auto* ul : queues) {
     for (auto q : {std::ref(ul->RQ), std::ref(ul->PQ)}) {
-      auto [begin, end] = champsim::get_span_p(std::cbegin(q.get()), std::cend(q.get()), [ul, this](const auto& pkt) { return this->add_rq(pkt, ul); });
+      auto [begin, end] = champsim::get_span_p(std::begin(q.get()), std::end(q.get()), [ul, this](auto& pkt) { return this->add_rq(pkt, ul); });
       q.get().erase(begin, end);
     }
 
     // Initiate write requests
-    auto [wq_begin, wq_end] = champsim::get_span_p(std::cbegin(ul->WQ), std::cend(ul->WQ), [this](const auto& pkt) { return this->add_wq(pkt); });
+    auto [wq_begin, wq_end] = champsim::get_span_p(std::begin(ul->WQ), std::end(ul->WQ), [this](auto& pkt) { return this->add_wq(pkt); });
     ul->WQ.erase(wq_begin, wq_end);
   }
 }
 
-DRAM_CHANNEL::request_type::request_type(const typename champsim::channel::request_type& req)
-    : pf_metadata(req.pf_metadata), address(req.address), v_address(req.address), data(req.data), instr_depend_on_me(req.instr_depend_on_me)
+DRAM_CHANNEL::status_type::status_type(const typename champsim::channel::request_type& req) : address(req.address), data(req.data)
 {
   asid[0] = req.asid[0];
   asid[1] = req.asid[1];
@@ -520,12 +502,12 @@ bool MEMORY_CONTROLLER::add_rq(const request_type& packet, champsim::channel* ul
 
   if (auto rq_it = std::find_if_not(std::begin(channel.RQ), std::end(channel.RQ), [this](const auto& pkt) { return pkt.has_value(); });
       rq_it != std::end(channel.RQ)) {
-    *rq_it = DRAM_CHANNEL::request_type{packet};
+    *rq_it = DRAM_CHANNEL::status_type{packet};
     rq_it->value().forward_checked = false;
     rq_it->value().scheduled = false;
     rq_it->value().ready_time = current_time;
     if (packet.response_requested)
-      rq_it->value().to_return = {&ul->returned};
+      rq_it->value().reqs.push_back({packet.pf_metadata, packet.address, packet.v_address, packet.data, packet.instr_depend_on_me, &ul->returned});
 
     return true;
   }
@@ -540,7 +522,7 @@ bool MEMORY_CONTROLLER::add_wq(const request_type& packet)
   // search for the empty index
   if (auto wq_it = std::find_if_not(std::begin(channel.WQ), std::end(channel.WQ), [](const auto& pkt) { return pkt.has_value(); });
       wq_it != std::end(channel.WQ)) {
-    *wq_it = DRAM_CHANNEL::request_type{packet};
+    *wq_it = DRAM_CHANNEL::status_type{packet};
     wq_it->value().forward_checked = false;
     wq_it->value().scheduled = false;
     wq_it->value().ready_time = current_time;

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -676,6 +676,7 @@ long O3_CPU::handle_memory_return()
         lq_entry->finish(std::begin(ROB), std::end(ROB));
         lq_entry.reset();
         ++progress;
+        break;
       }
     }
     ++progress;

--- a/src/ptw.cc
+++ b/src/ptw.cc
@@ -212,14 +212,22 @@ void PageTableWalker::finish_packet(const response_type& packet)
   auto is_last_step = [](auto x) {
     return x.translation_level <= 0;
   };
-  auto last_finished = std::partition(std::begin(MSHR), std::end(MSHR), matches_addr);
 
-  std::for_each(std::begin(MSHR), last_finished, [is_last_step, finish_step, finish_last_step](auto& mshr_entry) {
-    mshr_entry.data = is_last_step(mshr_entry) ? finish_last_step(mshr_entry) : finish_step(mshr_entry);
-  });
+  for (auto& mshr_entry : MSHR) {
+    if (matches_addr(mshr_entry)) {
+      if (is_last_step(mshr_entry)) {
+        mshr_entry.data = finish_last_step(mshr_entry);
+        completed.push_back(std::move(mshr_entry));
+      } else {
+        mshr_entry.data = finish_step(mshr_entry);
+        finished.push_back(std::move(mshr_entry));
+      }
 
-  std::partition_copy(std::begin(MSHR), last_finished, std::back_inserter(completed), std::back_inserter(finished), is_last_step);
-  MSHR.erase(std::begin(MSHR), last_finished);
+      mshr_entry = std::move(MSHR.back());
+      MSHR.pop_back();
+      break;
+    }
+  }
 }
 
 void PageTableWalker::begin_phase()

--- a/src/ptw.cc
+++ b/src/ptw.cc
@@ -69,7 +69,7 @@ auto PageTableWalker::handle_read(const request_type& handle_pkt, channel_type* 
   fwd_mshr.address = champsim::address{champsim::splice(champsim::page_number{walk_init.ptw_addr}, champsim::page_offset{walk_offset})};
   fwd_mshr.v_address = handle_pkt.address;
   if (handle_pkt.response_requested) {
-    fwd_mshr.to_return = {&ul->returned};
+    fwd_mshr.to_return = &ul->returned;
   }
 
   if constexpr (champsim::debug_print) {
@@ -135,8 +135,8 @@ long PageTableWalker::operate()
   champsim::bandwidth fill_bw{MAX_FILL};
   auto [complete_begin, complete_end] = champsim::get_span_p(std::cbegin(completed), std::cend(completed), fill_bw, is_ready);
   std::for_each(complete_begin, complete_end, [](auto& mshr_entry) {
-    for (auto ret : mshr_entry.to_return) {
-      ret->emplace_back(mshr_entry.v_address, mshr_entry.v_address, *mshr_entry.data, mshr_entry.pf_metadata, mshr_entry.instr_depend_on_me);
+    if (mshr_entry.to_return) {
+      mshr_entry.to_return->emplace_back(mshr_entry.v_address, mshr_entry.v_address, *mshr_entry.data, mshr_entry.pf_metadata, mshr_entry.instr_depend_on_me);
     }
   });
   fill_bw.consume(std::distance(complete_begin, complete_end));

--- a/test/cpp/src/431-merge-prefetch.cc
+++ b/test/cpp/src/431-merge-prefetch.cc
@@ -64,7 +64,7 @@ SCENARIO("A prefetch that hits an MSHR is dropped")
     {
       REQUIRE_THAT(testbed.uut.MSHR, Catch::Matchers::SizeIs(1));
       CHECK(testbed.uut.MSHR.front().instr_id == 0);
-      CHECK_THAT(testbed.uut.MSHR.front().to_return, Catch::Matchers::SizeIs(1));
+      CHECK_THAT(testbed.uut.MSHR.front().reqs, Catch::Matchers::SizeIs(1));
     }
 
     WHEN("A prefetch is issued")
@@ -75,7 +75,7 @@ SCENARIO("A prefetch that hits an MSHR is dropped")
       {
         REQUIRE_THAT(testbed.uut.MSHR, Catch::Matchers::SizeIs(1));
         CHECK(testbed.uut.MSHR.front().instr_id == 0);
-        CHECK_THAT(testbed.uut.MSHR.front().to_return, Catch::Matchers::SizeIs(2));
+        CHECK_THAT(testbed.uut.MSHR.front().reqs, Catch::Matchers::SizeIs(2));
       }
     }
   }
@@ -95,7 +95,7 @@ SCENARIO("A prefetch MSHR that gets hit is promoted")
     {
       REQUIRE_THAT(testbed.uut.MSHR, Catch::Matchers::SizeIs(1));
       CHECK(testbed.uut.MSHR.front().instr_id == 0);
-      CHECK_THAT(testbed.uut.MSHR.front().to_return, Catch::Matchers::SizeIs(1));
+      CHECK_THAT(testbed.uut.MSHR.front().reqs, Catch::Matchers::SizeIs(1));
     }
 
     WHEN("A " + std::string{str} + " is issued")
@@ -109,13 +109,13 @@ SCENARIO("A prefetch MSHR that gets hit is promoted")
         REQUIRE_THAT(testbed.uut.MSHR, Catch::Matchers::SizeIs(1));
         CHECK(testbed.uut.MSHR.front().time_enqueued > old_time_enqueued);
         // CHECK(testbed.uut.MSHR.front().instr_id == 1);
-        CHECK_THAT(testbed.uut.MSHR.front().to_return, Catch::Matchers::SizeIs(2));
+        CHECK_THAT(testbed.uut.MSHR.front().reqs, Catch::Matchers::SizeIs(2));
       }
 
       AND_WHEN("The MSHR is closed")
       {
         champsim::channel::response_type response{testbed.uut.MSHR.front().address, testbed.uut.MSHR.front().v_address,
-                                                  testbed.uut.MSHR.front().data_promise->data, 0, testbed.uut.MSHR.front().instr_depend_on_me};
+                                                  testbed.uut.MSHR.front().data_promise->data, 0, testbed.uut.MSHR.front().reqs.front().instr_depend_on_me};
 
         testbed.uut.lower_level->returned.push_back(response);
         for (uint64_t i = 0; i < 8 * (testbed.hit_latency); ++i)

--- a/test/cpp/src/701-dram-scheduler.cc
+++ b/test/cpp/src/701-dram-scheduler.cc
@@ -15,7 +15,7 @@ std::vector<uint64_t> dram_test(MEMORY_CONTROLLER* uut, std::vector<champsim::ch
   // load requests into controller
   std::transform(std::cbegin(*packet_stream), std::cend(*packet_stream), std::cbegin(*arriv_time), ins_begin,
                  [period = uut->clock_period, start_time](auto pkt, uint64_t cycle) {
-                   auto r_pkt = DRAM_CHANNEL::request_type{pkt};
+                   auto r_pkt = DRAM_CHANNEL::status_type{pkt};
                    r_pkt.forward_checked = false;
                    r_pkt.scheduled = false;
                    r_pkt.ready_time = start_time + cycle * period;


### PR DESCRIPTION
This is a follow-up of #618.

Traditionally, ChampSim had several mechanisms to merge memory transactions. This duplication of merging operations makes it complicated to instrument for Kanata, an instruction pipeline visualizer (please also see https://github.com/ChampSim/ChampSim/pull/594). Even without Kanata, it adds extra code complexity and hurts simulation accuracy because the cost of duplicate merging operations are not accounted.

A path of memory transaction in ChampSim can be understood as it consists of the following:
1. Requester
2. Channel
3. Completer

#618 removed duplicate merging operations in channel (2). This pull request removes merging operations in completers (3). In other words, this pull request ensures that the requester always sees one response for each request it makes, just as a real hardware protocol like AXI do.

With this change, merging will only happen at the requester. More concretely, `O3_CPU` fetches multiple instructions with one request. `CACHE` allocates an MSHR for multiple upstream requests with overlapping addresses and issues one corresponding request to the downstream.

As I have done in #618, I evaluated the changes with the DPC-3 traces:
https://github.dev/akihikodaki/e/blob/fd8e72e83fa95aa41e308de2d7c4e0b148478778/stats.ipynb
The "timeline" column at the bottom left allows you to compare commits.

Notably, commit d048f26505127f379174e487e6f8b7ebe3430483 dramatically reduced the IPC by about 4 %. This is because the bandwidth consumption for responses that used to be merged is now properly modeled.