### PR TITLE
Reverse the order after building in `generate_environment.cc`

### DIFF
--- a/src/generated_environment.cc
+++ b/src/generated_environment.cc
@@ -20,6 +20,7 @@ auto build(PTWs... builders)
 {
   std::forward_list<R> retval{};
   (..., retval.emplace_front(builders));
+  retval.reverse();
   return retval;
 }
 } // namespace champsim::configured


### PR DESCRIPTION
This fixes were the caches and PTW are built in the reversed direction addressed in #683 .