### PR TITLE
make dib_inorder_width and dib_hit_buffer_size configurable

### DIFF
--- a/config/instantiation_file.py
+++ b/config/instantiation_file.py
@@ -51,6 +51,8 @@ core_builder_parts = {
     'dib_set': '  .dib_set({dib_set})',
     'dib_way': '  .dib_way({dib_way})',
     'dib_window': '  .dib_window({dib_window})',
+    'dib_inorder_width': '  .dib_inorder_width(champsim::bandwidth::maximum_type{{{inorder_width}}})',
+    'dib_hit_buffer_size': '  .dib_hit_buffer_size({DIB[inorder_width]})',
     'L1I': ['.l1i(&{^l1i_ptr})', '.l1i_bandwidth({^l1i_ptr}.MAX_TAG)', '.fetch_queues(&{^fetch_queues})'],
     'L1D': ['.l1d_bandwidth({^l1d_ptr}.MAX_TAG)', '.data_queues(&{^data_queues})'],
     '_branch_predictor_data': '.branch_predictor<{^branch_predictor_string}>()',
@@ -62,7 +64,9 @@ core_builder_parts = {
 dib_builder_parts = {
     'sets': '  .dib_set({DIB[sets]})',
     'ways': '  .dib_way({DIB[ways]})',
-    'window_size': '  .dib_window({DIB[window_size]})'
+    'window_size': '  .dib_window({DIB[window_size]})',
+    'inorder_width': '  .dib_inorder_width(champsim::bandwidth::maximum_type{{{DIB[inorder_width]}}})',
+    'hit_buffer_size': '  .dib_hit_buffer_size({DIB[inorder_width]})',
 }
 
 cache_builder_parts = {

--- a/inc/defaults.hpp
+++ b/inc/defaults.hpp
@@ -35,7 +35,7 @@ const auto default_core =
         .ifetch_buffer_size(64)
         .decode_buffer_size(32)
         .dispatch_buffer_size(32)
-        .dib_hit_buffer_size(32) // assumed
+        .dib_hit_buffer_size(32)
         .register_file_size(128)
         .rob_size(352)
         .lq_size(128)
@@ -47,7 +47,7 @@ const auto default_core =
         .lq_width(champsim::bandwidth::maximum_type{2})
         .sq_width(champsim::bandwidth::maximum_type{2})
         .retire_width(champsim::bandwidth::maximum_type{5})
-        .dib_inorder_width(champsim::bandwidth::maximum_type{5}) // assumed
+        .dib_inorder_width(champsim::bandwidth::maximum_type{5})
         .mispredict_penalty(1)
         .schedule_width(champsim::bandwidth::maximum_type{128})
         .decode_latency(1)


### PR DESCRIPTION
Make `dib_inorder_width` and `dib_hit_buffer_size` configurable with the config.json.

I was trying to configure champsim to get an unrealistically high IPC just to confirm that there aren't missing pieces in my understanding of how everything works and found I couldn't make IPC above 5. I believe the culprit is these configuration values being hard-coded.