### PR TITLE
Ship tag check fix

### DIFF
--- a/replacement/ship/ship.cc
+++ b/replacement/ship/ship.cc
@@ -49,7 +49,7 @@ void ship::update_replacement_state(uint32_t triggering_cpu, long set, long way,
 
     // check hit
     auto match = std::find_if(s_set_begin, s_set_end,
-                              [addr = full_addr, shamt = champsim::data::bits{champsim::lg2(champsim::msl::get_num_samples(NUM_SET)) + champsim::lg2(NUM_WAY)}](
+                              [addr = full_addr, shamt = champsim::data::bits{champsim::lg2(champsim::msl::get_num_samples(NUM_SET))}](
                                   auto x) { return x.valid && x.address.slice_upper(shamt) == addr.slice_upper(shamt); });
     if (match != s_set_end) {
       auto SHCT_idx = match->ip.slice_lower<32_b>().to<std::size_t>() % SHCT_PRIME;

--- a/replacement/ship/ship.cc
+++ b/replacement/ship/ship.cc
@@ -10,7 +10,8 @@
 ship::ship(CACHE* cache)
     : replacement(cache), NUM_SET(cache->NUM_SET), NUM_WAY(cache->NUM_WAY),
       sampler(champsim::msl::get_num_samples(NUM_SET) * NUM_CPUS * static_cast<std::size_t>(NUM_WAY)),
-      rrpv_values(static_cast<std::size_t>(NUM_SET * NUM_WAY), maxRRPV), set_categorizer(champsim::msl::get_sample_rate(NUM_SET))
+      rrpv_values(static_cast<std::size_t>(NUM_SET * NUM_WAY), maxRRPV), set_categorizer(champsim::msl::get_sample_rate(NUM_SET)),
+      sampler_tag_bits(cache->OFFSET_BITS)
 {
   std::generate_n(std::back_inserter(SHCT), NUM_CPUS, []() -> typename decltype(SHCT)::value_type { return {}; });
 }
@@ -48,8 +49,9 @@ void ship::update_replacement_state(uint32_t triggering_cpu, long set, long way,
     auto s_set_end = std::next(s_set_begin, NUM_WAY);
 
     // check hit
-    auto match = std::find_if(s_set_begin, s_set_end,
-                              [addr = champsim::block_number{full_addr}](auto x) { return x.valid && champsim::block_number{x.address} == addr; });
+    auto match = std::find_if(s_set_begin, s_set_end, [addr = full_addr, shamt = sampler_tag_bits](auto x) {
+      return x.valid && x.address.slice_upper(shamt) == addr.slice_upper(shamt);
+    });
     if (match != s_set_end) {
       auto SHCT_idx = match->ip.slice_lower<32_b>().to<std::size_t>() % SHCT_PRIME;
       SHCT[triggering_cpu][SHCT_idx] -= 1;

--- a/replacement/ship/ship.cc
+++ b/replacement/ship/ship.cc
@@ -49,8 +49,7 @@ void ship::update_replacement_state(uint32_t triggering_cpu, long set, long way,
 
     // check hit
     auto match = std::find_if(s_set_begin, s_set_end,
-                              [addr = full_addr, shamt = champsim::data::bits{champsim::lg2(champsim::msl::get_num_samples(NUM_SET))}](
-                                  auto x) { return x.valid && x.address.slice_upper(shamt) == addr.slice_upper(shamt); });
+                              [addr = champsim::block_number{full_addr}](auto x) { return x.valid && champsim::block_number{x.address} == addr; });
     if (match != s_set_end) {
       auto SHCT_idx = match->ip.slice_lower<32_b>().to<std::size_t>() % SHCT_PRIME;
       SHCT[triggering_cpu][SHCT_idx] -= 1;

--- a/replacement/ship/ship.h
+++ b/replacement/ship/ship.h
@@ -36,8 +36,8 @@ public:
   // sampler
   std::vector<SAMPLER_class> sampler;
   std::vector<int> rrpv_values;
-
   champsim::msl::categorizer<long> set_categorizer;
+  champsim::data::bits sampler_tag_bits;
 
   // prediction table structure
   std::vector<std::array<champsim::msl::fwcounter<champsim::msl::lg2(SHCT_MAX + 1)>, SHCT_SIZE>> SHCT;

--- a/test/cpp/src/445-ship-replacement.cc
+++ b/test/cpp/src/445-ship-replacement.cc
@@ -6,16 +6,20 @@
 TEST_CASE("SHIP sampler matches at cache block granularity")
 {
   /*
-   * The SHIP sampler compares addresses using champsim::block_number so that
+   * The SHIP sampler compares addresses at cache block granularity so that
    * two addresses in the same cache block are treated as the same entry.
    *
-   * With BLOCK_SIZE=64 (LOG2_BLOCK_SIZE=6):
+   * With BLOCK_SIZE=64 (OFFSET_BITS=6):
    *   block_number{address{0}}  == block_number{address{32}}  (same block)
-   *   block_number{address{0}}  != block_number{address{64}}  (different blocks)
+   *   block_number{address{0}}  != block_number{address{512}} (different blocks)
    *
-   * A buggy implementation that uses a shamt based on the sampler size could
-   * draw false distinctions within the same block, treating two accesses to
-   * the same cache line as different entries.
+   * Observable behavior through the function interface:
+   *   - Same-block accesses produce sampler hits, decrementing SHCT. When SHCT
+   *     is below its maximum, replacement_cache_fill assigns rrpv = maxRRPV - 1.
+   *   - Different-block accesses produce sampler misses. When an unused sampler
+   *     entry is evicted, SHCT is incremented. When SHCT reaches its maximum,
+   *     replacement_cache_fill assigns rrpv = maxRRPV, making the line the
+   *     preferred eviction victim in find_victim.
    */
   CACHE cache{champsim::cache_builder{champsim::defaults::default_l1d}
                   .name("445-ship-tag-test")
@@ -28,42 +32,70 @@ TEST_CASE("SHIP sampler matches at cache block granularity")
   REQUIRE(model != nullptr);
   auto& uut = std::get<ship>(model->intern_);
 
-  REQUIRE(uut.NUM_SET == 8);
-  REQUIRE(uut.NUM_WAY == 8);
-  REQUIRE(uut.sampler_tag_bits == champsim::data::bits{6}); // shamt should be equal to OFFSET_BITS
+  champsim::address test_ip{100};
+  champsim::address baseline_ip{200};
 
-  champsim::address ip{100};
-  auto SHCT_idx = ip.slice_lower<champsim::data::bits{32}>().to<std::size_t>() % ship::SHCT_PRIME;
+  // Set 0 is a sampled set (category 0 with 8 sets, sample_rate=4).
+  // Set 1 is not sampled, used for observing RRPV effects via find_victim.
+  constexpr long sampler_set = 0;
+  constexpr long observe_set = 1;
 
   SECTION("Same-block addresses are recognized as a sampler hit")
   {
-    // Addresses 0 and 32 are both within cache block 0 (BLOCK_SIZE=64)
+    // Push SHCT for test_ip to its maximum via many distinct-block accesses.
+    // With 8 sampler ways, the first 8 accesses fill the sampler; subsequent
+    // accesses evict unused entries (ip=test_ip), incrementing SHCT each time.
+    for (int i = 0; i < 15; ++i) {
+      champsim::address addr{static_cast<uint64_t>(i * 512)};
+      uut.update_replacement_state(0, sampler_set, 0, addr, test_ip, champsim::address{}, access_type::LOAD, 0);
+    }
+
+    // Access addr 0: sampler miss (block 0 was evicted from sampler during pumping)
     champsim::address addr1{0};
+    uut.update_replacement_state(0, sampler_set, 0, addr1, test_ip, champsim::address{}, access_type::LOAD, 0);
+
+    // Access addr 32 (same cache block as addr 0, BLOCK_SIZE=64):
+    // Correct implementation recognizes this as a sampler HIT → SHCT decremented below max.
+    // A buggy shamt would treat it as a different entry (miss) → SHCT stays at max.
     champsim::address addr2{32};
-    // First access: sampler miss, stores entry for block 0
-    uut.update_replacement_state(0, 0, 0, addr1, ip, champsim::address{}, access_type::LOAD, 0);
+    uut.update_replacement_state(0, sampler_set, 0, addr2, test_ip, champsim::address{}, access_type::LOAD, 0);
 
-    // Second access: same block → sampler HIT → SHCT decremented (clamped at 0)
-    uut.update_replacement_state(0, 0, 1, addr2, ip, champsim::address{}, access_type::LOAD, 0);
+    // Fill all ways of the observation set:
+    // ways 0-6 with baseline_ip (SHCT=0 → rrpv = maxRRPV - 1)
+    // way 7 with test_ip
+    for (long w = 0; w < 7; ++w)
+      uut.replacement_cache_fill(0, observe_set, w, champsim::address{static_cast<uint64_t>((w + 1) * 0x1000)},
+                                 baseline_ip, champsim::address{}, access_type::LOAD);
+    uut.replacement_cache_fill(0, observe_set, 7, champsim::address{0x8000},
+                               test_ip, champsim::address{}, access_type::LOAD);
 
-    // Sampler hit: SHCT was 0, decremented → clamped to 0
-    // A buggy shamt would treat these as different → sampler miss → SHCT incremented to 1
-    CHECK(uut.SHCT[0][SHCT_idx].value() == 0);
+    // With SHCT below max (correct impl), way 7 gets the same rrpv as baseline ways.
+    // find_victim should NOT preferentially select way 7.
+    auto victim = uut.find_victim(0, 0, observe_set, nullptr, test_ip, champsim::address{}, access_type::LOAD);
+    CHECK(victim != 7);
   }
 
   SECTION("Different-block addresses are recognized as a sampler miss")
   {
-    // Addresses 0 and 64 are in different cache blocks (block 0 vs block 1)
-    champsim::address addr1{0};
-    champsim::address addr2{64*8}; // ensure different block even with a buggy shamt of 6 (64 entries per block)
+    // Access 15 distinct blocks: each unique block beyond the sampler capacity (8)
+    // evicts an unused entry, incrementing SHCT. After enough evictions SHCT reaches max.
+    for (int i = 0; i < 15; ++i) {
+      champsim::address addr{static_cast<uint64_t>(i * 512)};
+      uut.update_replacement_state(0, sampler_set, 0, addr, test_ip, champsim::address{}, access_type::LOAD, 0);
+    }
 
-    // First access: sampler miss, stores entry for block 0
-    uut.update_replacement_state(0, 0, 0, addr1, ip, champsim::address{}, access_type::LOAD, 0);
+    // Fill all ways of the observation set:
+    // ways 0-6 with baseline_ip (SHCT=0 → rrpv = maxRRPV - 1)
+    // way 7 with test_ip (SHCT at max → rrpv = maxRRPV)
+    for (long w = 0; w < 7; ++w)
+      uut.replacement_cache_fill(0, observe_set, w, champsim::address{static_cast<uint64_t>((w + 1) * 0x1000)},
+                                 baseline_ip, champsim::address{}, access_type::LOAD);
+    uut.replacement_cache_fill(0, observe_set, 7, champsim::address{0x8000},
+                               test_ip, champsim::address{}, access_type::LOAD);
 
-    // Second access: different block → sampler MISS → evicts old entry (used=false) → SHCT++
-    uut.update_replacement_state(0, 0, 1, addr2, ip, champsim::address{}, access_type::LOAD, 0);
-
-    // Sampler miss: old entry (block 0, used=false) evicted → SHCT incremented to 1
-    CHECK(uut.SHCT[0][SHCT_idx].value() == 1);
+    // With SHCT at max, way 7 gets rrpv = maxRRPV (higher than baseline ways).
+    // find_victim should select way 7 as the preferred eviction victim.
+    auto victim = uut.find_victim(0, 0, observe_set, nullptr, test_ip, champsim::address{}, access_type::LOAD);
+    CHECK(victim == 7);
   }
 }

--- a/test/cpp/src/445-ship-replacement.cc
+++ b/test/cpp/src/445-ship-replacement.cc
@@ -17,11 +17,11 @@ TEST_CASE("SHIP sampler matches at cache block granularity")
    * draw false distinctions within the same block, treating two accesses to
    * the same cache line as different entries.
    */
-
   CACHE cache{champsim::cache_builder{champsim::defaults::default_l1d}
                   .name("445-ship-tag-test")
                   .sets(8)
                   .ways(8)
+                  .offset_bits(champsim::data::bits{6}) // BLOCK_SIZE=64 → OFFSET_BITS=6
                   .replacement<ship>()};
 
   auto* model = dynamic_cast<CACHE::replacement_module_model<ship>*>(cache.repl_module_pimpl.get());
@@ -30,6 +30,7 @@ TEST_CASE("SHIP sampler matches at cache block granularity")
 
   REQUIRE(uut.NUM_SET == 8);
   REQUIRE(uut.NUM_WAY == 8);
+  REQUIRE(uut.sampler_tag_bits == champsim::data::bits{6}); // shamt should be equal to OFFSET_BITS
 
   champsim::address ip{100};
   auto SHCT_idx = ip.slice_lower<champsim::data::bits{32}>().to<std::size_t>() % ship::SHCT_PRIME;
@@ -39,12 +40,11 @@ TEST_CASE("SHIP sampler matches at cache block granularity")
     // Addresses 0 and 32 are both within cache block 0 (BLOCK_SIZE=64)
     champsim::address addr1{0};
     champsim::address addr2{32};
-
     // First access: sampler miss, stores entry for block 0
     uut.update_replacement_state(0, 0, 0, addr1, ip, champsim::address{}, access_type::LOAD, 0);
 
     // Second access: same block → sampler HIT → SHCT decremented (clamped at 0)
-    uut.update_replacement_state(0, 0, 0, addr2, ip, champsim::address{}, access_type::LOAD, 0);
+    uut.update_replacement_state(0, 0, 1, addr2, ip, champsim::address{}, access_type::LOAD, 0);
 
     // Sampler hit: SHCT was 0, decremented → clamped to 0
     // A buggy shamt would treat these as different → sampler miss → SHCT incremented to 1
@@ -55,13 +55,13 @@ TEST_CASE("SHIP sampler matches at cache block granularity")
   {
     // Addresses 0 and 64 are in different cache blocks (block 0 vs block 1)
     champsim::address addr1{0};
-    champsim::address addr2{64};
+    champsim::address addr2{64*8}; // ensure different block even with a buggy shamt of 6 (64 entries per block)
 
     // First access: sampler miss, stores entry for block 0
     uut.update_replacement_state(0, 0, 0, addr1, ip, champsim::address{}, access_type::LOAD, 0);
 
     // Second access: different block → sampler MISS → evicts old entry (used=false) → SHCT++
-    uut.update_replacement_state(0, 0, 0, addr2, ip, champsim::address{}, access_type::LOAD, 0);
+    uut.update_replacement_state(0, 0, 1, addr2, ip, champsim::address{}, access_type::LOAD, 0);
 
     // Sampler miss: old entry (block 0, used=false) evicted → SHCT incremented to 1
     CHECK(uut.SHCT[0][SHCT_idx].value() == 1);

--- a/test/cpp/src/445-ship-sampler-tag.cc
+++ b/test/cpp/src/445-ship-sampler-tag.cc
@@ -4,72 +4,74 @@
 #include "defaults.hpp"
 #include "mocks.hpp"
 
-TEST_CASE("SHIP sampler correctly distinguishes addresses that differ only in low tag bits")
+TEST_CASE("SHIP sampler matches at cache block granularity")
 {
   /*
-   * The SHIP sampler compares addresses by slicing off the lower bits used
-   * to index into the sampler. The shift amount (shamt) should be based only
-   * on the number of sampler sets (lg2(num_samples)), not also on lg2(NUM_WAY).
+   * The SHIP sampler compares addresses using champsim::block_number so that
+   * two addresses in the same cache block are treated as the same entry.
    *
-   * With NUM_SET=8, NUM_WAY=8, OFFSET_BITS=0:
-   *   sample_rate = 4, num_samples = 2
-   *   Correct shamt = lg2(2) = 1
-   *   Buggy shamt   = lg2(2) + lg2(8) = 4   (would mask low tag bits)
+   * With BLOCK_SIZE=64 (LOG2_BLOCK_SIZE=6):
+   *   block_number{address{0}}  == block_number{address{32}}  (same block)
+   *   block_number{address{0}}  != block_number{address{64}}  (different blocks)
    *
-   * Addresses 0 and 8 are both in cache set 0 (8 % 8 == 0) with different tags.
-   * With a buggy shamt of 4: (0 >> 4) == (8 >> 4) == 0, causing a false match.
-   * With the correct shamt of 1: (0 >> 1) == 0 != 4 == (8 >> 1), correctly no match.
+   * A buggy implementation that uses a shamt based on the sampler size could
+   * draw false distinctions within the same block, treating two accesses to
+   * the same cache line as different entries.
    */
 
   do_nothing_MRC mock_ll;
   to_rq_MRP mock_ul;
 
-  // Create a cache with NUM_SET=8, NUM_WAY=8, OFFSET_BITS=0
-  // The SHIP instance reads NUM_SET and NUM_WAY from the cache pointer.
   CACHE cache{champsim::cache_builder{champsim::defaults::default_l1d}
                   .name("445-ship-tag-test")
                   .sets(8)
                   .ways(8)
                   .upper_levels({&mock_ul.queues})
                   .lower_level(&mock_ll.queues)
-                  .offset_bits(champsim::data::bits{})
                   .replacement<lru>()};
 
   cache.initialize();
   cache.warmup = false;
   cache.begin_phase();
 
-  // Create a standalone SHIP instance for direct unit testing
   ship uut{&cache};
 
   REQUIRE(uut.NUM_SET == 8);
   REQUIRE(uut.NUM_WAY == 8);
 
-  // Set 0 is sampled (category 0 for sample_rate=4)
-  // Addresses 0 and 8 both map to cache set 0 but have different tags
-  champsim::address addr1{0};
-  champsim::address addr2{8};
   champsim::address ip{100};
-
   auto SHCT_idx = ip.slice_lower<champsim::data::bits{32}>().to<std::size_t>() % ship::SHCT_PRIME;
 
-  // First access: addr1 with ip=100, set 0 (sampler MISS, new entry stored)
-  uut.update_replacement_state(0, 0, 0, addr1, ip, champsim::address{}, access_type::LOAD, 0);
+  SECTION("Same-block addresses are recognized as a sampler hit")
+  {
+    // Addresses 0 and 32 are both within cache block 0 (BLOCK_SIZE=64)
+    champsim::address addr1{0};
+    champsim::address addr2{32};
 
-  // Second access: addr2 with ip=100, set 0
-  //   Correct behavior: sampler MISS (addr2 != addr1), evicts the entry for
-  //   addr1 (which was not reused, used=false) → SHCT[ip] incremented
-  //
-  //   Buggy behavior: false sampler HIT (addr2 matches addr1 under wrong shamt),
-  //   SHCT[ip] decremented (but clamped at 0)
-  uut.update_replacement_state(0, 0, 0, addr2, ip, champsim::address{}, access_type::LOAD, 0);
+    // First access: sampler miss, stores entry for block 0
+    uut.update_replacement_state(0, 0, 0, addr1, ip, champsim::address{}, access_type::LOAD, 0);
 
-  // With the correct fix, the second access is a sampler miss.
-  // The evicted entry (addr1, ip=100) had used=false, so SHCT[ip] is incremented.
-  // SHCT[0][SHCT_idx] should be 1 (incremented from 0).
-  //
-  // With the bug, the second access falsely matches entry for addr1,
-  // SHCT[ip] is decremented from 0 → clamped to 0.
-  // SHCT[0][SHCT_idx] would remain 0.
-  CHECK(uut.SHCT[0][SHCT_idx].value() == 1);
+    // Second access: same block → sampler HIT → SHCT decremented (clamped at 0)
+    uut.update_replacement_state(0, 0, 0, addr2, ip, champsim::address{}, access_type::LOAD, 0);
+
+    // Sampler hit: SHCT was 0, decremented → clamped to 0
+    // A buggy shamt would treat these as different → sampler miss → SHCT incremented to 1
+    CHECK(uut.SHCT[0][SHCT_idx].value() == 0);
+  }
+
+  SECTION("Different-block addresses are recognized as a sampler miss")
+  {
+    // Addresses 0 and 64 are in different cache blocks (block 0 vs block 1)
+    champsim::address addr1{0};
+    champsim::address addr2{64};
+
+    // First access: sampler miss, stores entry for block 0
+    uut.update_replacement_state(0, 0, 0, addr1, ip, champsim::address{}, access_type::LOAD, 0);
+
+    // Second access: different block → sampler MISS → evicts old entry (used=false) → SHCT++
+    uut.update_replacement_state(0, 0, 0, addr2, ip, champsim::address{}, access_type::LOAD, 0);
+
+    // Sampler miss: old entry (block 0, used=false) evicted → SHCT incremented to 1
+    CHECK(uut.SHCT[0][SHCT_idx].value() == 1);
+  }
 }

--- a/test/cpp/src/445-ship-sampler-tag.cc
+++ b/test/cpp/src/445-ship-sampler-tag.cc
@@ -1,0 +1,75 @@
+#include <catch.hpp>
+
+#include "../replacement/ship/ship.h"
+#include "defaults.hpp"
+#include "mocks.hpp"
+
+TEST_CASE("SHIP sampler correctly distinguishes addresses that differ only in low tag bits")
+{
+  /*
+   * The SHIP sampler compares addresses by slicing off the lower bits used
+   * to index into the sampler. The shift amount (shamt) should be based only
+   * on the number of sampler sets (lg2(num_samples)), not also on lg2(NUM_WAY).
+   *
+   * With NUM_SET=8, NUM_WAY=8, OFFSET_BITS=0:
+   *   sample_rate = 4, num_samples = 2
+   *   Correct shamt = lg2(2) = 1
+   *   Buggy shamt   = lg2(2) + lg2(8) = 4   (would mask low tag bits)
+   *
+   * Addresses 0 and 8 are both in cache set 0 (8 % 8 == 0) with different tags.
+   * With a buggy shamt of 4: (0 >> 4) == (8 >> 4) == 0, causing a false match.
+   * With the correct shamt of 1: (0 >> 1) == 0 != 4 == (8 >> 1), correctly no match.
+   */
+
+  do_nothing_MRC mock_ll;
+  to_rq_MRP mock_ul;
+
+  // Create a cache with NUM_SET=8, NUM_WAY=8, OFFSET_BITS=0
+  // The SHIP instance reads NUM_SET and NUM_WAY from the cache pointer.
+  CACHE cache{champsim::cache_builder{champsim::defaults::default_l1d}
+                  .name("445-ship-tag-test")
+                  .sets(8)
+                  .ways(8)
+                  .upper_levels({&mock_ul.queues})
+                  .lower_level(&mock_ll.queues)
+                  .offset_bits(champsim::data::bits{})
+                  .replacement<lru>()};
+
+  cache.initialize();
+  cache.warmup = false;
+  cache.begin_phase();
+
+  // Create a standalone SHIP instance for direct unit testing
+  ship uut{&cache};
+
+  REQUIRE(uut.NUM_SET == 8);
+  REQUIRE(uut.NUM_WAY == 8);
+
+  // Set 0 is sampled (category 0 for sample_rate=4)
+  // Addresses 0 and 8 both map to cache set 0 but have different tags
+  champsim::address addr1{0};
+  champsim::address addr2{8};
+  champsim::address ip{100};
+
+  auto SHCT_idx = ip.slice_lower<champsim::data::bits{32}>().to<std::size_t>() % ship::SHCT_PRIME;
+
+  // First access: addr1 with ip=100, set 0 (sampler MISS, new entry stored)
+  uut.update_replacement_state(0, 0, 0, addr1, ip, champsim::address{}, access_type::LOAD, 0);
+
+  // Second access: addr2 with ip=100, set 0
+  //   Correct behavior: sampler MISS (addr2 != addr1), evicts the entry for
+  //   addr1 (which was not reused, used=false) → SHCT[ip] incremented
+  //
+  //   Buggy behavior: false sampler HIT (addr2 matches addr1 under wrong shamt),
+  //   SHCT[ip] decremented (but clamped at 0)
+  uut.update_replacement_state(0, 0, 0, addr2, ip, champsim::address{}, access_type::LOAD, 0);
+
+  // With the correct fix, the second access is a sampler miss.
+  // The evicted entry (addr1, ip=100) had used=false, so SHCT[ip] is incremented.
+  // SHCT[0][SHCT_idx] should be 1 (incremented from 0).
+  //
+  // With the bug, the second access falsely matches entry for addr1,
+  // SHCT[ip] is decremented from 0 → clamped to 0.
+  // SHCT[0][SHCT_idx] would remain 0.
+  CHECK(uut.SHCT[0][SHCT_idx].value() == 1);
+}

--- a/test/cpp/src/445-ship-sampler-tag.cc
+++ b/test/cpp/src/445-ship-sampler-tag.cc
@@ -2,7 +2,6 @@
 
 #include "../replacement/ship/ship.h"
 #include "defaults.hpp"
-#include "mocks.hpp"
 
 TEST_CASE("SHIP sampler matches at cache block granularity")
 {
@@ -19,20 +18,10 @@ TEST_CASE("SHIP sampler matches at cache block granularity")
    * the same cache line as different entries.
    */
 
-  do_nothing_MRC mock_ll;
-  to_rq_MRP mock_ul;
-
   CACHE cache{champsim::cache_builder{champsim::defaults::default_l1d}
                   .name("445-ship-tag-test")
                   .sets(8)
-                  .ways(8)
-                  .upper_levels({&mock_ul.queues})
-                  .lower_level(&mock_ll.queues)
-                  .replacement<lru>()};
-
-  cache.initialize();
-  cache.warmup = false;
-  cache.begin_phase();
+                  .ways(8)};
 
   ship uut{&cache};
 

--- a/test/cpp/src/445-ship-sampler-tag.cc
+++ b/test/cpp/src/445-ship-sampler-tag.cc
@@ -21,9 +21,12 @@ TEST_CASE("SHIP sampler matches at cache block granularity")
   CACHE cache{champsim::cache_builder{champsim::defaults::default_l1d}
                   .name("445-ship-tag-test")
                   .sets(8)
-                  .ways(8)};
+                  .ways(8)
+                  .replacement<ship>()};
 
-  ship uut{&cache};
+  auto* model = dynamic_cast<CACHE::replacement_module_model<ship>*>(cache.repl_module_pimpl.get());
+  REQUIRE(model != nullptr);
+  auto& uut = std::get<ship>(model->intern_);
 
   REQUIRE(uut.NUM_SET == 8);
   REQUIRE(uut.NUM_WAY == 8);


### PR DESCRIPTION
The previous implementation of the sampler-set tag check mechanism was convoluted, and would result in false matches / false mismatches under some cache configurations.

This pr simplifies the check to the block number, functionally equivalent to what should have been implemented but far simpler and avoids any confusion or potential bugs by introducing additional slicing to remove variable amounts of set index and sampler index bits.

A test was added to ensure the matcher was behaving properly.

Fixes issue raised in #697 