### PR TITLE
chore: standardize catch.hpp import

### DIFF
--- a/test/cpp/src/030-address-ops.cc
+++ b/test/cpp/src/030-address-ops.cc
@@ -1,9 +1,9 @@
+#include <catch.hpp>
 #include <iomanip>
 #include <sstream>
 #include <fmt/core.h>
 
 #include "address.h"
-#include "catch.hpp"
 #include "champsim.h"
 #include "util/detect.h"
 #include "util/units.h"

--- a/test/cpp/src/031-address-slice.cc
+++ b/test/cpp/src/031-address-slice.cc
@@ -1,6 +1,7 @@
 #define CATCH_CONFIG_RUNTIME_STATIC_REQUIRE
+#include <catch.hpp>
+
 #include "address.h"
-#include "catch.hpp"
 #include "champsim.h"
 #include "util/detect.h"
 

--- a/test/cpp/src/032-address-slice-dynamic.cc
+++ b/test/cpp/src/032-address-slice-dynamic.cc
@@ -1,8 +1,8 @@
 #define CATCH_CONFIG_RUNTIME_STATIC_REQUIRE
+#include <catch.hpp>
 #include <type_traits>
 
 #include "address.h"
-#include "catch.hpp"
 #include "champsim.h"
 
 using namespace champsim::data::data_literals;

--- a/test/cpp/src/033-address-arithmetic.cc
+++ b/test/cpp/src/033-address-arithmetic.cc
@@ -1,5 +1,6 @@
+#include <catch.hpp>
+
 #include "address.h"
-#include "catch.hpp"
 
 using namespace champsim::data::data_literals;
 

--- a/test/cpp/src/602-walk-latency.cc
+++ b/test/cpp/src/602-walk-latency.cc
@@ -1,4 +1,5 @@
-#include "catch.hpp"
+#include <catch.hpp>
+
 #include "defaults.hpp"
 #include "dram_controller.h"
 #include "mocks.hpp"

--- a/test/cpp/src/603-pte-page-correctness.cc
+++ b/test/cpp/src/603-pte-page-correctness.cc
@@ -1,6 +1,6 @@
 #include <array>
+#include <catch.hpp>
 
-#include "catch.hpp"
 #include "defaults.hpp"
 #include "dram_controller.h"
 #include "mocks.hpp"


### PR DESCRIPTION
catch2 dependency includes should be angle brackets, not double quotes - otherwise you will get errors such as the following

only a few test files had quotes, most already have angle brackets

```bash
champsim> g++ @global.options @absolute.options -MM -MT .csconfig/test/602-walk-latency.d -MT .csconfig/test/602-walk-latency.o -I.csconfig -MF .csconfig/test/602-walk-latency.d test/cpp/src/602-walk-latency.cc
champsim> test/cpp/src/602-walk-latency.cc:1:10: fatal error: catch.hpp: No such file or directory
champsim>     1 | #include "catch.hpp"
champsim>
```

ran clang format to sort the imports