### PR TITLE
Fix scheduler and pipt timing

### DIFF
--- a/src/cache.cc
+++ b/src/cache.cc
@@ -402,12 +402,17 @@ long CACHE::operate()
   const champsim::bandwidth::maximum_type bandwidth_from_tag_checks{champsim::to_underlying(MAX_TAG) * (long)(HIT_LATENCY / clock_period)
                                                                     - (long)std::size(inflight_tag_check)};
   champsim::bandwidth initiate_tag_bw{std::clamp(bandwidth_from_tag_checks, champsim::bandwidth::maximum_type{0}, MAX_TAG)};
-  auto can_translate = [avail = (std::size(translation_stash) < static_cast<std::size_t>(MSHR_SIZE))](const auto& entry) {
-    return avail || entry.is_translated;
+  // Admission throttle: cap in-flight untranslated tag checks at MSHR_SIZE.
+  // Counted fresh (not a start-of-cycle snapshot) so the cap tightens as
+  // untranslated entries are admitted this cycle. Translated entries and
+  // non-translating caches are never throttled. finish_translation re-admits
+  // translated entries directly, so there is nothing to pull from the stash here.
+  auto can_translate = [this](const auto& entry) {
+    return entry.is_translated || lower_translate == nullptr
+           || (std::count_if(std::begin(inflight_tag_check), std::end(inflight_tag_check), [](const auto& e) { return !e.is_translated; })
+               + static_cast<long>(std::size(translation_stash)))
+                  < static_cast<long>(MSHR_SIZE);
   };
-  auto stash_bandwidth_consumed =
-      champsim::transform_while_n(translation_stash, std::back_inserter(inflight_tag_check), initiate_tag_bw, is_translated, initiate_tag_check<false>());
-  initiate_tag_bw.consume(stash_bandwidth_consumed);
   std::vector<long long> channels_bandwidth_consumed{};
 
   if (std::size(upper_levels) > 1) {
@@ -440,9 +445,12 @@ long CACHE::operate()
   std::for_each(std::begin(inflight_tag_check), std::end(inflight_tag_check), [this](auto& x) { this->issue_translation(x); });
   std::for_each(std::begin(translation_stash), std::end(translation_stash), [this](auto& x) { this->issue_translation(x); });
 
-  // Find entries that would be ready except that they have not finished translation, move them to the stash
+  // Park EVERY untranslated entry in the stash, not only those already ready.
+  // The tag check cannot begin before translation resolves the physical set
+  // index, and while parked the entry cannot block translated entries behind it.
+  // finish_translation re-admits it, timing the tag check from translation.
   auto [last_not_missed, stash_end] = champsim::extract_if(std::begin(inflight_tag_check), std::end(inflight_tag_check), std::back_inserter(translation_stash),
-                                                           [is_ready, is_translated](const auto& x) { return is_ready(x) && !is_translated(x); });
+                                                           [is_translated](const auto& x) { return !is_translated(x); });
   progress += std::distance(last_not_missed, std::end(inflight_tag_check));
   inflight_tag_check.erase(last_not_missed, std::end(inflight_tag_check));
 
@@ -465,10 +473,10 @@ long CACHE::operate()
   impl_prefetcher_cycle_operate();
 
   if constexpr (champsim::debug_print) {
-    fmt::print("[{}] {} cycle completed: {} tags checked: {} remaining: {} stash consumed: {} remaining: {} channel consumed: {} pq consumed {} unused consume "
+    fmt::print("[{}] {} cycle completed: {} tags checked: {} remaining: {} stash remaining: {} channel consumed: {} pq consumed {} unused consume "
                "bw {}\n",
                NAME, __func__, current_time.time_since_epoch() / clock_period, tag_check_bw.amount_consumed(), std::size(inflight_tag_check),
-               stash_bandwidth_consumed, std::size(translation_stash), channels_bandwidth_consumed, pq_bandwidth_consumed, initiate_tag_bw.amount_remaining());
+               std::size(translation_stash), channels_bandwidth_consumed, pq_bandwidth_consumed, initiate_tag_bw.amount_remaining());
   }
 
   return progress + fill_bw.amount_consumed() + initiate_tag_bw.amount_consumed() + tag_check_bw.amount_consumed();
@@ -585,10 +593,14 @@ void CACHE::finish_translation(const response_type& packet)
   auto matches_vpage = [page_num = champsim::page_number{packet.v_address}](const auto& entry) {
     return (champsim::page_number{entry.v_address} == page_num) && !entry.is_translated;
   };
-  auto mark_translated = [p_page = champsim::page_number{packet.data}, this](auto& entry) {
+  // A physically-indexed tag check cannot begin until translation resolves the
+  // physical set index, so time it from translation completion, not admission.
+  const auto tag_check_ready = current_time + (warmup ? champsim::chrono::clock::duration{} : HIT_LATENCY);
+  auto mark_translated = [p_page = champsim::page_number{packet.data}, tag_check_ready, this](auto& entry) {
     [[maybe_unused]] auto old_address = entry.address;
     entry.address = champsim::address{champsim::splice(p_page, champsim::page_offset{entry.v_address})}; // translated address
     entry.is_translated = true;                                                                          // This entry is now translated
+    entry.event_cycle = tag_check_ready;                                                                 // serialize: tag check waits for translation
 
     if constexpr (champsim::debug_print) {
       fmt::print("[{}_TRANSLATE] finish_translation old: {} paddr: {} vaddr: {} type: {} cycle: {}\n", this->NAME, old_address, entry.address, entry.v_address,
@@ -596,17 +608,17 @@ void CACHE::finish_translation(const response_type& packet)
     }
   };
 
-  // Restart stashed translations
-  auto finish_begin = std::find_if_not(std::begin(translation_stash), std::end(translation_stash), [](const auto& x) { return x.is_translated; });
-  auto finish_end = std::stable_partition(finish_begin, std::end(translation_stash), matches_vpage);
-  std::for_each(finish_begin, finish_end, mark_translated);
-
-  // Find all packets that match the page of the returned packet
-  for (auto& entry : inflight_tag_check) {
-    if (matches_vpage(entry)) {
-      mark_translated(entry);
-    }
-  }
+  // Move every stash entry whose translation just resolved into the timed
+  // tag-check pipeline. Re-admission happens here, not in operate(), so it does
+  // not compete for tag-check bandwidth with newly-admitted entries. Every
+  // untranslated entry is parked, so inflight_tag_check holds only translated
+  // entries and there is nothing left to mark there.
+  auto matched_end = std::stable_partition(std::begin(translation_stash), std::end(translation_stash), matches_vpage);
+  std::for_each(std::begin(translation_stash), matched_end, [&](auto& entry) {
+    mark_translated(entry);
+    inflight_tag_check.push_back(std::move(entry));
+  });
+  translation_stash.erase(std::begin(translation_stash), matched_end);
 }
 
 void CACHE::issue_translation(tag_lookup_type& q_entry) const

--- a/src/ooo_cpu.cc
+++ b/src/ooo_cpu.cc
@@ -415,13 +415,16 @@ long O3_CPU::schedule_instruction()
   champsim::bandwidth search_bw{SCHEDULER_SIZE};
   int progress{0};
   for (auto rob_it = std::begin(ROB); rob_it != std::end(ROB) && search_bw.has_remaining(); ++rob_it) {
-    // if there aren't enough physical registers available for the next instruction, stop scheduling
-    unsigned long sources_to_allocate = std::count_if(rob_it->source_registers.begin(), rob_it->source_registers.end(),
-                                                      [&alloc = std::as_const(reg_allocator)](auto srcreg) { return !alloc.isAllocated(srcreg); });
-    if (reg_allocator.count_free_registers() < (sources_to_allocate + rob_it->destination_registers.size())) {
-      break;
-    }
     if (!rob_it->scheduled && rob_it->ready_time <= current_time) {
+      // The free-register rename gate applies only to instructions being
+      // renamed this cycle. An already-scheduled instruction has claimed its
+      // registers, so evaluating the gate against it (and breaking when free
+      // registers fall below its destination count) wrongly blocks scheduling.
+      unsigned long sources_to_allocate = std::count_if(rob_it->source_registers.begin(), rob_it->source_registers.end(),
+                                                        [&alloc = std::as_const(reg_allocator)](auto srcreg) { return !alloc.isAllocated(srcreg); });
+      if (reg_allocator.count_free_registers() < (sources_to_allocate + rob_it->destination_registers.size())) {
+        break;
+      }
       do_scheduling(*rob_it);
       ++progress;
     }

--- a/test/cpp/src/202-scheduler-rename-gate.cc
+++ b/test/cpp/src/202-scheduler-rename-gate.cc
@@ -1,0 +1,74 @@
+#include <catch.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+
+#include "instr.h"
+#include "mocks.hpp"
+#include "ooo_cpu.h"
+#include "defaults.hpp"
+
+// The free-physical-register rename gate must apply only to instructions being
+// renamed this cycle. An already-scheduled instruction has already claimed its
+// registers, so evaluating the gate against it -- and breaking scheduling when
+// the free pool is smaller than its destination count -- wrongly stalls ready
+// instructions sitting behind it in the ROB whenever registers are scarce.
+SCENARIO("An exhausted register file does not block scheduling behind an already-scheduled instruction")
+{
+  GIVEN("A core whose register file is drained by scheduling a ROB full of in-flight writers")
+  {
+    constexpr unsigned schedule_width = 128;
+    constexpr unsigned schedule_latency = 1;
+    constexpr uint32_t register_file_size = 32;
+
+    do_nothing_MRC mock_L1I, mock_L1D;
+    O3_CPU uut{champsim::modules::ModuleBuilder{"t202_core", "DEFAULT_CORE", champsim::defaults::default_core()}
+                   .add_parameter("schedule_width", champsim::bandwidth::maximum_type{schedule_width})
+                   .add_parameter("register_file_size", register_file_size)
+                   .add_parameter("schedule_latency", static_cast<unsigned>(schedule_latency))
+                   .add_parameter("fetch_queues", static_cast<champsim::modules::channel_module*>(&mock_L1I.queues))
+                   .add_parameter("data_queues", static_cast<champsim::modules::channel_module*>(&mock_L1D.queues))};
+
+    std::array<champsim::operable*, 3> elements{{&uut, &mock_L1I, &mock_L1D}};
+
+    // Fill the ROB with as many single-destination writers as there are free
+    // physical registers. Each one claims exactly one register when the scheduler
+    // renames it, so scheduling the whole batch drains the file through the real
+    // rename path -- no poking the allocator directly.
+    const auto writer_count = uut.reg_allocator.count_free_registers();
+    REQUIRE(writer_count > 0);
+    for (uint64_t i = 0; i < writer_count; ++i) {
+      auto writer = champsim::test::instruction_with_ip(1 + i);
+      writer.instr_id = 1 + i;
+      writer.destination_registers.push_back(10);
+      writer.ready_time = champsim::chrono::clock::time_point{};
+      uut.ROB.push_back(writer);
+    }
+
+    WHEN("The core cycles so every writer is scheduled and the register file is exhausted")
+    {
+      for (auto op : elements)
+        op->_operate();
+
+      REQUIRE(std::all_of(std::begin(uut.ROB), std::end(uut.ROB), [](const auto& instr) { return instr.scheduled; }));
+      REQUIRE(uut.reg_allocator.count_free_registers() == 0);
+
+      AND_WHEN("A ready instruction needing no new registers arrives behind the in-flight writers and the core cycles again")
+      {
+        auto probe = champsim::test::instruction_with_ip(1000);
+        probe.instr_id = 1000;
+        probe.ready_time = champsim::chrono::clock::time_point{};
+        uut.ROB.push_back(probe);
+
+        for (auto op : elements)
+          op->_operate();
+
+        THEN("It still schedules -- the exhausted file must not gate an already-scheduled instruction ahead of it")
+        {
+          REQUIRE(uut.ROB.back().scheduled);
+        }
+      }
+    }
+  }
+}

--- a/test/cpp/src/415-translation-collision.cc
+++ b/test/cpp/src/415-translation-collision.cc
@@ -60,7 +60,7 @@ SCENARIO("A cache keeps the address for packets that don't need translation")
 
       THEN("The address of the test packet is unmodified")
       {
-        REQUIRE_THAT(mock_ll.addresses, Catch::Matchers::RangeEquals(std::vector{champsim::address{0x11111eef}, test.address}));
+        REQUIRE_THAT(mock_ll.addresses, Catch::Matchers::UnorderedRangeEquals(std::vector{champsim::address{0x11111eef}, test.address}));
       }
     }
   }

--- a/test/cpp/src/416-pipt-translation-latency.cc
+++ b/test/cpp/src/416-pipt-translation-latency.cc
@@ -1,0 +1,190 @@
+#include <catch.hpp>
+
+#include "channel.h"
+#include "defaults.hpp"
+#include "mocks.hpp"
+
+// PIPT translation-timing fix: for a translating cache (lower_translate !=
+// nullptr), an UNTRANSLATED access cannot tag-check until translation yields the
+// physical set index, so translation latency is ADDITIVE, never hidden under
+// HIT_LATENCY. The bug only surfaced for FAST (TLB-hit) translations that fit
+// inside the HIT_LATENCY window (fully overlapped); this test uses
+// translate_latency < hit_latency to pin that case. 412 pins the slow case
+// (translator latency > HIT_LATENCY), which was additive even pre-fix.
+TEMPLATE_TEST_CASE("An untranslated access serializes translation before its tag check (PIPT)", "", to_wq_MRP, to_rq_MRP, to_pq_MRP)
+{
+  GIVEN("An empty cache with a translator faster than its hit latency")
+  {
+    constexpr uint64_t hit_latency = 10;
+    constexpr uint64_t fill_latency = 3;
+    constexpr uint64_t translate_latency = 4; // strictly < hit_latency: the overlapped (TLB-hit) case the bug hid
+    do_nothing_MRC mock_translator{static_cast<int>(translate_latency)};
+    do_nothing_MRC mock_ll;
+    TestType mock_ul{[](auto x, auto y) {
+      return x.v_address == y.v_address;
+    }};
+    CACHE uut{champsim::modules::ModuleBuilder{"t416_cache", "DEFAULT_CACHE", champsim::defaults::default_l1d()}
+                  .add_parameter("mshr_size", static_cast<uint32_t>(8))
+                  .add_parameter("upper_levels", std::vector<champsim::modules::channel_module*>{&mock_ul.queues})
+                  .add_parameter("lower_level", static_cast<champsim::modules::channel_module*>(&mock_ll.queues))
+                  .add_parameter("lower_translate", static_cast<champsim::modules::channel_module*>(&mock_translator.queues))
+                  .add_parameter("hit_latency", static_cast<uint64_t>(hit_latency))
+                  .add_parameter("fill_latency", static_cast<uint64_t>(fill_latency))};
+
+    std::array<champsim::operable*, 4> elements{{&uut, &mock_ll, &mock_ul, &mock_translator}};
+
+    for (auto elem : elements) {
+      elem->initialize();
+      elem->warmup = false;
+      elem->begin_phase();
+    }
+
+    WHEN("An untranslated packet is sent")
+    {
+      typename TestType::request_type test;
+      test.address = champsim::address{0xdeadbeef};
+      test.v_address = champsim::address{0xdeadbeef};
+      test.is_translated = false;
+      test.cpu = 0;
+
+      auto test_result = mock_ul.issue(test);
+      THEN("The issue is accepted") { REQUIRE(test_result); }
+
+      for (int i = 0; i < 100; ++i) {
+        for (auto elem : elements)
+          elem->_operate();
+      }
+
+      THEN("The packet is translated and forwarded on a miss")
+      {
+        REQUIRE(std::size(mock_ll.addresses) == 1);
+        REQUIRE(mock_ll.addresses.front() == champsim::address{0x11111eef});
+      }
+
+      THEN("Translation latency is additive, not hidden under the hit latency")
+      {
+        // Additive total: translate + hit + fill + 2 (the +2 is fixed
+        // inter-element clocking, as in 412). Since translate(4) < hit(10), the
+        // buggy overlapped model would hide translation and return
+        // hit+fill+2==15; the additive value is 19.
+        constexpr uint64_t additive = translate_latency + hit_latency + fill_latency + 2;
+        constexpr uint64_t overlapped_buggy = hit_latency + fill_latency + 2;
+        static_assert(additive > overlapped_buggy, "the fix must make the fast-translation path strictly slower than the overlapped bug");
+        REQUIRE_THAT(mock_ul.packets.front(), champsim::test::ReturnedMatcher(static_cast<long>(additive), 1));
+      }
+    }
+  }
+}
+
+// A pre-translated access into the same translating cache never translates, so
+// its tag check is timed from admission + HIT_LATENCY as before. The delta from
+// the untranslated case above is precisely the translation round trip.
+TEST_CASE("A pre-translated access into a translating cache is not delayed by translation")
+{
+  constexpr uint64_t hit_latency = 10;
+  constexpr uint64_t fill_latency = 3;
+  constexpr uint64_t translate_latency = 4;
+  do_nothing_MRC mock_translator{static_cast<int>(translate_latency)};
+  do_nothing_MRC mock_ll;
+  to_rq_MRP mock_ul{[](auto x, auto y) {
+    return x.v_address == y.v_address;
+  }};
+  CACHE uut{champsim::modules::ModuleBuilder{"t416_cache_pretranslated", "DEFAULT_CACHE", champsim::defaults::default_l1d()}
+                .add_parameter("mshr_size", static_cast<uint32_t>(8))
+                .add_parameter("upper_levels", std::vector<champsim::modules::channel_module*>{&mock_ul.queues})
+                .add_parameter("lower_level", static_cast<champsim::modules::channel_module*>(&mock_ll.queues))
+                .add_parameter("lower_translate", static_cast<champsim::modules::channel_module*>(&mock_translator.queues))
+                .add_parameter("hit_latency", static_cast<uint64_t>(hit_latency))
+                .add_parameter("fill_latency", static_cast<uint64_t>(fill_latency))};
+
+  std::array<champsim::operable*, 4> elements{{&uut, &mock_ll, &mock_ul, &mock_translator}};
+
+  for (auto elem : elements) {
+    elem->initialize();
+    elem->warmup = false;
+    elem->begin_phase();
+  }
+
+  WHEN("A pre-translated packet is sent")
+  {
+    to_rq_MRP::request_type test;
+    test.address = champsim::address{0xdeadbeef};
+    test.v_address = champsim::address{0xdeadbeef};
+    test.is_translated = true;
+    test.cpu = 0;
+
+    REQUIRE(mock_ul.issue(test));
+
+    for (int i = 0; i < 100; ++i) {
+      for (auto elem : elements)
+        elem->_operate();
+    }
+
+    THEN("No translation was issued") { REQUIRE(mock_translator.packet_count() == 0); }
+
+    THEN("It returns in hit_latency + fill_latency + 2 (translation not on its path)")
+    {
+      // Same clocking overhead as the untranslated case above, minus the
+      // translation round trip: exactly translate_latency cycles faster.
+      constexpr uint64_t pre_translated = hit_latency + fill_latency + 2;
+      REQUIRE_THAT(mock_ul.packets.front(), champsim::test::ReturnedMatcher(static_cast<long>(pre_translated), 1));
+    }
+  }
+}
+
+// A cache with no translator (lower_translate == nullptr) is a TLB / any
+// non-translating cache. The fixed path is gated on (lower_translate != nullptr
+// && !is_translated), so it is never entered: every access tag-checks from
+// admission + HIT_LATENCY, byte-identical to pre-fix. 401 corroborates.
+SCENARIO("A non-translating (TLB-like) cache tag-checks without waiting on translation")
+{
+  GIVEN("An empty cache with no translator")
+  {
+    constexpr uint64_t hit_latency = 7;
+    do_nothing_MRC mock_ll;
+    to_rq_MRP mock_ul;
+    CACHE uut{champsim::modules::ModuleBuilder{"t416_tlb_like", "DEFAULT_CACHE", champsim::defaults::default_l1d()}
+                  .add_parameter("mshr_size", static_cast<uint32_t>(8))
+                  .add_parameter("upper_levels", std::vector<champsim::modules::channel_module*>{&mock_ul.queues})
+                  .add_parameter("lower_level", static_cast<champsim::modules::channel_module*>(&mock_ll.queues))
+                  .add_parameter("hit_latency", static_cast<uint64_t>(hit_latency))};
+
+    // lower_translate defaults to nullptr in default_l1d(): this is the TLB case.
+    REQUIRE(uut.lower_translate == nullptr);
+
+    std::array<champsim::operable*, 3> elements{{&uut, &mock_ll, &mock_ul}};
+    for (auto elem : elements) {
+      elem->initialize();
+      elem->warmup = false;
+      elem->begin_phase();
+    }
+
+    WHEN("A pre-translated line is filled and then hit")
+    {
+      to_rq_MRP::request_type seed;
+      seed.address = champsim::address{0xdeadbeef};
+      seed.is_translated = true; // a TLB receives is_translated == true requests (issue_translation sets it)
+      seed.instr_id = 1;
+      seed.cpu = 0;
+      REQUIRE(mock_ul.issue(seed));
+
+      for (int i = 0; i < 100; ++i)
+        for (auto elem : elements)
+          elem->_operate();
+
+      auto test = seed;
+      test.instr_id = 2;
+      REQUIRE(mock_ul.issue(test));
+
+      for (uint64_t i = 0; i < 2 * hit_latency; ++i)
+        for (auto elem : elements)
+          elem->_operate();
+
+      THEN("The hit returns in exactly HIT_LATENCY, timed from admission (byte-identical to pre-fix)")
+      {
+        REQUIRE(std::size(mock_ul.packets) == 2);
+        REQUIRE_THAT(mock_ul.packets.back(), champsim::test::ReturnedMatcher(static_cast<long>(hit_latency), 1));
+      }
+    }
+  }
+}


### PR DESCRIPTION
Two fixes for bugs discovered during optimizations.

1. Rename happens IN-ORDER, so walks stop once they cannot allocate registers for an instruction. **However, this check was happening against all instructions, even scheduled ones**, resulting in some scheduler walks ending earlier than they should. Performance impact was minimal as long as the scheduler was not the bottleneck of the machine (or for that matter, the RAT table was at a realistic size).

2. Translation timing and tag check timing were allowed to overlap. At the moment, caches are modeled PIPT so this was not correct. Impacted L1D latency, scaled with DTLB/ITLB latency (typically only 1-2 cycles), minimal IPC impact on realistic configurations where L1D latency >> DLTB/ITLB latency.

Tests were added for each.
Follow up work on caches may reintroduce this timing path for VIPT caches when implemented.