### PR TITLE
Fix strict weak ordering comparator in ChampSim DRAM channel

### DIFF
--- a/src/dram_controller.cc
+++ b/src/dram_controller.cc
@@ -249,7 +249,7 @@ long DRAM_CHANNEL::populate_dbus()
   long progress{0};
 
   auto iter_next_process = std::min_element(std::begin(bank_request), std::end(bank_request),
-                                            [](const auto& lhs, const auto& rhs) { return !rhs.valid || (lhs.valid && lhs.ready_time < rhs.ready_time); });
+                                            [](const auto& lhs, const auto& rhs) { return lhs.valid && (!rhs.valid || lhs.ready_time < rhs.ready_time); });
   if (iter_next_process->valid && iter_next_process->ready_time <= current_time) {
     if (active_request == std::end(bank_request) && dbus_cycle_available <= current_time) {
       // Bus is available


### PR DESCRIPTION
`DRAM_CHANNEL::populate_dbus`uses `std::min_element` to select the next ready bank request. The previous comparator returned `!rhs.valid || (lhs.valid && lhs.ready_time < rhs.ready_time)`, which evaluates to true when both lhs and rhs are invalid. This violates irreflexivity and asymmetry required by strict weak ordering. Thus require lhs.valid so invalid requests are never considered strictly less than other invalid requests.